### PR TITLE
feat: add OBD PID parser service with Jasmine specs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add *)",
+      "Bash(git commit -m ' *)",
+      "Bash(git push *)",
+      "Bash(xargs cat *)",
+      "Bash(xargs ls *)",
+      "Bash(npm run *)",
+      "Bash(node --max-old-space-size=4096 node_modules/@angular/cli/bin/ng.js build)",
+      "Bash(node --max-old-space-size=4096 C:/Users/Lenovo/Downloads/OBD/node_modules/@angular/cli/bin/ng.js build)",
+      "Bash(node C:/Users/Lenovo/Downloads/OBD/node_modules/typescript/bin/tsc --noEmit --project tsconfig.app.json)",
+      "Bash(git log *)",
+      "Bash(gh pr *)",
+      "Bash(xargs grep *)",
+      "Bash(git fetch *)",
+      "Bash(git rebase *)",
+      "Read(//c/Users/Lenovo/Downloads/OBD/**)",
+      "Bash(npm start *)",
+      "Bash(node node_modules/@angular/cli/bin/ng.js serve --host 0.0.0.0)"
+    ]
+  }
+}

--- a/src/app/core/adapters/obd-pid-parser.service.spec.ts
+++ b/src/app/core/adapters/obd-pid-parser.service.spec.ts
@@ -1,0 +1,154 @@
+import { TestBed } from '@angular/core/testing';
+import { ObdPidParserService } from './obd-pid-parser.service';
+
+describe('ObdPidParserService', () => {
+  let service: ObdPidParserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ObdPidParserService);
+  });
+
+  // ── 010C RPM ───────────────────────────────────────────────────────────────
+
+  describe('010C — RPM', () => {
+    it('parses spaced response', () => {
+      // 0x1A = 26, 0xF8 = 248  →  ((26 × 256) + 248) / 4 = 1726
+      expect(service.parse('010C', '41 0C 1A F8')).toBe(1726);
+    });
+
+    it('parses compact response without spaces', () => {
+      expect(service.parse('010C', '410C1AF8')).toBe(1726);
+    });
+
+    it('parses response containing ELM327 prompt', () => {
+      expect(service.parse('010C', '41 0C 1A F8\r\n>')).toBe(1726);
+    });
+
+    it('returns idle RPM correctly — 0x0C 0xA0 = 800 rpm', () => {
+      // ((12 × 256) + 160) / 4 = 800
+      expect(service.parse('010C', '41 0C 0C A0')).toBe(800);
+    });
+  });
+
+  // ── 010D Speed ────────────────────────────────────────────────────────────
+
+  describe('010D — Speed', () => {
+    it('parses 80 km/h', () => {
+      // 0x50 = 80
+      expect(service.parse('010D', '41 0D 50')).toBe(80);
+    });
+
+    it('parses zero speed', () => {
+      expect(service.parse('010D', '41 0D 00')).toBe(0);
+    });
+  });
+
+  // ── 0105 Coolant Temp ─────────────────────────────────────────────────────
+
+  describe('0105 — Coolant temperature', () => {
+    it('parses 90 °C operating temperature', () => {
+      // 0x82 = 130  →  130 − 40 = 90
+      expect(service.parse('0105', '41 05 82')).toBe(90);
+    });
+
+    it('parses sub-zero cold start temperature', () => {
+      // 0x00 = 0  →  0 − 40 = −40
+      expect(service.parse('0105', '41 05 00')).toBe(-40);
+    });
+  });
+
+  // ── 0104 Engine Load ──────────────────────────────────────────────────────
+
+  describe('0104 — Engine load', () => {
+    it('parses 50% load', () => {
+      // 0x80 = 128  →  (128 × 100) / 255 ≈ 50.2
+      expect(service.parse('0104', '41 04 80')).toBeCloseTo(50.2, 0);
+    });
+
+    it('parses 100% load', () => {
+      // 0xFF = 255  →  (255 × 100) / 255 = 100
+      expect(service.parse('0104', '41 04 FF')).toBe(100);
+    });
+  });
+
+  // ── 0106 STFT B1 ──────────────────────────────────────────────────────────
+
+  describe('0106 — Short-term fuel trim Bank 1', () => {
+    it('parses 0% trim (stoichiometric)', () => {
+      // 0x80 = 128  →  (128 − 128) × 100 / 128 = 0
+      expect(service.parse('0106', '41 06 80')).toBe(0);
+    });
+
+    it('parses positive lean correction', () => {
+      // 0x90 = 144  →  (144 − 128) × 100 / 128 = 12.5%
+      expect(service.parse('0106', '41 06 90')).toBeCloseTo(12.5, 1);
+    });
+
+    it('parses negative rich correction', () => {
+      // 0x70 = 112  →  (112 − 128) × 100 / 128 = −12.5%
+      expect(service.parse('0106', '41 06 70')).toBeCloseTo(-12.5, 1);
+    });
+  });
+
+  // ── 0107 LTFT B1 ──────────────────────────────────────────────────────────
+
+  describe('0107 — Long-term fuel trim Bank 1', () => {
+    it('parses 0% trim', () => {
+      expect(service.parse('0107', '41 07 80')).toBe(0);
+    });
+
+    it('uses same formula as STFT', () => {
+      expect(service.parse('0107', '41 07 90')).toBeCloseTo(12.5, 1);
+    });
+  });
+
+  // ── Error / edge cases ────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('returns null for NO DATA', () => {
+      expect(service.parse('010C', 'NO DATA')).toBeNull();
+    });
+
+    it('returns null for NO DATA with prompt', () => {
+      expect(service.parse('010C', 'NO DATA\r\n>')).toBeNull();
+    });
+
+    it('returns null for STOPPED', () => {
+      expect(service.parse('010C', 'STOPPED')).toBeNull();
+    });
+
+    it('returns null for ERROR', () => {
+      expect(service.parse('010C', 'ERROR')).toBeNull();
+    });
+
+    it('returns null for UNABLE TO CONNECT', () => {
+      expect(service.parse('010C', 'UNABLE TO CONNECT')).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(service.parse('010C', '')).toBeNull();
+    });
+
+    it('returns null when too few data bytes', () => {
+      // RPM needs 2 data bytes; only 1 provided
+      expect(service.parse('010C', '41 0C 1A')).toBeNull();
+    });
+
+    it('returns null for unknown PID', () => {
+      expect(service.parse('0100', '41 00 BE 3E B8 11')).toBeNull();
+    });
+
+    it('returns null for malformed hex', () => {
+      expect(service.parse('010D', '41 0D ZZ')).toBeNull();
+    });
+
+    it('is case-insensitive for PID lookup', () => {
+      expect(service.parse('010c', '41 0C 1A F8')).toBe(1726);
+    });
+
+    it('handles lowercase hex response', () => {
+      expect(service.parse('010C', '41 0c 1a f8')).toBe(1726);
+    });
+  });
+});

--- a/src/app/core/adapters/obd-pid-parser.service.ts
+++ b/src/app/core/adapters/obd-pid-parser.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@angular/core';
+
+/** Strings that indicate the ELM327 could not obtain a valid response. */
+const ERROR_TOKENS = ['NO DATA', 'STOPPED', 'ERROR', 'UNABLE TO CONNECT', 'NODATA'];
+
+/**
+ * Converts a clean ELM327 OBD Mode-01 response string into an engineering value.
+ *
+ * Parsing pipeline (per §10 of ble-elm327-plan.md):
+ *   "41 0C 1A F8"
+ *    → strip prompt/noise → normalise → split → drop echo bytes → parse hex → apply formula
+ */
+@Injectable({ providedIn: 'root' })
+export class ObdPidParserService {
+
+  /**
+   * Parses a raw ELM327 response for the given PID command.
+   *
+   * @param pid     The command that was sent, e.g. "010C"
+   * @param raw     The raw response received from the adapter
+   * @returns       Engineering value, or null if the response is invalid/empty
+   */
+  parse(pid: string, raw: string): number | null {
+    const bytes = this.extractBytes(raw);
+    if (bytes === null) return null;
+
+    switch (pid.toUpperCase()) {
+      case '010C': return this.parseRpm(bytes);
+      case '010D': return this.parseSpeed(bytes);
+      case '0105': return this.parseCoolantTemp(bytes);
+      case '0104': return this.parseEngineLoad(bytes);
+      case '0106': return this.parseStft(bytes);
+      case '0107': return this.parseLtft(bytes);
+      default:     return null;
+    }
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────────────
+
+  /**
+   * Strips the ELM327 prompt (`>`), whitespace, and linefeeds, then splits the
+   * response into an array of decimal byte values.
+   *
+   * Handles both spaced ("41 0C 1A F8") and compact ("410C1AF8") formats.
+   * Drops the two echo bytes (mode byte "41" + PID byte).
+   * Returns null when an error token is present or the byte count is insufficient.
+   */
+  private extractBytes(raw: string): number[] | null {
+    if (!raw) return null;
+
+    const cleaned = raw
+      .replace(/>/g, '')   // strip ELM327 prompt
+      .replace(/\r/g, '')
+      .replace(/\n/g, '')
+      .trim()
+      .toUpperCase();
+
+    // Reject known error responses
+    for (const token of ERROR_TOKENS) {
+      if (cleaned.includes(token)) return null;
+    }
+
+    // Normalise to space-separated pairs: "410C1AF8" → "41 0C 1A F8"
+    const spaced = cleaned.includes(' ')
+      ? cleaned
+      : cleaned.match(/.{1,2}/g)?.join(' ') ?? cleaned;
+
+    const parts = spaced.split(/\s+/).filter(p => p.length > 0);
+
+    // Need at least the two echo bytes plus one data byte
+    if (parts.length < 3) return null;
+
+    // Validate every part is a valid hex byte
+    if (!parts.every(p => /^[0-9A-F]{2}$/.test(p))) return null;
+
+    // Drop mode byte ("41") and PID echo byte — data starts at index 2
+    const dataBytes = parts.slice(2).map(p => parseInt(p, 16));
+
+    return dataBytes;
+  }
+
+  // ── PID formulas (SAE J1979 / ble-elm327-plan.md §8) ─────────────────────
+
+  /** 010C — Engine RPM: ((A × 256) + B) / 4  →  rpm */
+  private parseRpm(bytes: number[]): number | null {
+    if (bytes.length < 2) return null;
+    const [A, B] = bytes;
+    return ((A * 256) + B) / 4;
+  }
+
+  /** 010D — Vehicle speed: A  →  km/h */
+  private parseSpeed(bytes: number[]): number | null {
+    if (bytes.length < 1) return null;
+    return bytes[0];
+  }
+
+  /** 0105 — Engine coolant temperature: A − 40  →  °C */
+  private parseCoolantTemp(bytes: number[]): number | null {
+    if (bytes.length < 1) return null;
+    return bytes[0] - 40;
+  }
+
+  /** 0104 — Calculated engine load: (A × 100) / 255  →  % */
+  private parseEngineLoad(bytes: number[]): number | null {
+    if (bytes.length < 1) return null;
+    return (bytes[0] * 100) / 255;
+  }
+
+  /** 0106 — Short-term fuel trim Bank 1: (A − 128) × 100 / 128  →  % */
+  private parseStft(bytes: number[]): number | null {
+    if (bytes.length < 1) return null;
+    return ((bytes[0] - 128) * 100) / 128;
+  }
+
+  /** 0107 — Long-term fuel trim Bank 1: (A − 128) × 100 / 128  →  % */
+  private parseLtft(bytes: number[]): number | null {
+    if (bytes.length < 1) return null;
+    return ((bytes[0] - 128) * 100) / 128;
+  }
+}


### PR DESCRIPTION
Converts raw ELM327 responses to engineering values for 6 PIDs: RPM (010C), speed (010D), coolant temp (0105), engine load (0104), STFT B1 (0106), LTFT B1 (0107).

Handles spaced and compact hex formats, ELM327 prompt stripping, and returns null for NO DATA / STOPPED / ERROR / malformed inputs. 20 Jasmine tests covering happy path, edge cases, and error handling.