### PR TITLE
feat: MVP Advanced Diagnostics — Export, Unknown DTC Logging, Multi-DTC Patterns (#52 #53 #54)

### DIFF
--- a/src/app/core/diagnostics/deep-diagnosis.service.ts
+++ b/src/app/core/diagnostics/deep-diagnosis.service.ts
@@ -9,6 +9,7 @@ import { revTest } from './guided-tests/rev-test.test';
 import { warmupTest } from './guided-tests/warmup-test.test';
 import { DtcDecoderService } from './dtc/dtc-decoder.service';
 import { DtcCode } from './dtc/dtc-code.model';
+import { UnknownDtcLoggerService } from './dtc/unknown-dtc-logger.service';
 import { DtcCorrelationService } from './intelligence/dtc-correlation.service';
 import { SeverityEngineService } from './intelligence/severity-engine.service';
 import { DiagnosticRecommendationService } from './intelligence/diagnostic-recommendation.service';
@@ -69,6 +70,7 @@ export class DeepDiagnosisService {
     @Inject(OBD_ADAPTER) private obdAdapter: ObdAdapter,
     private guidedTestService: GuidedTestService,
     private dtcDecoder: DtcDecoderService,
+    private unknownDtcLogger: UnknownDtcLoggerService,
     private dtcCorrelation: DtcCorrelationService,
     private severityEngine: SeverityEngineService,
     private recommendationEngine: DiagnosticRecommendationService,
@@ -318,6 +320,7 @@ export class DeepDiagnosisService {
       }
 
       const dtcCodes = this.dtcDecoder.decodeMany([...rawCodes], manufacturer);
+      dtcCodes.filter(d => d.source === 'unknown').forEach(d => this.unknownDtcLogger.log(d.code));
       this.updateState({ dtcCodes });
     } catch {
       this.updateState({ dtcCodes: [] });

--- a/src/app/core/diagnostics/dtc/unknown-dtc-logger.service.ts
+++ b/src/app/core/diagnostics/dtc/unknown-dtc-logger.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+
+export interface UnknownDtcEntry {
+  code: string;
+  timestamp: number;
+  sessionId: string;
+}
+
+const DB_NAME = 'obd-unknown-dtcs';
+const STORE_NAME = 'unknown_dtcs';
+const DB_VERSION = 1;
+
+@Injectable({ providedIn: 'root' })
+export class UnknownDtcLoggerService {
+  private db: IDBDatabase | null = null;
+  private readonly sessionId = crypto.randomUUID();
+
+  constructor() {
+    this.openDb().catch(() => {/* silently skip if IndexedDB unavailable */});
+  }
+
+  log(code: string): void {
+    const entry: UnknownDtcEntry = { code, timestamp: Date.now(), sessionId: this.sessionId };
+    this.openDb()
+      .then(db => {
+        db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME).add(entry);
+      })
+      .catch(() => {/* fire-and-forget — must not affect diagnosis flow */});
+  }
+
+  getAll(): Promise<UnknownDtcEntry[]> {
+    return this.openDb().then(
+      db => new Promise((resolve, reject) => {
+        const req = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).getAll();
+        req.onsuccess = () => resolve(req.result as UnknownDtcEntry[]);
+        req.onerror = () => reject(req.error);
+      })
+    );
+  }
+
+  private openDb(): Promise<IDBDatabase> {
+    if (this.db) return Promise.resolve(this.db);
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, DB_VERSION);
+      req.onupgradeneeded = () => {
+        const store = req.result.createObjectStore(STORE_NAME, { autoIncrement: true });
+        store.createIndex('code', 'code', { unique: false });
+        store.createIndex('timestamp', 'timestamp', { unique: false });
+      };
+      req.onsuccess = () => { this.db = req.result; resolve(req.result); };
+      req.onerror = () => reject(req.error);
+    });
+  }
+}

--- a/src/app/core/diagnostics/intelligence/diagnosis-export.service.ts
+++ b/src/app/core/diagnostics/intelligence/diagnosis-export.service.ts
@@ -64,7 +64,9 @@ export class DiagnosisExportService {
     a.href = url;
     a.download = filename;
     a.click();
-    URL.revokeObjectURL(url);
+    // Defer revocation so the browser has time to begin navigation before the
+    // object URL is invalidated (immediate revocation breaks Firefox/Safari).
+    setTimeout(() => URL.revokeObjectURL(url), 100);
   }
 
   private timestamp(): string {

--- a/src/app/core/diagnostics/intelligence/diagnosis-export.service.ts
+++ b/src/app/core/diagnostics/intelligence/diagnosis-export.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@angular/core';
+import { DeepDiagnosisState } from '../deep-diagnosis.service';
+
+@Injectable({ providedIn: 'root' })
+export class DiagnosisExportService {
+
+  exportJson(state: DeepDiagnosisState): void {
+    const data = {
+      exportedAt: new Date().toISOString(),
+      severity: state.severity ?? null,
+      dtcCodes: state.dtcCodes ?? [],
+      correlationFindings: state.correlationFindings ?? [],
+      recommendations: state.recommendations ?? null,
+      summary: state.diagnosisSummary ?? null,
+      timeline: state.timelineEvents ?? [],
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    this.triggerDownload(blob, `diagnosis-${this.timestamp()}.json`);
+  }
+
+  exportCsv(state: DeepDiagnosisState): void {
+    const lines: string[] = ['Section,Field,Value'];
+
+    if (state.severity) {
+      lines.push(`Severity,Score,${state.severity.score}`);
+      lines.push(`Severity,Level,${state.severity.level}`);
+    }
+
+    if (state.diagnosisSummary) {
+      lines.push(`Summary,Text,${this.escape(state.diagnosisSummary.summaryText)}`);
+      lines.push(`Summary,Recommended Action,${this.escape(state.diagnosisSummary.recommendedAction)}`);
+    }
+
+    for (const dtc of state.dtcCodes ?? []) {
+      lines.push(`DTC,${dtc.code},${this.escape(dtc.title + ' - ' + dtc.description)}`);
+    }
+
+    for (const finding of state.correlationFindings ?? []) {
+      lines.push(`Finding,${finding.codes.join('/')},${this.escape(finding.message)}`);
+    }
+
+    for (const check of state.recommendations?.recommendedChecks ?? []) {
+      lines.push(`Recommended Check,,${this.escape(check)}`);
+    }
+
+    for (const step of state.recommendations?.nextSteps ?? []) {
+      lines.push(`Next Step,,${this.escape(step)}`);
+    }
+
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
+    this.triggerDownload(blob, `diagnosis-${this.timestamp()}.csv`);
+  }
+
+  private escape(value: string): string {
+    if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+      return `"${value.replace(/"/g, '""')}"`;
+    }
+    return value;
+  }
+
+  private triggerDownload(blob: Blob, filename: string): void {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  private timestamp(): string {
+    return new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  }
+}

--- a/src/app/core/diagnostics/intelligence/dtc-correlation.service.ts
+++ b/src/app/core/diagnostics/intelligence/dtc-correlation.service.ts
@@ -131,6 +131,46 @@ export class DtcCorrelationService {
       });
     }
 
+    findings.push(...this.detectMultiDtcPatterns(codes));
+
+    return findings;
+  }
+
+  private detectMultiDtcPatterns(codes: Set<string>): CorrelationFinding[] {
+    const findings: CorrelationFinding[] = [];
+
+    if (codes.has('P0171') && codes.has('P0101')) {
+      findings.push({
+        codes: ['P0171', 'P0101'],
+        message: 'P0171 + P0101: Combined lean and MAF fault — likely air intake or airflow restriction. Inspect MAF sensor, air filter, and intake ducts for leaks.',
+        upgradesSeverity: true,
+      });
+    }
+
+    if (codes.has('P0300') && codes.has('P0171')) {
+      findings.push({
+        codes: ['P0300', 'P0171'],
+        message: 'P0300 + P0171: Random misfire with lean condition — lean fuel mixture likely starving cylinders. Resolve lean fault first; inspect fuel delivery and vacuum integrity.',
+        upgradesSeverity: true,
+      });
+    }
+
+    if (codes.has('P0300') && codes.has('P0172')) {
+      findings.push({
+        codes: ['P0300', 'P0172'],
+        message: 'P0300 + P0172: Random misfire with rich condition — excess fuel may be washing cylinder walls. Inspect injectors and fuel pressure regulator.',
+        upgradesSeverity: true,
+      });
+    }
+
+    if (codes.has('P0420') && codes.has('P0300')) {
+      findings.push({
+        codes: ['P0420', 'P0300'],
+        message: 'P0420 + P0300: Catalyst inefficiency alongside misfire — unburned fuel from misfires may be degrading the catalytic converter. Resolve misfire fault first.',
+        upgradesSeverity: false,
+      });
+    }
+
     return findings;
   }
 


### PR DESCRIPTION
## Summary

- **#52** — `DiagnosisExportService`: download full diagnosis report as JSON or CSV (severity, DTCs, findings, recommendations, summary, timeline)
- **#53** — `UnknownDtcLoggerService`: fire-and-forget IndexedDB logging of unrecognised DTC codes; integrated into `DeepDiagnosisService`; structured for future Firebase upload
- **#54** — Multi-DTC pattern detection in `DtcCorrelationService`: detects P0171+P0101, P0300+P0171, P0300+P0172, P0420+P0300 as combined findings alongside per-code analysis

## Test plan

- [ ] Call `exportJson` / `exportCsv` after a completed diagnosis — verify file downloads with correct data
- [ ] Trigger a diagnosis with an unknown DTC code — confirm entry appears in IndexedDB (`obd-unknown-dtcs` → `unknown_dtcs`)
- [ ] Simulate DTCs P0171+P0101 together — confirm combined pattern finding appears in correlation results
- [ ] Simulate DTCs P0300+P0171 together — confirm misfire-lean combined finding
- [ ] Verify no regression in existing per-code correlation rules (lean, rich, misfire, MAF, catalyst)
- [ ] Verify unknown DTC logging does not delay or throw during normal diagnosis flow