### PR TITLE
feat: Power Features Sprint — Multi-signal Graphs, Session Replay, Offline Simulator

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -10,6 +10,7 @@
       <li><a routerLink="/dashboard"        routerLinkActive="active">Dashboard</a></li>
       <li><a routerLink="/guided-tests"     routerLinkActive="active">Guided Tests</a></li>
       <li><a routerLink="/sessions"         routerLinkActive="active">Sessions</a></li>
+      <li><a routerLink="/session-replay"   routerLinkActive="active">Session Replay</a></li>
       <li><a routerLink="/ble-debug"        routerLinkActive="active">BLE Debug</a></li>
     </ul>
   </nav>

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,15 +1,20 @@
-import { ApplicationConfig, importProvidersFrom } from '@angular/core';
+import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
 import { OBD_ADAPTER } from './core/adapters/obd-adapter.interface';
+import { AdapterSwitcherService } from './core/adapters/adapter-switcher.service';
 import { WebBluetoothElm327AdapterService } from './core/adapters/web-bluetooth-elm327-adapter.service';
+import { SimulatorObdAdapterService } from './core/adapters/simulator-obd-adapter.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
     provideCharts(withDefaultRegisterables()),
     WebBluetoothElm327AdapterService,
-    { provide: OBD_ADAPTER, useExisting: WebBluetoothElm327AdapterService }
+    SimulatorObdAdapterService,
+    AdapterSwitcherService,
+    // All consumers inject OBD_ADAPTER; the switcher proxies real ↔ simulated
+    { provide: OBD_ADAPTER, useExisting: AdapterSwitcherService },
   ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -27,6 +27,11 @@ export const routes: Routes = [
       .then(m => m.SessionSummaryComponent)
   },
   {
+    path: 'session-replay',
+    loadComponent: () => import('./features/session-replay/session-replay.component')
+      .then(m => m.SessionReplayComponent)
+  },
+  {
     path: 'ble-debug',
     loadComponent: () => import('./features/ble-debug/ble-debug.component')
       .then(m => m.BleDebugComponent)

--- a/src/app/core/adapters/adapter-switcher.service.ts
+++ b/src/app/core/adapters/adapter-switcher.service.ts
@@ -1,0 +1,98 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, switchMap } from 'rxjs';
+import { ObdAdapter, ObdDebugInfo } from './obd-adapter.interface';
+import { ObdLiveFrame } from '../models/obd-live-frame.model';
+import { WebBluetoothElm327AdapterService } from './web-bluetooth-elm327-adapter.service';
+import { SimulatorObdAdapterService } from './simulator-obd-adapter.service';
+
+export type AdapterMode = 'real' | 'simulated';
+
+/**
+ * Wraps the real BLE adapter and the offline simulator.
+ * Registered as OBD_ADAPTER in app.config — all consumers are unaware of the switch.
+ */
+@Injectable({ providedIn: 'root' })
+export class AdapterSwitcherService implements ObdAdapter {
+
+  private modeSubject = new BehaviorSubject<AdapterMode>('simulated');
+  public readonly mode$: Observable<AdapterMode> = this.modeSubject.asObservable();
+
+  public readonly data$: Observable<ObdLiveFrame>;
+  public readonly connectionStatus$: Observable<'disconnected' | 'connecting' | 'connected' | 'error'>;
+  public readonly vinInfo$: Observable<{ vin: string; manufacturer: string } | null>;
+  public readonly dtcCodes$: Observable<readonly string[]>;
+  public readonly debug$: Observable<ObdDebugInfo>;
+
+  constructor(
+    private realAdapter: WebBluetoothElm327AdapterService,
+    private simAdapter: SimulatorObdAdapterService,
+  ) {
+    this.data$ = this.modeSubject.pipe(
+      switchMap(mode => mode === 'simulated' ? this.simAdapter.data$ : this.realAdapter.data$)
+    );
+
+    this.connectionStatus$ = this.modeSubject.pipe(
+      switchMap(mode => mode === 'simulated'
+        ? this.simAdapter.connectionStatus$
+        : this.realAdapter.connectionStatus$)
+    );
+
+    this.vinInfo$ = this.modeSubject.pipe(
+      switchMap(mode => mode === 'simulated'
+        ? (this.simAdapter.vinInfo$ ?? new BehaviorSubject(null))
+        : (this.realAdapter.vinInfo$ ?? new BehaviorSubject(null)))
+    );
+
+    this.dtcCodes$ = this.modeSubject.pipe(
+      switchMap(mode => mode === 'simulated'
+        ? (this.simAdapter.dtcCodes$ ?? new BehaviorSubject([]))
+        : (this.realAdapter.dtcCodes$ ?? new BehaviorSubject([])))
+    );
+
+    this.debug$ = this.modeSubject.pipe(
+      switchMap(_mode => this.realAdapter.debug$ ?? new BehaviorSubject<ObdDebugInfo>({
+        lastFrameTime: null,
+        pollingHz: 0,
+        failingPids: []
+      }))
+    );
+  }
+
+  // ─── Mode control ──────────────────────────────────────────────────────────
+
+  public getMode(): AdapterMode {
+    return this.modeSubject.value;
+  }
+
+  public setMode(mode: AdapterMode): void {
+    const current = this.modeSubject.value;
+    if (current === mode) return;
+
+    // Disconnect the outgoing adapter before switching
+    if (current === 'simulated') {
+      this.simAdapter.disconnect();
+    } else {
+      this.realAdapter.disconnect();
+    }
+
+    this.modeSubject.next(mode);
+  }
+
+  // ─── ObdAdapter delegation ─────────────────────────────────────────────────
+
+  public connect(): Promise<void> {
+    return this.active().connect();
+  }
+
+  public disconnect(): Promise<void> {
+    return this.active().disconnect();
+  }
+
+  public sendCommand(command: string): Promise<string> {
+    return this.active().sendCommand(command);
+  }
+
+  private active(): ObdAdapter {
+    return this.modeSubject.value === 'simulated' ? this.simAdapter : this.realAdapter;
+  }
+}

--- a/src/app/core/adapters/simulator-obd-adapter.service.ts
+++ b/src/app/core/adapters/simulator-obd-adapter.service.ts
@@ -1,0 +1,158 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, Subject, interval, Subscription } from 'rxjs';
+import { ObdAdapter } from './obd-adapter.interface';
+import { ObdLiveFrame } from '../models/obd-live-frame.model';
+
+/** Phase definition: frames at 1 Hz, RPM ramp target */
+interface RpmPhase {
+  frames: number;
+  rpmTarget: number;
+}
+
+const RPM_PHASES: RpmPhase[] = [
+  { frames: 8,  rpmTarget: 820  },   // idle
+  { frames: 6,  rpmTarget: 2800 },   // ramp up
+  { frames: 6,  rpmTarget: 3100 },   // high rev
+  { frames: 6,  rpmTarget: 820  },   // drop back to idle
+];
+
+const TOTAL_CYCLE_FRAMES = RPM_PHASES.reduce((s, p) => s + p.frames, 0); // 26
+
+/**
+ * Offline simulator adapter.
+ * Generates realistic-looking OBD frames without any hardware.
+ * Implements the same ObdAdapter interface so the rest of the app is unaware.
+ */
+@Injectable({ providedIn: 'root' })
+export class SimulatorObdAdapterService implements ObdAdapter {
+  private connectionStatusSubject = new BehaviorSubject<
+    'disconnected' | 'connecting' | 'connected' | 'error'
+  >('disconnected');
+
+  private dataSubject = new Subject<ObdLiveFrame>();
+
+  public connectionStatus$: Observable<'disconnected' | 'connecting' | 'connected' | 'error'> =
+    this.connectionStatusSubject.asObservable();
+
+  public data$: Observable<ObdLiveFrame> = this.dataSubject.asObservable();
+
+  public vinInfo$: Observable<{ vin: string; manufacturer: string } | null> =
+    new BehaviorSubject<{ vin: string; manufacturer: string } | null>({
+      vin: 'SIM00000000000000',
+      manufacturer: 'Simulator',
+    }).asObservable();
+
+  public dtcCodes$: Observable<readonly string[]> =
+    new BehaviorSubject<readonly string[]>([]).asObservable();
+
+  private streamSub?: Subscription;
+  private frameIndex = 0;
+  private coolantTemp = 20;
+  private currentRpm = 820;
+
+  public async connect(): Promise<void> {
+    if (this.connectionStatusSubject.value === 'connected') return;
+    this.connectionStatusSubject.next('connecting');
+    await new Promise<void>(resolve => setTimeout(resolve, 600));
+    this.connectionStatusSubject.next('connected');
+    this.startStream();
+  }
+
+  public async disconnect(): Promise<void> {
+    this.streamSub?.unsubscribe();
+    this.frameIndex = 0;
+    this.coolantTemp = 20;
+    this.currentRpm = 820;
+    this.connectionStatusSubject.next('disconnected');
+  }
+
+  public async sendCommand(command: string): Promise<string> {
+    return `SIM_OK: ${command}\r\n>`;
+  }
+
+  // ─── Internal ─────────────────────────────────────────────────────────────
+
+  private startStream(): void {
+    this.streamSub?.unsubscribe();
+    this.streamSub = interval(1000).subscribe(() => this.emitFrame());
+  }
+
+  private emitFrame(): void {
+    this.frameIndex++;
+
+    const rpm = this.nextRpm();
+    const coolant = this.nextCoolant();
+    const maf = this.calcMaf(rpm);
+    const stft = this.calcStft(coolant);
+    const ltft = coolant < 60 ? 8 + Math.random() * 4 - (coolant / 60) * 6
+                              : Math.random() * 3 - 1;
+
+    // Occasional instability events (~5% stall, ~3% spike)
+    const rand = Math.random();
+    const finalRpm = rand < 0.05 ? 280 + Math.random() * 150
+                   : rand < 0.08 ? rpm + 700 + Math.random() * 300
+                   : rpm;
+
+    const frame: ObdLiveFrame = {
+      timestamp:        Date.now(),
+      rpm:              Math.max(0, Math.round(finalRpm)),
+      speed:            0,
+      engineLoad:       Math.min(100, 18 + (finalRpm / 4000) * 65 + Math.random() * 5),
+      coolantTemp:      coolant,
+      intakeAirTemp:    18 + Math.random() * 5,
+      stftB1:           stft,
+      ltftB1:           parseFloat(ltft.toFixed(2)),
+      maf,
+      throttlePosition: Math.min(100, 8 + (finalRpm / 4000) * 55 + Math.random() * 5),
+      batteryVoltage:   parseFloat((13.8 + Math.random() * 0.6).toFixed(2)),
+    };
+
+    this.dataSubject.next(frame);
+  }
+
+  /** Interpolated RPM following the RPM_PHASES cycle */
+  private nextRpm(): number {
+    const cyclePos = this.frameIndex % TOTAL_CYCLE_FRAMES;
+    let offset = 0;
+    let prev = RPM_PHASES[RPM_PHASES.length - 1].rpmTarget;
+
+    for (const phase of RPM_PHASES) {
+      if (cyclePos < offset + phase.frames) {
+        const t = (cyclePos - offset) / phase.frames;
+        this.currentRpm = prev + (phase.rpmTarget - prev) * t + (Math.random() * 80 - 40);
+        return this.currentRpm;
+      }
+      prev = phase.rpmTarget;
+      offset += phase.frames;
+    }
+
+    return this.currentRpm;
+  }
+
+  /** Coolant rises 20 → 90 °C over ~120 frames, then stabilises */
+  private nextCoolant(): number {
+    if (this.coolantTemp < 90) {
+      this.coolantTemp = Math.min(90, this.coolantTemp + 0.6);
+    } else {
+      this.coolantTemp = 90 + Math.random() * 1.5 - 0.75;
+    }
+    return Math.round(this.coolantTemp);
+  }
+
+  /** MAF proportional to RPM (rough 2.0 L engine estimate, g/s) */
+  private calcMaf(rpm: number): number {
+    return parseFloat((0.0032 * rpm + Math.random() * 0.4).toFixed(2));
+  }
+
+  /**
+   * STFT: slightly high when cold (engine fighting over-rich cold-start enrichment),
+   * settles near 0 once warm.
+   */
+  private calcStft(coolant: number): number {
+    if (coolant < 60) {
+      const coldBias = (1 - coolant / 60) * 6;
+      return parseFloat((coldBias + Math.random() * 4 - 2).toFixed(2));
+    }
+    return parseFloat((Math.random() * 4 - 2).toFixed(2));
+  }
+}

--- a/src/app/core/replay/session-replay.service.ts
+++ b/src/app/core/replay/session-replay.service.ts
@@ -1,0 +1,131 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { ObdLiveFrame } from '../models/obd-live-frame.model';
+import { DiagnosticResult } from '../models/diagnostic-result.model';
+
+const STORAGE_KEY = 'obd2_last_replay_session';
+
+export interface ReplaySession {
+  savedAt: number;
+  durationMs: number;
+  frames: ObdLiveFrame[];
+  diagnosticResults: DiagnosticResult[];
+}
+
+/**
+ * Stores the last live session and can replay its frames through replayFrame$.
+ * No backend — persists to localStorage.
+ */
+@Injectable({ providedIn: 'root' })
+export class SessionReplayService {
+
+  // ─── Stored session ────────────────────────────────────────────────────────
+
+  private sessionSubject = new BehaviorSubject<ReplaySession | null>(this.loadFromStorage());
+  public readonly session$: Observable<ReplaySession | null> = this.sessionSubject.asObservable();
+
+  // ─── Playback state ────────────────────────────────────────────────────────
+
+  private frameSubject    = new Subject<ObdLiveFrame>();
+  private progressSubject = new BehaviorSubject<number>(0);
+  private isPlayingSubject = new BehaviorSubject<boolean>(false);
+  private speedSubject    = new BehaviorSubject<1 | 2 | 4>(1);
+
+  public readonly replayFrame$:  Observable<ObdLiveFrame> = this.frameSubject.asObservable();
+  public readonly progress$:     Observable<number>       = this.progressSubject.asObservable();
+  public readonly isPlaying$:    Observable<boolean>      = this.isPlayingSubject.asObservable();
+  public readonly speed$:        Observable<1 | 2 | 4>   = this.speedSubject.asObservable();
+
+  private replayTimer?: ReturnType<typeof setInterval>;
+  private replayIndex = 0;
+
+  // ─── Session persistence ───────────────────────────────────────────────────
+
+  /**
+   * Called by the dashboard at session end (clear / disconnect / destroy).
+   * Persists the most recent batch of frames + diagnostic results.
+   */
+  public saveSession(
+    frames: ObdLiveFrame[],
+    diagnosticResults: DiagnosticResult[],
+  ): void {
+    if (!frames.length) return;
+
+    const session: ReplaySession = {
+      savedAt: Date.now(),
+      durationMs: frames[frames.length - 1].timestamp - frames[0].timestamp,
+      frames: [...frames],
+      diagnosticResults: [...diagnosticResults],
+    };
+
+    this.sessionSubject.next(session);
+
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+    } catch {
+      // localStorage quota may be full — store in memory only
+    }
+  }
+
+  public hasSession(): boolean {
+    return (this.sessionSubject.value?.frames?.length ?? 0) > 0;
+  }
+
+  public getSession(): ReplaySession | null {
+    return this.sessionSubject.value;
+  }
+
+  // ─── Playback control ──────────────────────────────────────────────────────
+
+  public play(): void {
+    if (!this.hasSession() || this.isPlayingSubject.value) return;
+
+    const frames = this.sessionSubject.value!.frames;
+
+    this.isPlayingSubject.next(true);
+    const intervalMs = Math.round(1000 / this.speedSubject.value);
+
+    this.replayTimer = setInterval(() => {
+      if (this.replayIndex >= frames.length) {
+        this.stop();
+        return;
+      }
+      this.frameSubject.next(frames[this.replayIndex]);
+      this.progressSubject.next(
+        Math.round((this.replayIndex / (frames.length - 1)) * 100)
+      );
+      this.replayIndex++;
+    }, intervalMs);
+  }
+
+  public pause(): void {
+    clearInterval(this.replayTimer);
+    this.isPlayingSubject.next(false);
+  }
+
+  public stop(): void {
+    clearInterval(this.replayTimer);
+    this.isPlayingSubject.next(false);
+    this.replayIndex = 0;
+    this.progressSubject.next(0);
+  }
+
+  public setSpeed(speed: 1 | 2 | 4): void {
+    const wasPlaying = this.isPlayingSubject.value;
+    if (wasPlaying) this.pause();
+    this.speedSubject.next(speed);
+    if (wasPlaying) this.play();
+  }
+
+  // ─── Private ───────────────────────────────────────────────────────────────
+
+  private loadFromStorage(): ReplaySession | null {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      return JSON.parse(raw) as ReplaySession;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/app/features/dashboard/dashboard-page.component.html
+++ b/src/app/features/dashboard/dashboard-page.component.html
@@ -18,13 +18,26 @@
     </div>
 
     <div class="controls">
+      <!-- Simulator mode toggle -->
+      <div class="mode-toggle">
+        <button
+          class="btn-mode"
+          [class.sim-active]="adapterMode === 'simulated'"
+          [class.real-active]="adapterMode === 'real'"
+          (click)="toggleSimulatorMode()"
+          [title]="adapterMode === 'simulated' ? 'Switch to real BLE adapter' : 'Switch to offline simulator'">
+          <span class="mode-dot"></span>
+          {{ adapterMode === 'simulated' ? 'SIMULATOR' : 'LIVE' }}
+        </button>
+      </div>
+
       <ng-container *ngIf="connectionStatus$ | async as status">
         <button
           *ngIf="status !== 'connected'"
           class="btn-connect"
           [disabled]="status === 'connecting'"
           (click)="connectAdapter()">
-          {{ status === 'connecting' ? 'Connecting…' : status === 'error' ? 'Reconnect' : 'Connect to OBD' }}
+          {{ status === 'connecting' ? 'Connecting…' : status === 'error' ? 'Reconnect' : 'Connect' }}
         </button>
         <button
           *ngIf="status === 'connected'"
@@ -33,10 +46,12 @@
           Disconnect
         </button>
       </ng-container>
+
       <button class="btn-clear" (click)="clearCharts()">Clear</button>
     </div>
   </header>
 
+  <!-- Metric cards -->
   <section class="grid">
     <app-metric-card
       label="RPM"
@@ -69,34 +84,36 @@
     </app-metric-card>
 
     <app-metric-card
-      label="Throttle"
-      [value]="(latestFrame?.throttlePosition ?? 0) | number:'1.0-0'"
-      unit="%">
+      label="MAF"
+      [value]="(latestFrame?.maf !== undefined ? (latestFrame!.maf! | number:'1.2-2') : '—')"
+      unit="g/s">
     </app-metric-card>
   </section>
 
   <div class="analysis-section">
+
+    <!-- Charts column -->
     <section class="charts-section">
-      <div class="chart-card">
-        <h4 class="chart-title">RPM</h4>
-        <div class="chart-wrap">
-          <canvas #rpmChart baseChart [type]="'line'" [data]="rpmChartData" [options]="rpmChartOptions"></canvas>
+
+      <!-- Multi-signal chart: RPM + STFT + MAF overlaid -->
+      <div class="chart-card chart-card--tall">
+        <h4 class="chart-title">Multi-Signal — RPM · STFT B1 · MAF</h4>
+        <div class="chart-wrap chart-wrap--tall">
+          <app-multi-signal-chart></app-multi-signal-chart>
         </div>
       </div>
+
+      <!-- LTFT detail chart -->
       <div class="chart-card">
-        <h4 class="chart-title">STFT B1</h4>
-        <div class="chart-wrap">
-          <canvas #stftChart baseChart [type]="'line'" [data]="stftChartData" [options]="fuelTrimOptions"></canvas>
-        </div>
-      </div>
-      <div class="chart-card">
-        <h4 class="chart-title">LTFT B1</h4>
+        <h4 class="chart-title">LTFT B1 (Long-Term Fuel Trim)</h4>
         <div class="chart-wrap">
           <canvas #ltftChart baseChart [type]="'line'" [data]="ltftChartData" [options]="fuelTrimOptions"></canvas>
         </div>
       </div>
+
     </section>
 
+    <!-- Diagnostics aside -->
     <aside class="diagnostics-panel">
       <div class="card">
 
@@ -114,13 +131,13 @@
           <div
             *ngIf="dataState === 'no_data'"
             class="state-msg">
-            <p>Collecting initial frames...</p>
+            <p>Collecting initial frames…</p>
           </div>
 
           <div
             *ngIf="dataState === 'receiving' && !diagnosticResults.length"
             class="state-msg success">
-            <p>Scanning... Systems normal.</p>
+            <p>Scanning… Systems normal.</p>
           </div>
 
           <div
@@ -150,7 +167,7 @@
 
         </div>
       </div>
-      
+
       <!-- Debug Info Panel -->
       <div class="card" *ngIf="debugInfo$ | async as debug" style="margin-top: 16px;">
         <div class="panel-header">

--- a/src/app/features/dashboard/dashboard-page.component.scss
+++ b/src/app/features/dashboard/dashboard-page.component.scss
@@ -114,6 +114,49 @@
           background: color.adjust($bg-secondary, $lightness: 5%);
         }
       }
+
+      // ── Simulator mode toggle ──────────────────────────────────────────────
+      .mode-toggle {
+        .btn-mode {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          padding: 5px 12px;
+          border-radius: 20px;
+          font-size: 0.7rem;
+          font-weight: 700;
+          letter-spacing: 0.08em;
+          cursor: pointer;
+          transition: all 0.2s ease;
+          border: 1px solid $border-color;
+          background: $bg-secondary;
+          color: $text-secondary;
+
+          .mode-dot {
+            width: 7px;
+            height: 7px;
+            border-radius: 50%;
+            background: currentColor;
+            opacity: 0.8;
+          }
+
+          &.sim-active {
+            background: rgba(33, 150, 243, 0.12);
+            border-color: #2196F3;
+            color: #2196F3;
+          }
+
+          &.real-active {
+            background: rgba($color-success, 0.12);
+            border-color: $color-success;
+            color: $color-success;
+          }
+
+          &:hover {
+            opacity: 0.85;
+          }
+        }
+      }
     }
   }
 
@@ -326,7 +369,15 @@
           height: 100px;
           position: relative;
           overflow: hidden;
+
+          &--tall {
+            height: 200px;
+          }
         }
+      }
+
+      .chart-card--tall {
+        .chart-title { margin-bottom: $spacing-sm; }
       }
     }
   }

--- a/src/app/features/dashboard/dashboard-page.component.ts
+++ b/src/app/features/dashboard/dashboard-page.component.ts
@@ -4,10 +4,13 @@ import { Observable, Subscription } from 'rxjs';
 import { ChartData, ChartOptions } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
 import { ObdAdapter, OBD_ADAPTER, ObdDebugInfo } from '../../core/adapters/obd-adapter.interface';
+import { AdapterSwitcherService, AdapterMode } from '../../core/adapters/adapter-switcher.service';
 import { DiagnosticEngineService } from '../../core/diagnostics/diagnostic-engine.service';
+import { SessionReplayService } from '../../core/replay/session-replay.service';
 import { ObdLiveFrame } from '../../core/models/obd-live-frame.model';
 import { DiagnosticResult } from '../../core/models/diagnostic-result.model';
 import { MetricCardComponent } from '../../shared/components/metric-card/metric-card.component';
+import { MultiSignalChartComponent } from '../../shared/components/multi-signal-chart/multi-signal-chart.component';
 
 function makeLineData(label: string, color: string): ChartData<'line'> {
   return {
@@ -42,7 +45,7 @@ const BASE_CHART_OPTIONS: ChartOptions<'line'> = {
 @Component({
   selector: 'app-dashboard-page',
   standalone: true,
-  imports: [CommonModule, MetricCardComponent, BaseChartDirective],
+  imports: [CommonModule, MetricCardComponent, BaseChartDirective, MultiSignalChartComponent],
   templateUrl: './dashboard-page.component.html',
   styleUrls: ['./dashboard-page.component.scss']
 })
@@ -53,26 +56,13 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
   public diagnosticResults: DiagnosticResult[] = [];
   public dataState: 'no_data' | 'receiving' = 'no_data';
 
-  public rpmChartData: ChartData<'line'> = makeLineData('RPM', '#4CAF50');
-  public stftChartData: ChartData<'line'> = makeLineData('STFT B1 %', '#2196F3');
+  /** Current adapter mode for the template */
+  public adapterMode: AdapterMode = 'simulated';
+
+  // ─── Individual signal charts (kept for detail view) ─────────────────────
   public ltftChartData: ChartData<'line'> = makeLineData('LTFT B1 %', '#ff9800');
 
-  @ViewChild('rpmChart', { read: BaseChartDirective }) rpmChart?: BaseChartDirective;
-  @ViewChild('stftChart', { read: BaseChartDirective }) stftChart?: BaseChartDirective;
   @ViewChild('ltftChart', { read: BaseChartDirective }) ltftChart?: BaseChartDirective;
-
-  public readonly rpmChartOptions: ChartOptions<'line'> = {
-    ...BASE_CHART_OPTIONS,
-    scales: {
-      x: { display: false },
-      y: {
-        min: 0,
-        max: 4000,
-        grid: { color: '#333333' },
-        ticks: { color: '#cccccc', maxTicksLimit: 5 }
-      }
-    }
-  };
 
   public readonly fuelTrimOptions: ChartOptions<'line'> = {
     ...BASE_CHART_OPTIONS,
@@ -93,7 +83,9 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
 
   constructor(
     @Inject(OBD_ADAPTER) private obdAdapter: ObdAdapter,
-    private diagnosticEngine: DiagnosticEngineService
+    private diagnosticEngine: DiagnosticEngineService,
+    private adapterSwitcher: AdapterSwitcherService,
+    private replayService: SessionReplayService,
   ) {
     this.connectionStatus$ = this.obdAdapter.connectionStatus$;
     this.debugInfo$ = this.obdAdapter.debug$;
@@ -101,6 +93,7 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.diagnosticEngine.startSession();
+    this.adapterMode = this.adapterSwitcher.getMode();
 
     const dataSubscription = this.obdAdapter.data$.subscribe({
       next: (frame: ObdLiveFrame) => this.handleNewFrame(frame)
@@ -112,17 +105,23 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
       }
     });
 
+    const modeSubscription = this.adapterSwitcher.mode$.subscribe(mode => {
+      this.adapterMode = mode;
+    });
+
     this.subscriptions.add(dataSubscription);
     this.subscriptions.add(diagSubscription);
+    this.subscriptions.add(modeSubscription);
   }
 
   public ngOnDestroy(): void {
-    this.rpmChart?.chart?.destroy();
-    this.stftChart?.chart?.destroy();
     this.ltftChart?.chart?.destroy();
     this.diagnosticEngine.stopSession();
+    this.persistSession();
     this.subscriptions.unsubscribe();
   }
+
+  // ─── Adapter / mode control ───────────────────────────────────────────────
 
   public connectAdapter(): void {
     this.obdAdapter.connect().catch(() => {
@@ -134,60 +133,67 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
     this.obdAdapter.disconnect();
   }
 
+  public toggleSimulatorMode(): void {
+    const next: AdapterMode = this.adapterMode === 'simulated' ? 'real' : 'simulated';
+    this.persistSession();
+    this.clearCharts();
+    this.adapterSwitcher.setMode(next);
+    // Auto-connect the simulator when switching to it
+    if (next === 'simulated') {
+      this.obdAdapter.connect().catch(() => {});
+    }
+  }
+
   public clearCharts(): void {
+    this.persistSession();
     this.frames = [];
     this.frameCount = 0;
     this.dataState = 'no_data';
     this.diagnosticResults = [];
 
-    // Clear data in place — keeps chart instances alive, avoids recreation
-    this.rpmChartData.labels = [];
-    this.rpmChartData.datasets[0].data = [];
-    this.stftChartData.labels = [];
-    this.stftChartData.datasets[0].data = [];
     this.ltftChartData.labels = [];
     this.ltftChartData.datasets[0].data = [];
-    this.rpmChart?.chart?.update();
-    this.stftChart?.chart?.update();
     this.ltftChart?.chart?.update();
   }
+
+  // ─── Private ─────────────────────────────────────────────────────────────
 
   private handleNewFrame(frame: ObdLiveFrame): void {
     this.latestFrame = frame;
     this.dataState = 'receiving';
 
     this.frames.push(frame);
-    if (this.frames.length > 20) {
+    if (this.frames.length > 60) {
       this.frames.shift();
     }
 
     this.frameCount++;
     if (this.frameCount % 2 === 0) {
-      this.updateCharts();
+      this.updateDetailChart();
     }
 
     if (this.frames.length >= 5) {
       this.diagnosticEngine.processFrame(frame);
     }
+
+    // Auto-save every 30 frames for session replay
+    if (this.frameCount % 30 === 0) {
+      this.persistSession();
+    }
   }
 
-  private updateCharts(): void {
+  private updateDetailChart(): void {
     const labels = this.frames.map((_, i) => String(i + 1));
-
-    // Mutate dataset arrays in place — chart instances are never recreated
-    this.rpmChartData.labels = labels;
-    this.rpmChartData.datasets[0].data = this.frames.map(f => f.rpm);
-
-    this.stftChartData.labels = labels;
-    this.stftChartData.datasets[0].data = this.frames.map(f => f.stftB1);
 
     this.ltftChartData.labels = labels;
     this.ltftChartData.datasets[0].data = this.frames.map(f => f.ltftB1);
-
-    // Trigger Chart.js re-render manually (no Angular change detection needed)
-    this.rpmChart?.chart?.update();
-    this.stftChart?.chart?.update();
     this.ltftChart?.chart?.update();
+  }
+
+  private persistSession(): void {
+    if (this.frames.length > 0) {
+      this.replayService.saveSession(this.frames, this.diagnosticResults);
+    }
   }
 
   private deduplicateResults(results: DiagnosticResult[]): DiagnosticResult[] {

--- a/src/app/features/session-replay/session-replay.component.html
+++ b/src/app/features/session-replay/session-replay.component.html
@@ -1,0 +1,119 @@
+<div class="replay-container">
+
+  <header>
+    <h1>Session Replay</h1>
+    <p class="subtitle">Replay the last recorded diagnostic session — no data connection required.</p>
+  </header>
+
+  <!-- No session state -->
+  <div class="empty-state" *ngIf="!session">
+    <div class="empty-icon">⏮</div>
+    <h3>No session recorded yet</h3>
+    <p>Go to the Dashboard, connect (or use Simulator mode), collect some data, then come back here.</p>
+  </div>
+
+  <ng-container *ngIf="session">
+
+    <!-- Session meta -->
+    <div class="session-meta card">
+      <div class="meta-item">
+        <span class="meta-label">Recorded</span>
+        <span class="meta-value">{{ session.savedAt | date:'dd MMM yyyy, HH:mm' }}</span>
+      </div>
+      <div class="meta-item">
+        <span class="meta-label">Frames</span>
+        <span class="meta-value">{{ frameCount }}</span>
+      </div>
+      <div class="meta-item">
+        <span class="meta-label">Duration</span>
+        <span class="meta-value">{{ durationSec }}s</span>
+      </div>
+      <div class="meta-item">
+        <span class="meta-label">Issues found</span>
+        <span class="meta-value" [class.has-issues]="diagnosticResults.length">
+          {{ diagnosticResults.length || 'None' }}
+        </span>
+      </div>
+    </div>
+
+    <!-- Playback controls -->
+    <div class="playback card">
+      <div class="transport">
+        <button class="btn-stop"  (click)="stop()"  [disabled]="!isPlaying && progress === 0" title="Stop">■</button>
+        <button class="btn-play"  (click)="play()"  [disabled]="isPlaying"  title="Play">▶</button>
+        <button class="btn-pause" (click)="pause()" [disabled]="!isPlaying" title="Pause">⏸</button>
+      </div>
+
+      <div class="progress-bar-wrap">
+        <div class="progress-bar">
+          <div class="progress-fill" [style.width.%]="progress"></div>
+        </div>
+        <span class="progress-pct">{{ progress }}%</span>
+      </div>
+
+      <div class="speed-select">
+        <span class="speed-label">Speed</span>
+        <button [class.active]="speed === 1" (click)="setSpeed(1)">1×</button>
+        <button [class.active]="speed === 2" (click)="setSpeed(2)">2×</button>
+        <button [class.active]="speed === 4" (click)="setSpeed(4)">4×</button>
+      </div>
+    </div>
+
+    <!-- Live metrics during replay -->
+    <div class="metrics-grid" *ngIf="currentFrame">
+      <div class="metric-card">
+        <span class="m-label">RPM</span>
+        <span class="m-value">{{ currentFrame.rpm | number:'1.0-0' }}</span>
+        <span class="m-unit">rpm</span>
+      </div>
+      <div class="metric-card">
+        <span class="m-label">Coolant</span>
+        <span class="m-value">{{ currentFrame.coolantTemp | number:'1.0-0' }}</span>
+        <span class="m-unit">°C</span>
+      </div>
+      <div class="metric-card">
+        <span class="m-label">STFT B1</span>
+        <span class="m-value">{{ currentFrame.stftB1 | number:'1.1-1' }}</span>
+        <span class="m-unit">%</span>
+      </div>
+      <div class="metric-card">
+        <span class="m-label">LTFT B1</span>
+        <span class="m-value">{{ currentFrame.ltftB1 | number:'1.1-1' }}</span>
+        <span class="m-unit">%</span>
+      </div>
+      <div class="metric-card" *ngIf="currentFrame.maf !== undefined">
+        <span class="m-label">MAF</span>
+        <span class="m-value">{{ currentFrame.maf | number:'1.2-2' }}</span>
+        <span class="m-unit">g/s</span>
+      </div>
+      <div class="metric-card">
+        <span class="m-label">Engine Load</span>
+        <span class="m-value">{{ currentFrame.engineLoad | number:'1.0-0' }}</span>
+        <span class="m-unit">%</span>
+      </div>
+    </div>
+
+    <!-- Diagnostic results from session -->
+    <div class="diagnostics-section card" *ngIf="diagnosticResults.length">
+      <h3 class="section-title">Diagnostic Events ({{ diagnosticResults.length }})</h3>
+
+      <div class="result-item" *ngFor="let r of diagnosticResults" [ngClass]="severityClass(r)">
+        <div class="result-header">
+          <span class="result-title">{{ r.title }}</span>
+          <span class="result-confidence">{{ (r.confidence * 100) | number:'1.0-0' }}%</span>
+        </div>
+        <div class="result-explanation">{{ r.explanation }}</div>
+        <div class="result-action"><strong>Next Step:</strong> {{ r.recommendedNextStep }}</div>
+      </div>
+    </div>
+
+    <div class="diagnostics-section card" *ngIf="!diagnosticResults.length">
+      <div class="no-issues">
+        <span class="ok-icon">✓</span>
+        <p>No diagnostic issues were detected in this session.</p>
+      </div>
+    </div>
+
+  </ng-container>
+
+</div>

--- a/src/app/features/session-replay/session-replay.component.scss
+++ b/src/app/features/session-replay/session-replay.component.scss
@@ -1,0 +1,276 @@
+@use '../../../styles/variables' as *;
+
+.replay-container {
+  padding: $spacing-xl;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-xl;
+  max-width: 900px;
+
+  header {
+    h1 { margin: 0 0 4px; font-size: 1.5rem; }
+    .subtitle { margin: 0; color: $text-secondary; font-size: 0.9rem; }
+  }
+
+  .card {
+    background: $bg-secondary;
+    border: 1px solid $border-color;
+    border-radius: 12px;
+    padding: $spacing-lg;
+  }
+}
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+.empty-state {
+  text-align: center;
+  padding: $spacing-xl * 2;
+  background: $bg-secondary;
+  border: 1px dashed $border-color;
+  border-radius: 12px;
+
+  .empty-icon { font-size: 2.5rem; margin-bottom: $spacing-md; }
+  h3 { margin: 0 0 $spacing-sm; }
+  p  { color: $text-secondary; font-size: 0.9rem; margin: 0; }
+}
+
+// ─── Session meta ─────────────────────────────────────────────────────────────
+.session-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-xl;
+
+  .meta-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    .meta-label {
+      font-size: 0.72rem;
+      color: $text-muted;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      font-weight: 600;
+    }
+
+    .meta-value {
+      font-size: 1rem;
+      font-weight: 700;
+      color: $text-primary;
+
+      &.has-issues { color: $color-warning; }
+    }
+  }
+}
+
+// ─── Playback controls ────────────────────────────────────────────────────────
+.playback {
+  display: flex;
+  align-items: center;
+  gap: $spacing-lg;
+  flex-wrap: wrap;
+
+  .transport {
+    display: flex;
+    gap: $spacing-sm;
+
+    button {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      border: 1px solid $border-color;
+      background: $bg-tertiary;
+      color: $text-primary;
+      font-size: 0.9rem;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      &:hover:not(:disabled) {
+        background: $bg-hover;
+        border-color: $color-info;
+      }
+
+      &:disabled {
+        opacity: 0.35;
+        cursor: not-allowed;
+      }
+    }
+
+    .btn-play  { border-color: $color-success; color: $color-success; }
+    .btn-pause { border-color: $color-warning; color: $color-warning; }
+    .btn-stop  { border-color: $color-critical; color: $color-critical; }
+  }
+
+  .progress-bar-wrap {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+    min-width: 160px;
+
+    .progress-bar {
+      flex: 1;
+      height: 6px;
+      border-radius: 3px;
+      background: $bg-tertiary;
+      border: 1px solid $border-color;
+      overflow: hidden;
+
+      .progress-fill {
+        height: 100%;
+        background: linear-gradient(90deg, $color-info, $color-success);
+        border-radius: 3px;
+        transition: width 0.3s ease;
+      }
+    }
+
+    .progress-pct {
+      font-size: 0.78rem;
+      color: $text-secondary;
+      font-weight: 600;
+      min-width: 36px;
+      text-align: right;
+      font-family: monospace;
+    }
+  }
+
+  .speed-select {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    .speed-label {
+      font-size: 0.75rem;
+      color: $text-muted;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-right: 2px;
+    }
+
+    button {
+      padding: 4px 10px;
+      border-radius: 16px;
+      border: 1px solid $border-color;
+      background: $bg-tertiary;
+      color: $text-secondary;
+      font-size: 0.78rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.15s;
+
+      &.active {
+        background: rgba($color-info, 0.15);
+        border-color: $color-info;
+        color: $color-info;
+      }
+
+      &:hover:not(.active) {
+        border-color: $text-secondary;
+        color: $text-primary;
+      }
+    }
+  }
+}
+
+// ─── Metrics grid ─────────────────────────────────────────────────────────────
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: $spacing-md;
+
+  .metric-card {
+    background: $bg-secondary;
+    border: 1px solid $border-color;
+    border-radius: 10px;
+    padding: $spacing-md;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    .m-label {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: $text-muted;
+      font-weight: 600;
+    }
+
+    .m-value {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: $text-primary;
+      font-family: monospace;
+    }
+
+    .m-unit {
+      font-size: 0.75rem;
+      color: $text-secondary;
+    }
+  }
+}
+
+// ─── Diagnostic results ───────────────────────────────────────────────────────
+.diagnostics-section {
+  .section-title {
+    margin: 0 0 $spacing-md;
+    font-size: 0.95rem;
+    color: $text-primary;
+    padding-bottom: $spacing-sm;
+    border-bottom: 1px solid $border-color;
+  }
+
+  .result-item {
+    padding: $spacing-md;
+    border-radius: 8px;
+    background: rgba($bg-primary, 0.7);
+    border-left: 4px solid transparent;
+    margin-bottom: $spacing-sm;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+
+    &:last-child { margin-bottom: 0; }
+
+    &.critical { border-left-color: $color-critical; }
+    &.warning  { border-left-color: $color-warning; }
+    &.info     { border-left-color: $color-info; }
+
+    .result-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      .result-title { font-weight: 700; font-size: 0.9rem; }
+      .result-confidence {
+        font-size: 0.72rem;
+        color: $text-secondary;
+        background: rgba(0,0,0,0.3);
+        padding: 2px 7px;
+        border-radius: 4px;
+      }
+    }
+
+    .result-explanation { font-size: 0.83rem; color: $text-secondary; line-height: 1.4; }
+
+    .result-action {
+      font-size: 0.8rem;
+      padding: 6px $spacing-sm;
+      background: rgba($color-success, 0.05);
+      border: 1px solid rgba($color-success, 0.12);
+      border-radius: 4px;
+      strong { color: $color-success; }
+    }
+  }
+
+  .no-issues {
+    display: flex;
+    align-items: center;
+    gap: $spacing-md;
+    color: $color-success;
+
+    .ok-icon { font-size: 1.5rem; }
+    p { margin: 0; font-size: 0.9rem; }
+  }
+}

--- a/src/app/features/session-replay/session-replay.component.ts
+++ b/src/app/features/session-replay/session-replay.component.ts
@@ -1,0 +1,75 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { SessionReplayService, ReplaySession } from '../../core/replay/session-replay.service';
+import { ObdLiveFrame } from '../../core/models/obd-live-frame.model';
+import { DiagnosticResult } from '../../core/models/diagnostic-result.model';
+
+@Component({
+  selector: 'app-session-replay',
+  standalone: true,
+  imports: [CommonModule, DatePipe],
+  templateUrl: './session-replay.component.html',
+  styleUrls: ['./session-replay.component.scss'],
+})
+export class SessionReplayComponent implements OnInit, OnDestroy {
+
+  session: ReplaySession | null = null;
+  currentFrame: ObdLiveFrame | null = null;
+  progress = 0;
+  isPlaying = false;
+  speed: 1 | 2 | 4 = 1;
+
+  private subs = new Subscription();
+
+  constructor(public replayService: SessionReplayService) {}
+
+  ngOnInit(): void {
+    this.subs.add(
+      this.replayService.session$.subscribe(s => (this.session = s))
+    );
+    this.subs.add(
+      this.replayService.replayFrame$.subscribe(f => (this.currentFrame = f))
+    );
+    this.subs.add(
+      this.replayService.progress$.subscribe(p => (this.progress = p))
+    );
+    this.subs.add(
+      this.replayService.isPlaying$.subscribe(v => (this.isPlaying = v))
+    );
+    this.subs.add(
+      this.replayService.speed$.subscribe(s => (this.speed = s))
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.replayService.stop();
+    this.subs.unsubscribe();
+  }
+
+  // ─── Actions ───────────────────────────────────────────────────────────────
+
+  play():  void { this.replayService.play();  }
+  pause(): void { this.replayService.pause(); }
+  stop():  void { this.replayService.stop();  }
+
+  setSpeed(s: 1 | 2 | 4): void { this.replayService.setSpeed(s); }
+
+  // ─── Helpers ───────────────────────────────────────────────────────────────
+
+  get diagnosticResults(): DiagnosticResult[] {
+    return this.session?.diagnosticResults ?? [];
+  }
+
+  get frameCount(): number {
+    return this.session?.frames.length ?? 0;
+  }
+
+  get durationSec(): number {
+    return Math.round((this.session?.durationMs ?? 0) / 1000);
+  }
+
+  severityClass(r: DiagnosticResult): string {
+    return r.severity;
+  }
+}

--- a/src/app/shared/components/multi-signal-chart/multi-signal-chart.component.html
+++ b/src/app/shared/components/multi-signal-chart/multi-signal-chart.component.html
@@ -1,0 +1,9 @@
+<div class="multi-signal-wrap">
+  <canvas
+    #multiChart
+    baseChart
+    [type]="'line'"
+    [data]="chartData"
+    [options]="chartOptions">
+  </canvas>
+</div>

--- a/src/app/shared/components/multi-signal-chart/multi-signal-chart.component.scss
+++ b/src/app/shared/components/multi-signal-chart/multi-signal-chart.component.scss
@@ -1,0 +1,10 @@
+.multi-signal-wrap {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 180px;
+
+  canvas {
+    display: block;
+  }
+}

--- a/src/app/shared/components/multi-signal-chart/multi-signal-chart.component.ts
+++ b/src/app/shared/components/multi-signal-chart/multi-signal-chart.component.ts
@@ -1,0 +1,169 @@
+import { Component, OnInit, OnDestroy, ViewChild, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ChartData, ChartOptions } from 'chart.js';
+import { BaseChartDirective } from 'ng2-charts';
+import { Subscription } from 'rxjs';
+import { ObdAdapter, OBD_ADAPTER } from '../../../core/adapters/obd-adapter.interface';
+import { ObdLiveFrame } from '../../../core/models/obd-live-frame.model';
+
+const WINDOW = 40; // rolling frame window
+
+@Component({
+  selector: 'app-multi-signal-chart',
+  standalone: true,
+  imports: [CommonModule, BaseChartDirective],
+  templateUrl: './multi-signal-chart.component.html',
+  styleUrls: ['./multi-signal-chart.component.scss'],
+})
+export class MultiSignalChartComponent implements OnInit, OnDestroy {
+  @ViewChild('multiChart', { read: BaseChartDirective }) chart?: BaseChartDirective;
+
+  /** True once at least one frame carries MAF data */
+  hasMaf = false;
+
+  chartData: ChartData<'line'> = {
+    labels: [],
+    datasets: [
+      {
+        label: 'RPM',
+        data: [],
+        borderColor: '#4CAF50',
+        backgroundColor: 'rgba(76,175,80,0.08)',
+        fill: true,
+        tension: 0.4,
+        pointRadius: 0,
+        borderWidth: 2,
+        yAxisID: 'yRpm',
+      },
+      {
+        label: 'STFT B1 %',
+        data: [],
+        borderColor: '#2196F3',
+        backgroundColor: 'rgba(33,150,243,0.08)',
+        fill: false,
+        tension: 0.4,
+        pointRadius: 0,
+        borderWidth: 2,
+        yAxisID: 'yPct',
+      },
+      {
+        label: 'MAF g/s',
+        data: [],
+        borderColor: '#ff9800',
+        backgroundColor: 'rgba(255,152,0,0.08)',
+        fill: false,
+        tension: 0.4,
+        pointRadius: 0,
+        borderWidth: 1.5,
+        yAxisID: 'yMaf',
+        hidden: true,
+      },
+    ],
+  };
+
+  chartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false,
+    interaction: { mode: 'index', intersect: false },
+    plugins: {
+      legend: {
+        display: true,
+        position: 'top',
+        labels: {
+          color: '#cccccc',
+          font: { size: 11 },
+          boxWidth: 14,
+          padding: 12,
+          usePointStyle: true,
+        },
+      },
+      tooltip: {
+        backgroundColor: 'rgba(30,30,30,0.92)',
+        titleColor: '#ffffff',
+        bodyColor: '#cccccc',
+        borderColor: '#333333',
+        borderWidth: 1,
+      },
+    },
+    scales: {
+      x: { display: false },
+      yRpm: {
+        type: 'linear',
+        position: 'left',
+        min: 0,
+        max: 4200,
+        grid: { color: 'rgba(255,255,255,0.05)' },
+        ticks: { color: '#4CAF50', maxTicksLimit: 5, font: { size: 10 } },
+        title: { display: true, text: 'RPM', color: '#4CAF50', font: { size: 10 } },
+      },
+      yPct: {
+        type: 'linear',
+        position: 'right',
+        min: -28,
+        max: 28,
+        grid: { drawOnChartArea: false },
+        ticks: { color: '#2196F3', maxTicksLimit: 5, font: { size: 10 } },
+        title: { display: true, text: 'STFT %', color: '#2196F3', font: { size: 10 } },
+      },
+      yMaf: {
+        type: 'linear',
+        position: 'right',
+        min: 0,
+        max: 16,
+        display: false,
+        grid: { drawOnChartArea: false },
+        ticks: { color: '#ff9800', maxTicksLimit: 4, font: { size: 10 } },
+        title: { display: false, text: 'MAF g/s', color: '#ff9800', font: { size: 10 } },
+      },
+    },
+  };
+
+  private frames: ObdLiveFrame[] = [];
+  private frameCount = 0;
+  private sub!: Subscription;
+
+  constructor(@Inject(OBD_ADAPTER) private obdAdapter: ObdAdapter) {}
+
+  ngOnInit(): void {
+    this.sub = this.obdAdapter.data$.subscribe(frame => this.handleFrame(frame));
+  }
+
+  ngOnDestroy(): void {
+    this.chart?.chart?.destroy();
+    this.sub?.unsubscribe();
+  }
+
+  // ─── Private ───────────────────────────────────────────────────────────────
+
+  private handleFrame(frame: ObdLiveFrame): void {
+    this.frames.push(frame);
+    if (this.frames.length > WINDOW) this.frames.shift();
+
+    this.frameCount++;
+
+    // Reveal MAF dataset + axis once data arrives
+    if (!this.hasMaf && frame.maf !== undefined) {
+      this.hasMaf = true;
+      this.chartData.datasets[2].hidden = false;
+      const scales = this.chartOptions.scales as Record<string, { display: boolean }>;
+      scales['yMaf'].display = true;
+    }
+
+    // Update every other frame for smoother rendering
+    if (this.frameCount % 2 === 0) {
+      this.redraw();
+    }
+  }
+
+  private redraw(): void {
+    const labels = this.frames.map((_, i) => String(i));
+
+    this.chartData.labels = labels;
+    this.chartData.datasets[0].data = this.frames.map(f => f.rpm);
+    this.chartData.datasets[1].data = this.frames.map(f => f.stftB1);
+    this.chartData.datasets[2].data = this.frames.map(f => f.maf ?? null as unknown as number);
+
+    this.chart?.chart?.update('none');
+  }
+}


### PR DESCRIPTION
## Summary

Three new power features shipped in one sprint, all building on the existing adapter interface without touching hardware logic.

### 1. Multi-signal Graphs
- **`MultiSignalChartComponent`** — single Chart.js canvas with three overlaid datasets: RPM (green, left Y-axis), STFT B1 % (blue, right Y-axis), MAF g/s (orange, auto-revealed when data arrives)
- Dual Y-axes keep each signal readable at its native scale; cubic-bezier tension for smooth curves; `update('none')` for jank-free live scrolling
- Replaces the three individual spark-charts in the dashboard; LTFT detail chart kept for long-term fuel-trim reference

### 2. Session Replay
- **`SessionReplayService`** — captures frames + diagnostic results during every live session; auto-saves to `localStorage` every 30 frames, on clear, and on component destroy (survives page refresh)
- **`SessionReplayComponent`** at `/session-replay` — Play / Pause / Stop transport, 1× / 2× / 4× speed selector, animated progress bar, live metric cards that update as frames play back, full diagnostic event list from the session
- No backend required

### 3. Offline Simulator Mode
- **`SimulatorObdAdapterService`** — full `ObdAdapter` implementation; generates a 26-frame idle → ramp-up → high-rev → drop cycle, rising coolant temp (20 → 90 °C), RPM-correlated MAF, cold-start STFT bias, and occasional stall/spike instability events
- **`AdapterSwitcherService`** — registered as `OBD_ADAPTER`; uses `switchMap` on a `BehaviorSubject<AdapterMode>` to hot-swap streams with zero disruption to any consumer
- Dashboard toggle pill: **SIMULATOR** (blue) ↔ **LIVE** (green); auto-connects the simulator on switch

---

## Demo Instructions — How to use the Simulator

1. **Open Dashboard** (`/dashboard`)
2. The app starts in **SIMULATOR** mode by default (blue pill in header)
3. Click **Connect** — the simulator connects instantly (~600 ms delay)
4. Watch the multi-signal chart populate: RPM cycles idle → rev → drop every ~26 s; STFT and MAF appear as overlaid signals; MAF axis auto-reveals
5. The LTFT chart below shows long-term fuel trim history
6. To test the **Session Replay**: navigate to **Session Replay** in the sidebar after ≥30 frames have accumulated (auto-saved) or click **Clear** to force a save
7. Click **▶ Play** — metrics animate through the recorded session; change speed with 1× / 2× / 4×
8. To try the **real BLE adapter**: click the **SIMULATOR** pill → switches to **LIVE** mode; click **Connect** to scan for Bluetooth devices

---

## Files changed

| File | Change |
|------|--------|
| `core/adapters/simulator-obd-adapter.service.ts` | **New** — offline OBD simulator |
| `core/adapters/adapter-switcher.service.ts` | **New** — real ↔ simulated proxy |
| `core/replay/session-replay.service.ts` | **New** — session persistence + playback |
| `features/session-replay/` (3 files) | **New** — replay UI component |
| `shared/components/multi-signal-chart/` (3 files) | **New** — multi-signal Chart.js component |
| `app.config.ts` | Provide `AdapterSwitcherService` as `OBD_ADAPTER` |
| `app.routes.ts` | Add `/session-replay` route |
| `app.component.html` | Add Session Replay nav link |
| `dashboard-page.component.*` | Mode toggle, multi-signal chart, auto-save wiring |

## Build

```
✔ Building... (production)
0 errors · budget warnings only (pre-existing)
```