### PR TITLE
fix: Enforce DiagnosticRule contract and fix ObdLiveFrame type mismatches

### DIFF
--- a/src/app/core/adapters/mock-obd-adapter.service.ts
+++ b/src/app/core/adapters/mock-obd-adapter.service.ts
@@ -74,11 +74,13 @@ export class MockObdAdapterService implements ObdAdapter {
       timestamp: Date.now(),
       rpm: this.calculateRpm(),
       speed: 0,
+      engineLoad: 25 + Math.random() * 10,
       coolantTemp: this.calculateCoolant(),
+      intakeAirTemp: 20 + Math.random() * 5,
       stftB1: this.calculateStft(),
       ltftB1: this.calculateLtft(),
       throttlePosition: 15,
-      voltage: 14.2
+      batteryVoltage: 14.2
     };
 
     this.dataSubject.next(frame);

--- a/src/app/core/diagnostics/diagnostic-engine.service.ts
+++ b/src/app/core/diagnostics/diagnostic-engine.service.ts
@@ -3,6 +3,8 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { ObdLiveFrame } from '../models/obd-live-frame.model';
 import { DiagnosticResult } from '../models/diagnostic-result.model';
 import { DiagnosticRule } from './diagnostic-rule.interface';
+import { BatteryHealthRule } from './diagnostic-rules/battery-health.rule';
+import { IdleStabilityRule } from './diagnostic-rules/idle-stability.rule';
 import { LeanConditionRule } from './diagnostic-rules/lean-condition.rule';
 import { RichConditionRule } from './diagnostic-rules/rich-condition.rule';
 import { VacuumLeakPatternRule } from './diagnostic-rules/vacuum-leak-pattern.rule';
@@ -28,7 +30,9 @@ export class DiagnosticEngineService {
       new LeanConditionRule(),
       new RichConditionRule(),
       new VacuumLeakPatternRule(),
-      new WarmupIssueRule()
+      new WarmupIssueRule(),
+      new BatteryHealthRule(),
+      new IdleStabilityRule()
     ];
   }
 
@@ -53,9 +57,10 @@ export class DiagnosticEngineService {
 
   private runRules(): void {
     const results: DiagnosticResult[] = [];
+    const recentFrames = this.frameBuffer.slice(-15);
 
     for (const rule of this.rules) {
-      const result = rule.evaluate(this.frameBuffer);
+      const result = rule.evaluate(this.frameBuffer, recentFrames);
       if (result) {
         results.push(result);
       }

--- a/src/app/core/diagnostics/diagnostic-rules/battery-health.rule.ts
+++ b/src/app/core/diagnostics/diagnostic-rules/battery-health.rule.ts
@@ -18,20 +18,19 @@ import { DiagnosticResult } from '../../models/diagnostic-result.model';
 export class BatteryHealthRule implements DiagnosticRule {
   id = 'rule_battery_health';
 
-  evaluate(frames: ObdLiveFrame[], sessionDurationMs: number): DiagnosticResult | null {
-    if (frames.length < 20) {
+  evaluate(allFrames: ObdLiveFrame[], _recentFrames: ObdLiveFrame[]): DiagnosticResult | null {
+    if (allFrames.length < 20) {
       return null;
     }
 
-    const recentFrames = frames.slice(-20);
-    
-    // Check if engine is running
-    const isEngineRunning = recentFrames.every(f => f.rpm > 500);
+    const last20 = allFrames.slice(-20);
+
+    const isEngineRunning = last20.every(f => f.rpm > 500);
     if (!isEngineRunning) {
       return null;
     }
 
-    const avgVoltage = recentFrames.reduce((sum, f) => sum + (f.batteryVoltage || 14.0), 0) / recentFrames.length;
+    const avgVoltage = last20.reduce((sum, f) => sum + (f.batteryVoltage ?? 14.0), 0) / last20.length;
 
     if (avgVoltage >= 13.0) {
       return null;
@@ -41,10 +40,10 @@ export class BatteryHealthRule implements DiagnosticRule {
       issueId: this.id,
       title: 'Charging system voltage low',
       severity: 'critical',
-      confidence: 95,
+      confidence: 0.95,
       evidence: [
         `Engine is running (RPM > 500)`,
-        `Average Battery Voltage: ${avgVoltage.toFixed(1)}V (Expected > 13.5V)`
+        `Average battery voltage: ${avgVoltage.toFixed(1)}V (expected > 13.5V)`
       ],
       explanation: 'The vehicle voltage is lower than expected while the engine is running. This indicates the alternator may not be charging the battery properly.',
       recommendedNextStep: 'Check alternator output, battery terminals, and drive belt.',

--- a/src/app/core/diagnostics/diagnostic-rules/idle-stability.rule.ts
+++ b/src/app/core/diagnostics/diagnostic-rules/idle-stability.rule.ts
@@ -18,20 +18,19 @@ import { DiagnosticResult } from '../../models/diagnostic-result.model';
 export class IdleStabilityRule implements DiagnosticRule {
   id = 'rule_idle_stability';
 
-  evaluate(frames: ObdLiveFrame[], sessionDurationMs: number): DiagnosticResult | null {
-    if (frames.length < 50) {
+  evaluate(allFrames: ObdLiveFrame[], _recentFrames: ObdLiveFrame[]): DiagnosticResult | null {
+    if (allFrames.length < 50) {
       return null;
     }
 
-    const recentFrames = frames.slice(-50);
-    
-    // Ensure vehicle is stationary and throttle is essentially closed
-    const isIdling = recentFrames.every(f => f.speed === 0 && f.throttlePosition < 5);
+    const last50 = allFrames.slice(-50);
+
+    const isIdling = last50.every(f => f.speed === 0 && f.throttlePosition < 5);
     if (!isIdling) {
       return null;
     }
 
-    const rpms = recentFrames.map(f => f.rpm);
+    const rpms = last50.map(f => f.rpm);
     const minRpm = Math.min(...rpms);
     const maxRpm = Math.max(...rpms);
     const rpmVariance = maxRpm - minRpm;
@@ -44,10 +43,10 @@ export class IdleStabilityRule implements DiagnosticRule {
       issueId: this.id,
       title: 'Idle instability detected',
       severity: 'info',
-      confidence: 75,
+      confidence: 0.75,
       evidence: [
         `Vehicle is stationary with closed throttle`,
-        `RPM fluctuated between ${minRpm.toFixed(0)} and ${maxRpm.toFixed(0)} (Variance: ${rpmVariance.toFixed(0)} RPM)`
+        `RPM fluctuated between ${minRpm.toFixed(0)} and ${maxRpm.toFixed(0)} (variance: ${rpmVariance.toFixed(0)} RPM)`
       ],
       explanation: 'The engine RPM is fluctuating more than expected while idling. This can cause a rough idle or stalling.',
       recommendedNextStep: 'Check for vacuum leaks, clean the Idle Air Control (IAC) valve, and inspect the throttle body.',


### PR DESCRIPTION
## Summary

- `voltage` to `batteryVoltage`: Mock adapter generated frames with a wrong property name
- Missing required fields: `engineLoad` and `intakeAirTemp` added to mock frame generation
- Rule signature contract: `BatteryHealthRule` and `IdleStabilityRule` now match `evaluate(allFrames, recentFrames)` interface
- recentFrames in engine: `runRules()` now computes `recentFrames = frameBuffer.slice(-15)` and passes both args
- Confidence scale fix: corrected from integer (75, 95) to decimal (0.75, 0.95)
- Dead rules activated: Both rules now registered in DiagnosticEngineService

## Reviewer notes

Remaining compiler error (app.component.spec.ts:20) is pre-existing from the initial commit.

## Test plan

- [ ] `npx tsc --noEmit` passes with no new errors
- [ ] Dashboard loads and shows live metric cards
- [ ] Lean/Rich mode triggers diagnostic alerts

Generated with Claude Code