### PR TITLE
feat: BLE ELM327 adapter, dashboard connect flow, chart and throttle fixes

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,29 +1,16 @@
 import { TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
+      imports: [AppComponent, RouterModule.forRoot([])],
     }).compileComponents();
   });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
-  });
-
-  it(`should have the 'obd-dashboard' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('obd-dashboard');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, obd-dashboard');
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,10 +2,13 @@ import { ApplicationConfig, importProvidersFrom } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
+import { OBD_ADAPTER } from './core/adapters/obd-adapter.interface';
+import { WebBluetoothElm327AdapterService } from './core/adapters/web-bluetooth-elm327-adapter.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
-    provideCharts(withDefaultRegisterables())
+    provideCharts(withDefaultRegisterables()),
+    { provide: OBD_ADAPTER, useClass: WebBluetoothElm327AdapterService }
   ]
 };

--- a/src/app/core/adapters/elm327-command.service.spec.ts
+++ b/src/app/core/adapters/elm327-command.service.spec.ts
@@ -1,0 +1,361 @@
+import { TestBed, fakeAsync, tick, flushMicrotasks } from '@angular/core/testing';
+import {
+  Elm327CommandService,
+  BleWriteCharacteristic,
+  BleNotifyCharacteristic,
+} from './elm327-command.service';
+
+// ---------------------------------------------------------------------------
+// Fake BLE characteristics
+// ---------------------------------------------------------------------------
+
+class FakeTxChar extends EventTarget implements BleWriteCharacteristic {
+  readonly writes: Uint8Array[] = [];
+
+  writeValue(data: BufferSource): Promise<void> {
+    if (data instanceof ArrayBuffer) {
+      this.writes.push(new Uint8Array(data));
+    } else {
+      const view = data as ArrayBufferView;
+      this.writes.push(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
+    }
+    return Promise.resolve();
+  }
+}
+
+class FakeRxChar extends EventTarget implements BleNotifyCharacteristic {
+  value: DataView | null = null;
+
+  startNotifications(): Promise<this> {
+    return Promise.resolve(this);
+  }
+
+  /** Simulate an incoming BLE notification containing `text`. */
+  emit(text: string): void {
+    const buf = new TextEncoder().encode(text);
+    this.value = new DataView(buf.buffer, 0, buf.byteLength);
+    this.dispatchEvent(new Event('characteristicvaluechanged'));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function decodedWrites(tx: FakeTxChar): string[] {
+  return tx.writes.map(b => new TextDecoder().decode(b));
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('Elm327CommandService', () => {
+  let service: Elm327CommandService;
+  let tx: FakeTxChar;
+  let rx: FakeRxChar;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(Elm327CommandService);
+    tx = new FakeTxChar();
+    rx = new FakeRxChar();
+  });
+
+  // -------------------------------------------------------------------------
+  // Basic send / resolve
+  // -------------------------------------------------------------------------
+
+  it('resolves with cleaned response when prompt arrives', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    let result: string | undefined;
+    service.send('ATZ').then(r => (result = r));
+
+    flushMicrotasks(); // execute() runs, writeValue awaited
+    flushMicrotasks(); // writeValue resolves, pendingResolve set
+
+    rx.emit('ELM327 v2.1\r\r>');
+
+    flushMicrotasks();
+
+    expect(result).toBe('ELM327 v2.1');
+  }));
+
+  it('strips the > prompt from the response', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    let result: string | undefined;
+    service.send('ATE0').then(r => (result = r));
+    flushMicrotasks();
+    flushMicrotasks();
+
+    rx.emit('OK\r\r>');
+    flushMicrotasks();
+
+    expect(result).toBe('OK');
+  }));
+
+  it('returns multi-line responses joined with newline', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    let result: string | undefined;
+    service.send('03').then(r => (result = r));
+    flushMicrotasks();
+    flushMicrotasks();
+
+    rx.emit('43 01 33 00 00 00 00\r\r>');
+    flushMicrotasks();
+
+    expect(result).toBe('43 01 33 00 00 00 00');
+  }));
+
+  // -------------------------------------------------------------------------
+  // TX write encoding
+  // -------------------------------------------------------------------------
+
+  it('appends \\r to the command before writing', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    service.send('ATZ');
+    flushMicrotasks();
+    flushMicrotasks();
+
+    expect(decodedWrites(tx)).toEqual(['ATZ\r']);
+  }));
+
+  it('writes a short command as a single BLE chunk', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    service.send('010C');
+    flushMicrotasks();
+    flushMicrotasks();
+
+    expect(tx.writes.length).toBe(1);
+  }));
+
+  it('splits a command longer than 20 bytes into multiple chunks', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    // 21 chars + '\r' = 22 bytes → two chunks (20 + 2)
+    const longCmd = 'A'.repeat(21);
+    service.send(longCmd);
+    flushMicrotasks();
+    flushMicrotasks();
+    flushMicrotasks(); // second chunk awaited
+
+    expect(tx.writes.length).toBe(2);
+    expect(tx.writes[0].byteLength).toBe(20);
+    expect(tx.writes[1].byteLength).toBe(2);
+  }));
+
+  // -------------------------------------------------------------------------
+  // Multi-chunk RX accumulation
+  // -------------------------------------------------------------------------
+
+  it('accumulates RX chunks until > is seen', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    let result: string | undefined;
+    service.send('03').then(r => (result = r));
+    flushMicrotasks();
+    flushMicrotasks();
+
+    // Arrives in two separate BLE notifications
+    rx.emit('43 01 33');
+    expect(result).toBeUndefined(); // no prompt yet
+
+    rx.emit(' 00 00 00 00\r\r>');
+    flushMicrotasks();
+
+    expect(result).toBe('43 01 33 00 00 00 00');
+  }));
+
+  // -------------------------------------------------------------------------
+  // Timeout
+  // -------------------------------------------------------------------------
+
+  it('rejects with a timeout error if no prompt arrives within 3 s', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    let err: Error | undefined;
+    service.send('ATZ').catch(e => (err = e));
+    flushMicrotasks();
+    flushMicrotasks();
+
+    tick(3000);
+    flushMicrotasks();
+
+    expect(err?.message).toContain('timeout');
+    expect(err?.message).toContain('ATZ');
+  }));
+
+  it('does not reject before the timeout expires', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    let rejected = false;
+    service.send('ATZ').catch(() => (rejected = true));
+    flushMicrotasks();
+    flushMicrotasks();
+
+    tick(2999);
+    flushMicrotasks();
+
+    expect(rejected).toBeFalse();
+    tick(1); // drain remaining
+  }));
+
+  // -------------------------------------------------------------------------
+  // Not attached
+  // -------------------------------------------------------------------------
+
+  it('rejects immediately if send() is called before attach()', fakeAsync(() => {
+    let err: Error | undefined;
+    service.send('ATZ').catch(e => (err = e));
+    flushMicrotasks();
+
+    expect(err?.message).toContain('not attached');
+  }));
+
+  // -------------------------------------------------------------------------
+  // Serial queue
+  // -------------------------------------------------------------------------
+
+  it('queues commands and executes them in order', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    const results: string[] = [];
+    service.send('ATZ').then(r => results.push(r));
+    service.send('ATE0').then(r => results.push(r));
+
+    // Flush until first command is in flight
+    flushMicrotasks();
+    flushMicrotasks();
+
+    // Only ATZ should have been written so far
+    expect(decodedWrites(tx)).toEqual(['ATZ\r']);
+
+    // Resolve first command
+    rx.emit('ELM327 v2.1\r\r>');
+    flushMicrotasks(); // resolves ATZ, unblocks queue
+    flushMicrotasks(); // execute('ATE0') runs
+    flushMicrotasks(); // writeValue for ATE0 resolves, pendingResolve set
+
+    // ATE0 should now be written
+    expect(decodedWrites(tx)).toEqual(['ATZ\r', 'ATE0\r']);
+
+    // Resolve second command
+    rx.emit('OK\r\r>');
+    flushMicrotasks();
+
+    expect(results).toEqual(['ELM327 v2.1', 'OK']);
+  }));
+
+  it('second command does not start until first resolves', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    service.send('ATZ');
+    service.send('ATE0');
+
+    flushMicrotasks();
+    flushMicrotasks();
+
+    // First command written, second not yet
+    expect(tx.writes.length).toBe(1);
+
+    tick(3000); // let first command time out
+    flushMicrotasks();
+    flushMicrotasks();
+    flushMicrotasks();
+
+    // Second command now written after queue unblocks on timeout rejection
+    expect(tx.writes.length).toBe(2);
+
+    tick(3000); // drain second timeout
+  }));
+
+  // -------------------------------------------------------------------------
+  // detach()
+  // -------------------------------------------------------------------------
+
+  it('detach() rejects the in-flight command', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    let err: Error | undefined;
+    service.send('ATZ').catch(e => (err = e));
+    flushMicrotasks();
+    flushMicrotasks();
+
+    service.detach();
+    flushMicrotasks();
+
+    expect(err?.message).toContain('disconnected');
+  }));
+
+  it('detach() stops RX data from being processed', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    let resolved = false;
+    service.send('ATZ').then(() => (resolved = true)).catch(() => {});
+    flushMicrotasks();
+    flushMicrotasks();
+
+    service.detach();
+    rx.emit('ELM327 v2.1\r\r>'); // notification after detach
+    flushMicrotasks();
+
+    expect(resolved).toBeFalse();
+  }));
+
+  it('allows re-attach and send after detach', fakeAsync(() => {
+    service.attach(tx, rx);
+    service.detach();
+
+    const tx2 = new FakeTxChar();
+    const rx2 = new FakeRxChar();
+    service.attach(tx2, rx2);
+
+    let result: string | undefined;
+    service.send('ATZ').then(r => (result = r));
+    flushMicrotasks();
+    flushMicrotasks();
+
+    rx2.emit('ELM327 v2.1\r\r>');
+    flushMicrotasks();
+
+    expect(result).toBe('ELM327 v2.1');
+    expect(tx2.writes.length).toBe(1);
+  }));
+
+  // -------------------------------------------------------------------------
+  // Response edge cases
+  // -------------------------------------------------------------------------
+
+  it('handles response that is only the prompt character', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    let result: string | undefined;
+    service.send('ATE0').then(r => (result = r));
+    flushMicrotasks();
+    flushMicrotasks();
+
+    rx.emit('>');
+    flushMicrotasks();
+
+    expect(result).toBe('');
+  }));
+
+  it('handles NO DATA error token in response', fakeAsync(() => {
+    service.attach(tx, rx);
+
+    let result: string | undefined;
+    service.send('010C').then(r => (result = r));
+    flushMicrotasks();
+    flushMicrotasks();
+
+    rx.emit('NO DATA\r\r>');
+    flushMicrotasks();
+
+    expect(result).toBe('NO DATA');
+  }));
+});

--- a/src/app/core/adapters/elm327-command.service.ts
+++ b/src/app/core/adapters/elm327-command.service.ts
@@ -1,0 +1,135 @@
+import { Injectable } from '@angular/core';
+
+const TIMEOUT_MS = 3000;
+const BLE_MTU = 20;
+
+// Structural types for Web Bluetooth characteristics (avoids @types/web-bluetooth)
+export interface BleWriteCharacteristic extends EventTarget {
+  writeValue(data: BufferSource): Promise<void>;
+}
+
+export interface BleNotifyCharacteristic extends EventTarget {
+  value: DataView | null;
+  startNotifications(): Promise<BleNotifyCharacteristic>;
+}
+
+/**
+ * Serial command queue for ELM327 over BLE.
+ *
+ * Rules:
+ *  - Only one command in flight at a time; callers await naturally via the queue.
+ *  - Commands are UTF-8 encoded and appended with \r before writing.
+ *  - Writes are chunked to BLE_MTU (20) bytes to respect BLE MTU limits.
+ *  - Resolution waits for the '>' prompt that signals ELM327 is idle again.
+ *  - A 3-second timeout rejects the command if no prompt is received.
+ */
+@Injectable({ providedIn: 'root' })
+export class Elm327CommandService {
+  private txChar: BleWriteCharacteristic | null = null;
+  private rxChar: BleNotifyCharacteristic | null = null;
+  private rxBuffer = '';
+  private pendingResolve: ((response: string) => void) | null = null;
+  private pendingReject: ((err: Error) => void) | null = null;
+  private queue: Promise<void> = Promise.resolve();
+  private attached = false;
+
+  /** Wire up BLE characteristics. Resets queue and buffer. */
+  attach(tx: BleWriteCharacteristic, rx: BleNotifyCharacteristic): void {
+    this.txChar = tx;
+    this.rxChar = rx;
+    this.attached = true;
+    this.rxBuffer = '';
+    this.queue = Promise.resolve();
+    rx.addEventListener('characteristicvaluechanged', this.onRxData);
+  }
+
+  /** Release BLE characteristics and reject any in-flight command. */
+  detach(): void {
+    this.attached = false;
+    this.rxChar?.removeEventListener('characteristicvaluechanged', this.onRxData);
+    const reject = this.pendingReject;
+    this.pendingResolve = null;
+    this.pendingReject = null;
+    this.txChar = null;
+    this.rxChar = null;
+    this.rxBuffer = '';
+    this.queue = Promise.resolve();
+    reject?.(new Error('BLE disconnected'));
+  }
+
+  /**
+   * Enqueue a command and resolve with the cleaned ELM327 response.
+   * Rejects if not attached, if detach() is called mid-flight, or on timeout.
+   */
+  send(command: string): Promise<string> {
+    const result = this.queue.then(() => this.execute(command));
+    this.queue = result.then(
+      () => void 0,
+      () => void 0
+    );
+    return result;
+  }
+
+  private async execute(command: string): Promise<string> {
+    if (!this.attached || !this.txChar) {
+      throw new Error(`Cannot send "${command}": not attached to BLE device`);
+    }
+
+    this.rxBuffer = '';
+
+    const bytes = new TextEncoder().encode(command + '\r');
+    for (let offset = 0; offset < bytes.length; offset += BLE_MTU) {
+      if (!this.attached || !this.txChar) {
+        throw new Error(`Detached while sending "${command}"`);
+      }
+      await this.txChar.writeValue(bytes.slice(offset, offset + BLE_MTU));
+    }
+
+    if (!this.attached) {
+      throw new Error(`Detached after sending "${command}"`);
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingResolve = null;
+        this.pendingReject = null;
+        reject(new Error(`ELM327 timeout waiting for response to: ${command}`));
+      }, TIMEOUT_MS);
+
+      this.pendingResolve = (response: string) => {
+        clearTimeout(timer);
+        this.pendingResolve = null;
+        this.pendingReject = null;
+        resolve(response);
+      };
+
+      this.pendingReject = (err: Error) => {
+        clearTimeout(timer);
+        this.pendingResolve = null;
+        this.pendingReject = null;
+        reject(err);
+      };
+    });
+  }
+
+  // Arrow function preserves `this` when used as an EventTarget listener
+  private onRxData = (event: Event): void => {
+    const char = event.target as BleNotifyCharacteristic;
+    if (!char?.value) return;
+
+    this.rxBuffer += new TextDecoder().decode(char.value);
+
+    if (!this.rxBuffer.includes('>')) return;
+
+    // Strip prompt, normalise line endings, collapse blank lines
+    const response = this.rxBuffer
+      .replace(/>/g, '')
+      .replace(/\r\n|\r/g, '\n')
+      .split('\n')
+      .map(l => l.trim())
+      .filter(l => l.length > 0)
+      .join('\n');
+
+    this.pendingResolve?.(response);
+  };
+}

--- a/src/app/core/adapters/obd-adapter.interface.ts
+++ b/src/app/core/adapters/obd-adapter.interface.ts
@@ -1,5 +1,13 @@
+import { InjectionToken } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ObdLiveFrame } from '../models/obd-live-frame.model';
+
+/**
+ * DI token used to inject whichever ObdAdapter implementation is active.
+ * Providers: { provide: OBD_ADAPTER, useClass: WebBluetoothElm327AdapterService }
+ *        or: { provide: OBD_ADAPTER, useClass: MockObdAdapterService }
+ */
+export const OBD_ADAPTER = new InjectionToken<ObdAdapter>('ObdAdapter');
 
 /**
  * Common interface for all OBD2 hardware adapters.

--- a/src/app/core/adapters/obd-pid-parser.service.ts
+++ b/src/app/core/adapters/obd-pid-parser.service.ts
@@ -31,6 +31,7 @@ export class ObdPidParserService {
       case '0104': return this.parseEngineLoad(bytes);
       case '0106': return this.parseStft(bytes);
       case '0107': return this.parseLtft(bytes);
+      case '0111': return this.parseThrottlePosition(bytes);
       default:     return null;
     }
   }
@@ -116,5 +117,11 @@ export class ObdPidParserService {
   private parseLtft(bytes: number[]): number | null {
     if (bytes.length < 1) return null;
     return ((bytes[0] - 128) * 100) / 128;
+  }
+
+  /** 0111 — Absolute throttle position: (A × 100) / 255  →  % */
+  private parseThrottlePosition(bytes: number[]): number | null {
+    if (bytes.length < 1) return null;
+    return (bytes[0] * 100) / 255;
   }
 }

--- a/src/app/core/adapters/web-bluetooth-elm327-adapter.service.ts
+++ b/src/app/core/adapters/web-bluetooth-elm327-adapter.service.ts
@@ -69,10 +69,11 @@ const INIT_COMMANDS = ['ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH0', 'ATSP0'] as const;
  * 010D — Speed         A (km/h)
  * 0105 — Coolant temp  A−40 (°C)
  * 0104 — Engine load   (A×100)/255 (%)
- * 0106 — STFT Bank 1   (A−128)×100/128 (%)
- * 0107 — LTFT Bank 1   (A−128)×100/128 (%)
+ * 0106 — STFT Bank 1        (A−128)×100/128 (%)
+ * 0107 — LTFT Bank 1        (A−128)×100/128 (%)
+ * 0111 — Throttle position  (A×100)/255 (%)
  */
-const POLL_PIDS = ['010C', '010D', '0105', '0104', '0106', '0107'] as const;
+const POLL_PIDS = ['010C', '010D', '0105', '0104', '0106', '0107', '0111'] as const;
 
 /** Pause between poll cycles (ms). Prevents flooding the BLE link. */
 const POLL_INTERVAL_MS = 200;
@@ -90,7 +91,7 @@ function makeDefaultFrame(): ObdLiveFrame {
     intakeAirTemp: 0,   // PID 010F — not polled yet
     stftB1: 0,
     ltftB1: 0,
-    throttlePosition: 0, // PID 0111 — not polled yet
+    throttlePosition: 0,
   };
 }
 
@@ -280,8 +281,9 @@ export class WebBluetoothElm327AdapterService implements ObdAdapter {
       case '010D': this.currentFrame.speed       = value; break;
       case '0105': this.currentFrame.coolantTemp = value; break;
       case '0104': this.currentFrame.engineLoad  = value; break;
-      case '0106': this.currentFrame.stftB1      = value; break;
-      case '0107': this.currentFrame.ltftB1      = value; break;
+      case '0106': this.currentFrame.stftB1            = value; break;
+      case '0107': this.currentFrame.ltftB1            = value; break;
+      case '0111': this.currentFrame.throttlePosition  = value; break;
     }
   }
 

--- a/src/app/core/adapters/web-bluetooth-elm327-adapter.service.ts
+++ b/src/app/core/adapters/web-bluetooth-elm327-adapter.service.ts
@@ -1,0 +1,291 @@
+import { Injectable } from '@angular/core';
+import { Observable, Subject, BehaviorSubject } from 'rxjs';
+
+import { ObdAdapter } from './obd-adapter.interface';
+import { ObdLiveFrame } from '../models/obd-live-frame.model';
+import {
+  Elm327CommandService,
+  BleWriteCharacteristic,
+  BleNotifyCharacteristic,
+} from './elm327-command.service';
+import { ObdPidParserService } from './obd-pid-parser.service';
+
+// ── Minimal Web Bluetooth type declarations ────────────────────────────────
+// (avoids @types/web-bluetooth; mirrors the real BluetoothRemoteGATT* shape)
+
+/** A characteristic that supports both reading (notify) and writing. */
+interface BleCharacteristic extends BleWriteCharacteristic, BleNotifyCharacteristic {}
+
+interface BleService {
+  getCharacteristic(uuid: string): Promise<BleCharacteristic>;
+}
+
+interface BleGattServer {
+  connect(): Promise<BleGattServer>;
+  disconnect(): void;
+  getPrimaryService(uuid: string): Promise<BleService>;
+}
+
+interface BleDevice {
+  name?: string;
+  gatt?: BleGattServer;
+}
+
+interface BluetoothApi {
+  requestDevice(options: {
+    acceptAllDevices?: boolean;
+    optionalServices?: string[];
+  }): Promise<BleDevice>;
+}
+
+// ── GATT service / characteristic UUIDs ───────────────────────────────────
+
+// Variant A — Generic BLE Serial (most common OBD adapters)
+const SERVICE_A   = '0000fff0-0000-1000-8000-00805f9b34fb';
+const TX_A        = '0000fff2-0000-1000-8000-00805f9b34fb';
+const RX_A        = '0000fff1-0000-1000-8000-00805f9b34fb';
+
+// Variant B — Nordic UART Service (fallback)
+const SERVICE_NUS = '6e400001-b5a3-f393-e0a9-e50e24dcca9e';
+const TX_NUS      = '6e400002-b5a3-f393-e0a9-e50e24dcca9e';
+const RX_NUS      = '6e400003-b5a3-f393-e0a9-e50e24dcca9e';
+
+// ── ELM327 constants ───────────────────────────────────────────────────────
+
+/**
+ * Init sequence sent once after BLE connection.
+ * ATZ  — full reset (chip responds with version string + ">")
+ * ATE0 — echo off
+ * ATL0 — linefeeds off
+ * ATS0 — spaces off (cleaner hex for the parser)
+ * ATH0 — headers off
+ * ATSP0 — auto-detect OBD protocol
+ */
+const INIT_COMMANDS = ['ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH0', 'ATSP0'] as const;
+
+/**
+ * Mode-01 PIDs polled every cycle.
+ * 010C — RPM           ((A×256)+B)/4
+ * 010D — Speed         A (km/h)
+ * 0105 — Coolant temp  A−40 (°C)
+ * 0104 — Engine load   (A×100)/255 (%)
+ * 0106 — STFT Bank 1   (A−128)×100/128 (%)
+ * 0107 — LTFT Bank 1   (A−128)×100/128 (%)
+ */
+const POLL_PIDS = ['010C', '010D', '0105', '0104', '0106', '0107'] as const;
+
+/** Pause between poll cycles (ms). Prevents flooding the BLE link. */
+const POLL_INTERVAL_MS = 200;
+
+// ── Default frame ──────────────────────────────────────────────────────────
+
+/** Returns an ObdLiveFrame with safe zero defaults for all required fields. */
+function makeDefaultFrame(): ObdLiveFrame {
+  return {
+    timestamp: Date.now(),
+    rpm: 0,
+    speed: 0,
+    engineLoad: 0,
+    coolantTemp: 0,
+    intakeAirTemp: 0,   // PID 010F — not polled yet
+    stftB1: 0,
+    ltftB1: 0,
+    throttlePosition: 0, // PID 0111 — not polled yet
+  };
+}
+
+// ── Service ────────────────────────────────────────────────────────────────
+
+/**
+ * Implements ObdAdapter over Web Bluetooth + ELM327.
+ *
+ * Usage:
+ *   await adapter.connect();   // opens BLE picker, inits ELM327, starts polling
+ *   adapter.data$.subscribe(frame => ...);
+ *   await adapter.disconnect();
+ */
+@Injectable({ providedIn: 'root' })
+export class WebBluetoothElm327AdapterService implements ObdAdapter {
+
+  private readonly dataSubject = new Subject<ObdLiveFrame>();
+  private readonly statusSubject = new BehaviorSubject<
+    'disconnected' | 'connecting' | 'connected' | 'error'
+  >('disconnected');
+
+  readonly data$: Observable<ObdLiveFrame> = this.dataSubject.asObservable();
+  readonly connectionStatus$ = this.statusSubject.asObservable();
+
+  private gattServer: BleGattServer | null = null;
+  private polling = false;
+  private currentFrame: ObdLiveFrame = makeDefaultFrame();
+
+  constructor(
+    private readonly commandService: Elm327CommandService,
+    private readonly parser: ObdPidParserService,
+  ) {}
+
+  // ── ObdAdapter: connect ────────────────────────────────────────────────
+
+  async connect(): Promise<void> {
+    const bluetooth = (navigator as unknown as { bluetooth?: BluetoothApi }).bluetooth;
+    if (!bluetooth) {
+      throw new Error(
+        'Web Bluetooth is not available. Use Chrome or Edge on localhost / HTTPS.'
+      );
+    }
+
+    this.statusSubject.next('connecting');
+
+    try {
+      const device = await bluetooth.requestDevice({
+        acceptAllDevices: true,
+        optionalServices: [SERVICE_A, SERVICE_NUS],
+      });
+
+      if (!device.gatt) {
+        throw new Error('GATT server not available on this device.');
+      }
+
+      const server = await device.gatt.connect();
+      this.gattServer = server;
+
+      const { tx, rx } = await this.resolveCharacteristics(server);
+      this.commandService.attach(tx, rx);
+
+      await this.runInitSequence();
+
+      this.currentFrame = makeDefaultFrame();
+      this.polling = true;
+      this.statusSubject.next('connected');
+
+      // Fire-and-forget: polling loop runs independently until disconnect()
+      this.startPollLoop();
+
+    } catch (err) {
+      this.statusSubject.next('error');
+      this.commandService.detach();
+      this.gattServer?.disconnect();
+      this.gattServer = null;
+      throw err;
+    }
+  }
+
+  // ── ObdAdapter: disconnect ─────────────────────────────────────────────
+
+  async disconnect(): Promise<void> {
+    this.polling = false;
+    this.commandService.detach();    // rejects any in-flight send
+    this.gattServer?.disconnect();
+    this.gattServer = null;
+    this.statusSubject.next('disconnected');
+  }
+
+  // ── ObdAdapter: sendCommand ────────────────────────────────────────────
+
+  sendCommand(command: string): Promise<string> {
+    return this.commandService.send(command);
+  }
+
+  // ── BLE GATT setup ────────────────────────────────────────────────────
+
+  /**
+   * Resolves TX (write) and RX (notify) characteristics.
+   * Tries Generic BLE Serial (FFF0) first; falls back to Nordic UART (6E40).
+   */
+  private async resolveCharacteristics(
+    server: BleGattServer,
+  ): Promise<{ tx: BleWriteCharacteristic; rx: BleNotifyCharacteristic }> {
+    // Try Variant A — Generic BLE Serial
+    try {
+      const svc = await server.getPrimaryService(SERVICE_A);
+      const rx  = await svc.getCharacteristic(RX_A);
+      const tx  = await svc.getCharacteristic(TX_A);
+      await rx.startNotifications();
+      return { tx, rx };
+    } catch {
+      // Not found — fall through to Variant B
+    }
+
+    // Variant B — Nordic UART Service
+    const svc = await server.getPrimaryService(SERVICE_NUS);
+    const rx  = await svc.getCharacteristic(RX_NUS);
+    const tx  = await svc.getCharacteristic(TX_NUS);
+    await rx.startNotifications();
+    return { tx, rx };
+  }
+
+  // ── ELM327 init sequence ──────────────────────────────────────────────
+
+  /**
+   * Sends the standard init commands in order.
+   * ATZ resets the chip; the ">" prompt only arrives once the chip is back up,
+   * so no extra delay is needed — commandService.send() handles the wait.
+   */
+  private async runInitSequence(): Promise<void> {
+    for (const cmd of INIT_COMMANDS) {
+      await this.commandService.send(cmd);
+    }
+  }
+
+  // ── PID polling loop ──────────────────────────────────────────────────
+
+  private startPollLoop(): void {
+    const loop = async (): Promise<void> => {
+      while (this.polling) {
+        await this.pollOneCycle();
+        if (this.polling) {
+          await this.delay(POLL_INTERVAL_MS);
+        }
+      }
+    };
+
+    loop().catch(() => {
+      // Unexpected error in the loop — mark as error and stop
+      if (this.polling) {
+        this.polling = false;
+        this.statusSubject.next('error');
+      }
+    });
+  }
+
+  /**
+   * Sends each PID in sequence, parses the response, and emits one frame.
+   * Null responses (NO DATA, timeout, malformed) are skipped — the previous
+   * valid value is retained in currentFrame.
+   */
+  private async pollOneCycle(): Promise<void> {
+    for (const pid of POLL_PIDS) {
+      if (!this.polling) return;
+
+      try {
+        const raw   = await this.commandService.send(pid);
+        const value = this.parser.parse(pid, raw);
+        if (value !== null) {
+          this.applyPidValue(pid, value);
+        }
+      } catch {
+        // Individual PID timeout or disconnected — skip and continue
+      }
+    }
+
+    if (this.polling) {
+      this.dataSubject.next({ ...this.currentFrame, timestamp: Date.now() });
+    }
+  }
+
+  /** Write a parsed value into the current frame accumulator. */
+  private applyPidValue(pid: string, value: number): void {
+    switch (pid) {
+      case '010C': this.currentFrame.rpm         = value; break;
+      case '010D': this.currentFrame.speed       = value; break;
+      case '0105': this.currentFrame.coolantTemp = value; break;
+      case '0104': this.currentFrame.engineLoad  = value; break;
+      case '0106': this.currentFrame.stftB1      = value; break;
+      case '0107': this.currentFrame.ltftB1      = value; break;
+    }
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}

--- a/src/app/features/ble-debug/ble-debug.component.html
+++ b/src/app/features/ble-debug/ble-debug.component.html
@@ -23,7 +23,12 @@
   </div>
 
   <div class="log-panel" #logContainer>
-    <div *ngFor="let line of log" class="log-line" [class.log-rx]="line.startsWith('>>')" [class.log-tx]="line.startsWith('<<')" [class.log-err]="line.startsWith('!!')">
+    <div
+      *ngFor="let line of log"
+      class="log-line"
+      [class.log-rx]="line.startsWith('>>')"
+      [class.log-tx]="line.startsWith('<<')"
+      [class.log-err]="line.startsWith('!!')">
       {{ line }}
     </div>
     <div *ngIf="log.length === 0" class="log-empty">No output yet.</div>

--- a/src/app/features/ble-debug/ble-debug.component.ts
+++ b/src/app/features/ble-debug/ble-debug.component.ts
@@ -13,6 +13,7 @@ interface BleService {
 }
 interface BleGattServer {
   connect(): Promise<BleGattServer>;
+  disconnect(): void;
   getPrimaryService(uuid: string): Promise<BleService>;
 }
 interface BleDevice {
@@ -51,6 +52,8 @@ export class BleDebugComponent implements OnDestroy {
   @ViewChild('logContainer') private logContainer?: ElementRef<HTMLDivElement>;
 
   private txChar: BleCharacteristic | null = null;
+  private rxChar: BleCharacteristic | null = null;
+  private gattServer: BleGattServer | null = null;
 
   public get canConnect(): boolean {
     return this.status === 'idle' || this.status === 'error';
@@ -84,6 +87,7 @@ export class BleDebugComponent implements OnDestroy {
       }
 
       const server = await device.gatt.connect();
+      this.gattServer = server;
       this.appendLog('>> GATT connected');
 
       this.txChar = await this.resolveCharacteristics(server);
@@ -103,6 +107,7 @@ export class BleDebugComponent implements OnDestroy {
       const tx = await service.getCharacteristic(TX_A);
       await rx.startNotifications();
       rx.addEventListener('characteristicvaluechanged', this.onRxData);
+      this.rxChar = rx;
       this.appendLog('>> Profile: Generic BLE Serial (FFF0/FFF1/FFF2)');
       return tx;
     } catch {
@@ -115,6 +120,7 @@ export class BleDebugComponent implements OnDestroy {
     const tx = await service.getCharacteristic(TX_NUS);
     await rx.startNotifications();
     rx.addEventListener('characteristicvaluechanged', this.onRxData);
+    this.rxChar = rx;
     this.appendLog('>> Profile: Nordic UART Service (6E40/RX/TX)');
     return tx;
   }
@@ -169,6 +175,10 @@ export class BleDebugComponent implements OnDestroy {
   }
 
   public ngOnDestroy(): void {
+    this.rxChar?.removeEventListener('characteristicvaluechanged', this.onRxData);
+    this.gattServer?.disconnect();
+    this.rxChar = null;
     this.txChar = null;
+    this.gattServer = null;
   }
 }

--- a/src/app/features/dashboard/dashboard-page.component.html
+++ b/src/app/features/dashboard/dashboard-page.component.html
@@ -17,11 +17,23 @@
       </div>
     </div>
 
-    <div class="modes">
-      <button (click)="setMode('normal')">Normal</button>
-      <button (click)="setMode('lean')">Lean</button>
-      <button (click)="setMode('rich')">Rich</button>
-      <button (click)="setMode('vacuum-leak')">Vacuum Leak</button>
+    <div class="controls">
+      <ng-container *ngIf="connectionStatus$ | async as status">
+        <button
+          *ngIf="status !== 'connected'"
+          class="btn-connect"
+          [disabled]="status === 'connecting'"
+          (click)="connectAdapter()">
+          {{ status === 'connecting' ? 'Connecting…' : status === 'error' ? 'Reconnect' : 'Connect to OBD' }}
+        </button>
+        <button
+          *ngIf="status === 'connected'"
+          class="btn-disconnect"
+          (click)="disconnectAdapter()">
+          Disconnect
+        </button>
+      </ng-container>
+      <button class="btn-clear" (click)="clearCharts()">Clear</button>
     </div>
   </header>
 

--- a/src/app/features/dashboard/dashboard-page.component.scss
+++ b/src/app/features/dashboard/dashboard-page.component.scss
@@ -63,19 +63,50 @@
       }
     }
 
-    .modes {
+    .controls {
       display: flex;
       gap: $spacing-sm;
+      align-items: center;
 
       button {
-        padding: 6px 12px;
-        background: $bg-secondary;
-        border: 1px solid $border-color;
-        color: $text-secondary;
-        cursor: pointer;
+        padding: 6px 14px;
         border-radius: 4px;
         font-size: 0.8rem;
+        font-weight: 600;
+        cursor: pointer;
         transition: all 0.2s ease;
+        border: 1px solid transparent;
+
+        &:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+      }
+
+      .btn-connect {
+        background: rgba($color-success, 0.15);
+        border-color: $color-success;
+        color: $color-success;
+
+        &:hover:not(:disabled) {
+          background: rgba($color-success, 0.25);
+        }
+      }
+
+      .btn-disconnect {
+        background: rgba($color-critical, 0.15);
+        border-color: $color-critical;
+        color: $color-critical;
+
+        &:hover {
+          background: rgba($color-critical, 0.25);
+        }
+      }
+
+      .btn-clear {
+        background: $bg-secondary;
+        border-color: $border-color;
+        color: $text-secondary;
 
         &:hover {
           color: $text-primary;

--- a/src/app/features/dashboard/dashboard-page.component.ts
+++ b/src/app/features/dashboard/dashboard-page.component.ts
@@ -99,9 +99,6 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.diagnosticEngine.startSession();
-    this.obdAdapter.connect().catch(() => {
-      // Connection refused or Web Bluetooth unavailable — connectionStatus$ reflects the error state
-    });
 
     const dataSubscription = this.obdAdapter.data$.subscribe({
       next: (frame: ObdLiveFrame) => this.handleNewFrame(frame)
@@ -122,10 +119,21 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
     this.stftChart?.chart?.destroy();
     this.ltftChart?.chart?.destroy();
     this.diagnosticEngine.stopSession();
+    this.obdAdapter.disconnect();
     this.subscriptions.unsubscribe();
   }
 
-  public setMode(mode: string): void {
+  public connectAdapter(): void {
+    this.obdAdapter.connect().catch(() => {
+      // DOMException or connection failure — connectionStatus$ reflects the error state
+    });
+  }
+
+  public disconnectAdapter(): void {
+    this.obdAdapter.disconnect();
+  }
+
+  public clearCharts(): void {
     this.frames = [];
     this.frameCount = 0;
     this.dataState = 'no_data';

--- a/src/app/features/dashboard/dashboard-page.component.ts
+++ b/src/app/features/dashboard/dashboard-page.component.ts
@@ -56,9 +56,9 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
   public stftChartData: ChartData<'line'> = makeLineData('STFT B1 %', '#2196F3');
   public ltftChartData: ChartData<'line'> = makeLineData('LTFT B1 %', '#ff9800');
 
-  @ViewChild('rpmChart') rpmChart?: BaseChartDirective;
-  @ViewChild('stftChart') stftChart?: BaseChartDirective;
-  @ViewChild('ltftChart') ltftChart?: BaseChartDirective;
+  @ViewChild('rpmChart', { read: BaseChartDirective }) rpmChart?: BaseChartDirective;
+  @ViewChild('stftChart', { read: BaseChartDirective }) stftChart?: BaseChartDirective;
+  @ViewChild('ltftChart', { read: BaseChartDirective }) ltftChart?: BaseChartDirective;
 
   public readonly rpmChartOptions: ChartOptions<'line'> = {
     ...BASE_CHART_OPTIONS,

--- a/src/app/features/dashboard/dashboard-page.component.ts
+++ b/src/app/features/dashboard/dashboard-page.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { Component, Inject, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Observable, Subscription } from 'rxjs';
 import { ChartData, ChartOptions } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
-import { MockObdAdapterService, MockMode } from '../../core/adapters/mock-obd-adapter.service';
+import { ObdAdapter, OBD_ADAPTER } from '../../core/adapters/obd-adapter.interface';
 import { DiagnosticEngineService } from '../../core/diagnostics/diagnostic-engine.service';
 import { ObdLiveFrame } from '../../core/models/obd-live-frame.model';
 import { DiagnosticResult } from '../../core/models/diagnostic-result.model';
@@ -91,7 +91,7 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
   private subscriptions = new Subscription();
 
   constructor(
-    private obdAdapter: MockObdAdapterService,
+    @Inject(OBD_ADAPTER) private obdAdapter: ObdAdapter,
     private diagnosticEngine: DiagnosticEngineService
   ) {
     this.connectionStatus$ = this.obdAdapter.connectionStatus$;
@@ -99,7 +99,9 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.diagnosticEngine.startSession();
-    this.obdAdapter.connect();
+    this.obdAdapter.connect().catch(() => {
+      // Connection refused or Web Bluetooth unavailable — connectionStatus$ reflects the error state
+    });
 
     const dataSubscription = this.obdAdapter.data$.subscribe({
       next: (frame: ObdLiveFrame) => this.handleNewFrame(frame)
@@ -139,8 +141,6 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
     this.rpmChart?.chart?.update();
     this.stftChart?.chart?.update();
     this.ltftChart?.chart?.update();
-
-    this.obdAdapter.setMockMode(mode as MockMode);
   }
 
   private handleNewFrame(frame: ObdLiveFrame): void {


### PR DESCRIPTION
## Summary

This session implements the full BLE ELM327 hardware stack and wires it to the dashboard, replacing the mock adapter.

- **Elm327CommandService** - Promise-based BLE serial command queue: one command in-flight at a time, 20-byte write chunking, characteristicvaluechanged listener for RX, accumulates response until > prompt, 3-second timeout
- **ObdPidParserService** - Parses ELM327 Mode-01 raw responses for PIDs 010C / 010D / 0105 / 0104 / 0106 / 0107 / 0111 into engineering values (RPM, speed, coolant temp, engine load, STFT, LTFT, throttle position)
- **WebBluetoothElm327AdapterService** - Full ObdAdapter over Web Bluetooth + ELM327: BLE device picker, GATT resolution (Generic BLE Serial FFF0 with Nordic UART NUS fallback), init sequence (ATZ / ATE0 / ATL0 / ATS0 / ATH0 / ATSP0), PID poll loop at 200 ms
- **Dashboard wiring** - pp.config.ts now provides WebBluetoothElm327AdapterService under the OBD_ADAPTER token; dashboard injects it via token only
- **Connect / Disconnect UI** - Auto-connect removed from 
gOnInit (Web Bluetooth requires a user gesture); replaced mock-mode buttons with Connect / Connecting. / Reconnect / Disconnect / Clear controls with semantic colour coding
- **Chart @ViewChild fix** - Added { read: BaseChartDirective } to all three @ViewChild decorators; without it Angular resolved the template ref to ElementRef and chart.update() silently no-oped, so charts never re-rendered with live data
- **Throttle position fix** - PID  111 was missing from the poll list, the pplyPidValue switch, and the parser; card was stuck at 0%
- **BLE debug lifecycle** - BleDebugComponent now stores xChar and gattServer refs, removes the characteristicvaluechanged listener on destroy, and disconnects GATT

## Test plan

- [ ] 
g build passes with no errors or warnings
- [ ] Open in Chrome on localhost or HTTPS
- [ ] Click **Connect to OBD** - BLE device picker appears
- [ ] Status pill transitions: disconnected ? connecting ? connected
- [ ] All 6 metric cards update live (RPM, Speed, Coolant, STFT B1, LTFT B1, Throttle)
- [ ] RPM, STFT B1, LTFT B1 charts animate continuously
- [ ] Throttle position card shows non-zero values when pressing the accelerator
- [ ] Click **Disconnect** - status returns to disconnected, polling stops cleanly
- [ ] Click **Clear** - all charts and metrics reset to zero
- [ ] BLE Debug page: connect, send ATZ ? ATE0 ?  10C - verify raw hex responses appear in log
- [ ] Navigating away from dashboard and back does not leave dangling BLE connections