### PR TITLE
DTC Intelligence Sprint: decoder, integration, and rich UI display

### DIFF
--- a/src/app/core/diagnostics/deep-diagnosis.service.ts
+++ b/src/app/core/diagnostics/deep-diagnosis.service.ts
@@ -61,17 +61,20 @@ export class DeepDiagnosisService {
   ) {}
 
   public startDiagnosis(): void {
-    this.cancelDiagnosis();
+    this.stopInternal();
     this.sessionActive = true;
     this.stopSubject = new Subject<void>();
     this.idleFrames = [];
     this.revFrames = [];
+    this.finalResultSubject.next(null);
+    this.stateSubject.next(this.getInitialState());
     this.runBaselineScan();
   }
 
   public cancelDiagnosis(): void {
     this.sessionActive = false;
     this.stopInternal();
+    this.finalResultSubject.next(null);
     this.stateSubject.next({
       ...this.getInitialState(),
       status: 'cancelled',

--- a/src/app/core/diagnostics/dtc/dtc-decoder.service.spec.ts
+++ b/src/app/core/diagnostics/dtc/dtc-decoder.service.spec.ts
@@ -44,7 +44,7 @@ describe('DtcDecoderService', () => {
     it('falls back to generic map when manufacturer is provided but code not in manufacturer map', () => {
       const result = service.decode('P0300', 'toyota');
       expect(result.source).toBe('generic');
-      expect(result.description).toContain('misfire');
+      expect(result.description.toLowerCase()).toContain('misfire');
     });
 
     it('returns unknown for unrecognised code with no manufacturer', () => {

--- a/src/app/features/guided-tests/guided-tests-page.component.html
+++ b/src/app/features/guided-tests/guided-tests-page.component.html
@@ -118,12 +118,10 @@
             <!-- Fault Codes -->
             <div class="dtc-section" *ngIf="state.dtcCodes && state.dtcCodes.length > 0">
               <h4 class="section-label">Fault Codes</h4>
-              <ul class="dtc-list">
-                <li *ngFor="let dtc of state.dtcCodes" class="dtc-item">
-                  <span class="dtc-code">{{ dtc.code }}</span>
-                  <span class="dtc-desc">{{ dtc.description }}</span>
-                </li>
-              </ul>
+              <app-dtc-code-card
+                *ngFor="let dtc of state.dtcCodes"
+                [dtc]="dtc">
+              </app-dtc-code-card>
             </div>
 
             <!-- Sensor-based findings from tests -->

--- a/src/app/features/guided-tests/guided-tests-page.component.ts
+++ b/src/app/features/guided-tests/guided-tests-page.component.ts
@@ -9,6 +9,7 @@ import { idleStabilityTest } from '../../core/diagnostics/guided-tests/idle-stab
 import { revTest } from '../../core/diagnostics/guided-tests/rev-test.test';
 import { warmupTest } from '../../core/diagnostics/guided-tests/warmup-test.test';
 import { FuelTrimTestPanelComponent } from './components/fuel-trim-test-panel/fuel-trim-test-panel.component';
+import { DtcCodeCardComponent } from '../../shared/dtc-code-card/dtc-code-card.component';
 import { DeepDiagnosisService, DeepDiagnosisState, DiagnosisStepId } from '../../core/diagnostics/deep-diagnosis.service';
 import { ObdAdapter, OBD_ADAPTER } from '../../core/adapters/obd-adapter.interface';
 import { ObdLiveFrame } from '../../core/models/obd-live-frame.model';
@@ -34,7 +35,7 @@ interface StepChartConfig {
 @Component({
   selector: 'app-guided-tests-page',
   standalone: true,
-  imports: [CommonModule, FuelTrimTestPanelComponent, BaseChartDirective],
+  imports: [CommonModule, FuelTrimTestPanelComponent, DtcCodeCardComponent, BaseChartDirective],
   templateUrl: './guided-tests-page.component.html',
   styleUrls: ['./guided-tests-page.component.scss']
 })

--- a/src/app/shared/dtc-code-card/dtc-code-card.component.html
+++ b/src/app/shared/dtc-code-card/dtc-code-card.component.html
@@ -1,0 +1,32 @@
+<div class="dtc-card" [ngClass]="severityClass">
+  <div class="dtc-card-header" (click)="expanded = !expanded">
+    <div class="dtc-meta">
+      <span class="dtc-code-badge">{{ dtc.code }}</span>
+      <span class="dtc-severity-badge" [ngClass]="severityClass">{{ dtc.severity }}</span>
+      <span class="dtc-source-badge" *ngIf="dtc.source === 'manufacturer'">{{ dtc.manufacturer }}</span>
+    </div>
+    <div class="dtc-title-row">
+      <h4 class="dtc-title">{{ dtc.title }}</h4>
+      <span class="dtc-subsystem" *ngIf="dtc.subsystem">{{ dtc.subsystem }}</span>
+    </div>
+    <p class="dtc-description">{{ dtc.description }}</p>
+    <button class="dtc-expand-btn" type="button" aria-label="Toggle details">
+      {{ expanded ? '▲ Less' : '▼ More' }}
+    </button>
+  </div>
+
+  <div class="dtc-details" *ngIf="expanded">
+    <div class="dtc-causes" *ngIf="dtc.possibleCauses && dtc.possibleCauses.length > 0">
+      <h5>Possible Causes</h5>
+      <ul>
+        <li *ngFor="let cause of dtc.possibleCauses">{{ cause }}</li>
+      </ul>
+    </div>
+    <div class="dtc-checks" *ngIf="dtc.recommendedChecks && dtc.recommendedChecks.length > 0">
+      <h5>Recommended Checks</h5>
+      <ol>
+        <li *ngFor="let check of dtc.recommendedChecks">{{ check }}</li>
+      </ol>
+    </div>
+  </div>
+</div>

--- a/src/app/shared/dtc-code-card/dtc-code-card.component.scss
+++ b/src/app/shared/dtc-code-card/dtc-code-card.component.scss
@@ -1,0 +1,127 @@
+.dtc-card {
+  border-radius: 8px;
+  border-left: 4px solid #666;
+  background: #1e1e2e;
+  margin-bottom: 12px;
+  overflow: hidden;
+  transition: box-shadow 0.2s;
+
+  &:hover { box-shadow: 0 2px 12px rgba(0,0,0,0.4); }
+
+  &.severity-low    { border-left-color: #4caf50; }
+  &.severity-medium { border-left-color: #ff9800; }
+  &.severity-high   { border-left-color: #f44336; }
+  &.severity-critical { border-left-color: #9c27b0; }
+  &.severity-unknown { border-left-color: #666; }
+}
+
+.dtc-card-header {
+  padding: 14px 16px 10px;
+  cursor: pointer;
+}
+
+.dtc-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.dtc-code-badge {
+  font-family: monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #e0e0e0;
+  background: #2a2a3e;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+.dtc-severity-badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 10px;
+  letter-spacing: 0.05em;
+
+  &.severity-low     { background: rgba(76,175,80,0.2);  color: #81c784; }
+  &.severity-medium  { background: rgba(255,152,0,0.2);  color: #ffb74d; }
+  &.severity-high    { background: rgba(244,67,54,0.2);  color: #e57373; }
+  &.severity-critical{ background: rgba(156,39,176,0.2); color: #ce93d8; }
+  &.severity-unknown { background: rgba(102,102,102,0.2);color: #9e9e9e; }
+}
+
+.dtc-source-badge {
+  font-size: 0.68rem;
+  padding: 2px 6px;
+  border-radius: 10px;
+  background: rgba(33,150,243,0.15);
+  color: #64b5f6;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.dtc-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.dtc-title {
+  margin: 0;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #cdd6f4;
+}
+
+.dtc-subsystem {
+  font-size: 0.75rem;
+  color: #7f849c;
+  font-style: italic;
+}
+
+.dtc-description {
+  margin: 6px 0 8px;
+  font-size: 0.83rem;
+  color: #9399b2;
+  line-height: 1.45;
+}
+
+.dtc-expand-btn {
+  background: none;
+  border: none;
+  color: #585b70;
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0;
+
+  &:hover { color: #cdd6f4; }
+}
+
+.dtc-details {
+  padding: 0 16px 14px;
+  border-top: 1px solid #2a2a3e;
+
+  h5 {
+    font-size: 0.78rem;
+    color: #7f849c;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 12px 0 6px;
+  }
+
+  ul, ol {
+    margin: 0;
+    padding-left: 18px;
+
+    li {
+      font-size: 0.82rem;
+      color: #a6adc8;
+      line-height: 1.5;
+      margin-bottom: 2px;
+    }
+  }
+}

--- a/src/app/shared/dtc-code-card/dtc-code-card.component.ts
+++ b/src/app/shared/dtc-code-card/dtc-code-card.component.ts
@@ -1,0 +1,26 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DtcCode } from '../../core/diagnostics/dtc/dtc-code.model';
+
+@Component({
+  selector: 'app-dtc-code-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './dtc-code-card.component.html',
+  styleUrls: ['./dtc-code-card.component.scss'],
+})
+export class DtcCodeCardComponent {
+  @Input({ required: true }) dtc!: DtcCode;
+
+  expanded = false;
+
+  get severityClass(): string {
+    switch (this.dtc.severity) {
+      case 'Low':      return 'severity-low';
+      case 'Medium':   return 'severity-medium';
+      case 'High':     return 'severity-high';
+      case 'Critical': return 'severity-critical';
+      default:         return 'severity-unknown';
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **Sprint 1 (#23)** — `DtcCode` model with typed `category`/`severity`/`source` unions; `generic-dtc-map` with 21 OBD-II codes; `toyota-dtc-map` with 3 OEM codes
- **Sprint 2 (#27)** — `DtcDecoderService`: `decode(code, manufacturer?)` and `decodeMany()`; normalises input, manufacturer-first lookup, generic fallback, unknown fallback; full Jasmine unit tests
- **Sprint 3 (#29)** — `DeepDiagnosisState` gains `dtcCodes`/`dtcFindings`; DTC correlation rules for fuel trim (P0171/P0174), misfire (P0300-P0304), and MAF (P0100-P0104); results block shows Fault Codes + Code Analysis
- **Sprint 4 (#30)** — Standalone `DtcCodeCardComponent`: severity-colour-coded cards with expand/collapse for possible causes and recommended checks; replaces plain list in Full Engine Diagnosis results

## Test plan

- [ ] `ng build` passes (verified clean)
- [ ] `DtcDecoderService` unit tests pass for all paths
- [ ] Full Engine Diagnosis result page shows DTC cards with correct severity colours
- [ ] Expand/collapse shows possibleCauses and recommendedChecks
- [ ] Toyota codes show manufacturer badge

Closes #23, #27, #29, #30, #31