### PR TITLE
feat: close issues #62 + #87-93 — UI wording fix & Intelligence Sprint

### DIFF
--- a/src/app/core/diagnostics/deep-diagnosis.service.ts
+++ b/src/app/core/diagnostics/deep-diagnosis.service.ts
@@ -15,7 +15,9 @@ import { SeverityEngineService } from './intelligence/severity-engine.service';
 import { DiagnosticRecommendationService } from './intelligence/diagnostic-recommendation.service';
 import { DiagnosticSummaryService } from './intelligence/diagnostic-summary.service';
 import { DiagnosisTimelineService } from './intelligence/diagnosis-timeline.service';
-import { CorrelationFinding, DiagnosisSeverity, DiagnosisRecommendation, DiagnosisSummary, TimelineEvent } from './intelligence/diagnosis-intelligence.models';
+import { DriveSignatureService } from './intelligence/drive-signature.service';
+import { EvidenceGraphService } from './intelligence/evidence-graph.service';
+import { CorrelationFinding, DiagnosisSeverity, DiagnosisRecommendation, DiagnosisSummary, DriveSignature, HypothesisReport, TimelineEvent } from './intelligence/diagnosis-intelligence.models';
 
 export type DiagnosisStepId =
   | 'baseline_scan'
@@ -43,6 +45,8 @@ export interface DeepDiagnosisState {
   recommendations?: DiagnosisRecommendation;
   diagnosisSummary?: DiagnosisSummary;
   timelineEvents?: TimelineEvent[];
+  driveSignature?: DriveSignature;
+  hypothesisReport?: HypothesisReport;
 }
 
 @Injectable({
@@ -76,6 +80,8 @@ export class DeepDiagnosisService {
     private recommendationEngine: DiagnosticRecommendationService,
     private summaryService: DiagnosticSummaryService,
     private timeline: DiagnosisTimelineService,
+    private driveSignatureService: DriveSignatureService,
+    private evidenceGraphService: EvidenceGraphService,
   ) {}
 
   public startDiagnosis(): void {
@@ -343,6 +349,12 @@ export class DeepDiagnosisService {
     const recommendations = this.recommendationEngine.recommend(dtcCodes, correlationFindings, severity.level);
     const diagnosisSummary = this.summaryService.generate(correlationFindings, severity);
 
+    const driveSignature = this.driveSignatureService.extract(this.idleFrames, this.revFrames);
+    const evidenceGraph  = this.evidenceGraphService.buildGraph(dtcCodes, this.idleFrames, this.revFrames, driveSignature);
+    const contradictions = this.evidenceGraphService.detectContradictions(dtcCodes, this.idleFrames);
+    const hypotheses     = this.evidenceGraphService.rankHypotheses(evidenceGraph);
+    const hypothesisReport = this.evidenceGraphService.generateReport(hypotheses, contradictions);
+
     let finalStatus: 'pass' | 'warning' | 'fail' = 'pass';
     if (state.results.some(r => r.status === 'fail') || dtcCodes.length > 0) {
       finalStatus = 'fail';
@@ -365,7 +377,7 @@ export class DeepDiagnosisService {
     this.timeline.log('completed');
     const timelineEvents = this.timeline.getEvents();
     this.finalResultSubject.next(finalResult);
-    this.updateState({ status: 'completed', dtcFindings, correlationFindings, severity, recommendations, diagnosisSummary, timelineEvents });
+    this.updateState({ status: 'completed', dtcFindings, correlationFindings, severity, recommendations, diagnosisSummary, timelineEvents, driveSignature, hypothesisReport });
     this.sessionActive = false;
   }
 

--- a/src/app/core/diagnostics/intelligence/baseline-envelope.ts
+++ b/src/app/core/diagnostics/intelligence/baseline-envelope.ts
@@ -1,0 +1,10 @@
+import { BaselineEnvelope } from './diagnosis-intelligence.models';
+
+export type { BaselineEnvelope };
+
+export const DEFAULT_BASELINE: BaselineEnvelope = {
+  idleStability: { maxVariance: 150 },
+  revResponse:   { maxRiseTimeMs: 3000, maxOvershoot: 500 },
+  holdStability: { maxVariance: 200 },
+  decelPattern:  { maxDropRatePerSec: 1000 },
+};

--- a/src/app/core/diagnostics/intelligence/baseline-envelope.ts
+++ b/src/app/core/diagnostics/intelligence/baseline-envelope.ts
@@ -3,8 +3,8 @@ import { BaselineEnvelope } from './diagnosis-intelligence.models';
 export type { BaselineEnvelope };
 
 export const DEFAULT_BASELINE: BaselineEnvelope = {
-  idleStability: { maxVariance: 150 },
+  idleStability: { maxStdDev: 150 },
   revResponse:   { maxRiseTimeMs: 3000, maxOvershoot: 500 },
-  holdStability: { maxVariance: 200 },
+  holdStability: { maxStdDev: 200 },
   decelPattern:  { maxDropRatePerSec: 1000 },
 };

--- a/src/app/core/diagnostics/intelligence/diagnosis-intelligence.models.ts
+++ b/src/app/core/diagnostics/intelligence/diagnosis-intelligence.models.ts
@@ -26,3 +26,60 @@ export interface TimelineEvent {
   step: DiagnosisStepId;
   message: string;
 }
+
+// ── Intelligence Sprint models ────────────────────────────────────────────────
+
+export interface DriveSignature {
+  idleStability: { variance: number; meanRpm: number };
+  revResponse: { riseTimeMs: number; overshoot: number };
+  holdStability: { variance: number; meanRpm: number };
+  decelPattern: { dropRatePerSec: number };
+}
+
+export interface BaselineEnvelope {
+  idleStability: { maxVariance: number };
+  revResponse: { maxRiseTimeMs: number; maxOvershoot: number };
+  holdStability: { maxVariance: number };
+  decelPattern: { maxDropRatePerSec: number };
+}
+
+export type EvidenceNodeType = 'dtc' | 'signal' | 'signature' | 'hypothesis';
+
+export interface EvidenceNode {
+  id: string;
+  type: EvidenceNodeType;
+  label: string;
+}
+
+export interface EvidenceEdge {
+  fromId: string;
+  toId: string;
+  relation: 'supports' | 'contradicts';
+  weight: number;
+}
+
+export interface EvidenceGraph {
+  nodes: EvidenceNode[];
+  edges: EvidenceEdge[];
+}
+
+export interface ContradictionFinding {
+  description: string;
+  nodeALabel: string;
+  nodeBLabel: string;
+}
+
+export interface Hypothesis {
+  id: string;
+  title: string;
+  confidence: number;
+  rank: number;
+  supports: string[];
+  contradictions: string[];
+}
+
+export interface HypothesisReport {
+  hypotheses: Hypothesis[];
+  contradictions: ContradictionFinding[];
+  generatedAt: number;
+}

--- a/src/app/core/diagnostics/intelligence/diagnosis-intelligence.models.ts
+++ b/src/app/core/diagnostics/intelligence/diagnosis-intelligence.models.ts
@@ -30,16 +30,16 @@ export interface TimelineEvent {
 // ── Intelligence Sprint models ────────────────────────────────────────────────
 
 export interface DriveSignature {
-  idleStability: { variance: number; meanRpm: number };
+  idleStability: { stdDev: number; meanRpm: number };
   revResponse: { riseTimeMs: number; overshoot: number };
-  holdStability: { variance: number; meanRpm: number };
+  holdStability: { stdDev: number; meanRpm: number };
   decelPattern: { dropRatePerSec: number };
 }
 
 export interface BaselineEnvelope {
-  idleStability: { maxVariance: number };
+  idleStability: { maxStdDev: number };
   revResponse: { maxRiseTimeMs: number; maxOvershoot: number };
-  holdStability: { maxVariance: number };
+  holdStability: { maxStdDev: number };
   decelPattern: { maxDropRatePerSec: number };
 }
 

--- a/src/app/core/diagnostics/intelligence/drive-signature.service.ts
+++ b/src/app/core/diagnostics/intelligence/drive-signature.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@angular/core';
+import { ObdLiveFrame } from '../../models/obd-live-frame.model';
+import { DriveSignature } from './diagnosis-intelligence.models';
+
+@Injectable({ providedIn: 'root' })
+export class DriveSignatureService {
+
+  extract(idleFrames: ObdLiveFrame[], revFrames: ObdLiveFrame[]): DriveSignature {
+    return {
+      idleStability: this.extractIdleStability(idleFrames),
+      revResponse:   this.extractRevResponse(revFrames),
+      holdStability: this.extractHoldStability(revFrames),
+      decelPattern:  this.extractDecelPattern(revFrames),
+    };
+  }
+
+  private extractIdleStability(frames: ObdLiveFrame[]): DriveSignature['idleStability'] {
+    const idle = frames.filter(f => f.speed === 0 && f.throttlePosition < 5);
+    if (!idle.length) return { variance: 0, meanRpm: 0 };
+    const rpms = idle.map(f => f.rpm);
+    return { variance: this.variance(rpms), meanRpm: this.avg(rpms) };
+  }
+
+  private extractRevResponse(frames: ObdLiveFrame[]): DriveSignature['revResponse'] {
+    if (frames.length < 5) return { riseTimeMs: 0, overshoot: 0 };
+    const startIdx = frames.findIndex(f => f.rpm > 1000);
+    const peakIdx  = frames.findIndex(f => f.rpm > 2000);
+    const riseTimeMs = startIdx >= 0 && peakIdx > startIdx
+      ? frames[peakIdx].timestamp - frames[startIdx].timestamp
+      : 0;
+    const maxRpm = Math.max(...frames.map(f => f.rpm));
+    return { riseTimeMs, overshoot: Math.max(0, maxRpm - 2500) };
+  }
+
+  private extractHoldStability(frames: ObdLiveFrame[]): DriveSignature['holdStability'] {
+    const hold = frames.filter(f => f.rpm >= 2000 && f.rpm <= 3500);
+    if (!hold.length) return { variance: 0, meanRpm: 0 };
+    const rpms = hold.map(f => f.rpm);
+    return { variance: this.variance(rpms), meanRpm: this.avg(rpms) };
+  }
+
+  private extractDecelPattern(frames: ObdLiveFrame[]): DriveSignature['decelPattern'] {
+    if (frames.length < 5) return { dropRatePerSec: 0 };
+    const peakIdx   = frames.reduce((mi, f, i, arr) => f.rpm > arr[mi].rpm ? i : mi, 0);
+    const postPeak  = frames.slice(peakIdx);
+    if (postPeak.length < 2) return { dropRatePerSec: 0 };
+    const durationSec = (postPeak[postPeak.length - 1].timestamp - postPeak[0].timestamp) / 1000;
+    if (durationSec <= 0) return { dropRatePerSec: 0 };
+    return { dropRatePerSec: (postPeak[0].rpm - postPeak[postPeak.length - 1].rpm) / durationSec };
+  }
+
+  private avg(arr: number[]): number {
+    return arr.reduce((s, v) => s + v, 0) / arr.length;
+  }
+
+  private variance(arr: number[]): number {
+    if (arr.length < 2) return 0;
+    const mean = this.avg(arr);
+    return arr.reduce((s, v) => s + Math.pow(v - mean, 2), 0) / arr.length;
+  }
+}

--- a/src/app/core/diagnostics/intelligence/drive-signature.service.ts
+++ b/src/app/core/diagnostics/intelligence/drive-signature.service.ts
@@ -15,10 +15,11 @@ export class DriveSignatureService {
   }
 
   private extractIdleStability(frames: ObdLiveFrame[]): DriveSignature['idleStability'] {
-    const idle = frames.filter(f => f.speed === 0 && f.throttlePosition < 5);
-    if (!idle.length) return { variance: 0, meanRpm: 0 };
+    // Gate on RPM + speed only — throttlePosition varies widely across adapters at idle
+    const idle = frames.filter(f => f.speed === 0 && f.rpm <= 1200);
+    if (!idle.length) return { stdDev: 0, meanRpm: 0 };
     const rpms = idle.map(f => f.rpm);
-    return { variance: this.variance(rpms), meanRpm: this.avg(rpms) };
+    return { stdDev: this.stddev(rpms), meanRpm: this.avg(rpms) };
   }
 
   private extractRevResponse(frames: ObdLiveFrame[]): DriveSignature['revResponse'] {
@@ -34,9 +35,9 @@ export class DriveSignatureService {
 
   private extractHoldStability(frames: ObdLiveFrame[]): DriveSignature['holdStability'] {
     const hold = frames.filter(f => f.rpm >= 2000 && f.rpm <= 3500);
-    if (!hold.length) return { variance: 0, meanRpm: 0 };
+    if (!hold.length) return { stdDev: 0, meanRpm: 0 };
     const rpms = hold.map(f => f.rpm);
-    return { variance: this.variance(rpms), meanRpm: this.avg(rpms) };
+    return { stdDev: this.stddev(rpms), meanRpm: this.avg(rpms) };
   }
 
   private extractDecelPattern(frames: ObdLiveFrame[]): DriveSignature['decelPattern'] {
@@ -53,9 +54,9 @@ export class DriveSignatureService {
     return arr.reduce((s, v) => s + v, 0) / arr.length;
   }
 
-  private variance(arr: number[]): number {
+  private stddev(arr: number[]): number {
     if (arr.length < 2) return 0;
     const mean = this.avg(arr);
-    return arr.reduce((s, v) => s + Math.pow(v - mean, 2), 0) / arr.length;
+    return Math.sqrt(arr.reduce((s, v) => s + Math.pow(v - mean, 2), 0) / arr.length);
   }
 }

--- a/src/app/core/diagnostics/intelligence/evidence-graph.service.ts
+++ b/src/app/core/diagnostics/intelligence/evidence-graph.service.ts
@@ -252,9 +252,9 @@ export class EvidenceGraphService {
     nodes: EvidenceNode[],
     edges: EvidenceEdge[],
   ): void {
-    if (sig.idleStability.variance > baseline.idleStability.maxVariance) {
+    if (sig.idleStability.stdDev > baseline.idleStability.maxStdDev) {
       const id = 'signat-idle-unstable';
-      nodes.push({ id, type: 'signature', label: `Idle instability (RPM σ²: ${Math.round(sig.idleStability.variance)})` });
+      nodes.push({ id, type: 'signature', label: `Idle instability (RPM σ: ${Math.round(sig.idleStability.stdDev)})` });
       edges.push({ fromId: id, toId: 'misfire-ignition', relation: 'supports', weight: 0.6 });
       edges.push({ fromId: id, toId: 'vacuum-leak',      relation: 'supports', weight: 0.4 });
     }
@@ -266,9 +266,9 @@ export class EvidenceGraphService {
       edges.push({ fromId: id, toId: 'maf-sensor',    relation: 'supports', weight: 0.3 });
     }
 
-    if (sig.holdStability.variance > baseline.holdStability.maxVariance) {
+    if (sig.holdStability.stdDev > baseline.holdStability.maxStdDev) {
       const id = 'signat-hold-unstable';
-      nodes.push({ id, type: 'signature', label: `Hold instability at 2–3k RPM (σ²: ${Math.round(sig.holdStability.variance)})` });
+      nodes.push({ id, type: 'signature', label: `Hold instability at 2–3k RPM (RPM σ: ${Math.round(sig.holdStability.stdDev)})` });
       edges.push({ fromId: id, toId: 'misfire-ignition', relation: 'supports', weight: 0.5 });
     }
 

--- a/src/app/core/diagnostics/intelligence/evidence-graph.service.ts
+++ b/src/app/core/diagnostics/intelligence/evidence-graph.service.ts
@@ -1,0 +1,293 @@
+import { Injectable } from '@angular/core';
+import { DtcCode } from '../dtc/dtc-code.model';
+import { ObdLiveFrame } from '../../models/obd-live-frame.model';
+import {
+  ContradictionFinding,
+  DriveSignature,
+  EvidenceEdge,
+  EvidenceGraph,
+  EvidenceNode,
+  Hypothesis,
+  HypothesisReport,
+} from './diagnosis-intelligence.models';
+import { BaselineEnvelope, DEFAULT_BASELINE } from './baseline-envelope';
+
+// ── Static knowledge base ─────────────────────────────────────────────────────
+
+interface HypothesisTemplate { id: string; title: string; }
+
+const HYPOTHESIS_TEMPLATES: HypothesisTemplate[] = [
+  { id: 'vacuum-leak',      title: 'Vacuum / Intake Leak' },
+  { id: 'fuel-delivery',    title: 'Fuel Delivery Fault' },
+  { id: 'rich-injector',    title: 'Leaking or Rich Injector' },
+  { id: 'misfire-ignition', title: 'Misfire / Ignition Fault' },
+  { id: 'maf-sensor',       title: 'MAF Sensor Fault' },
+  { id: 'catalyst',         title: 'Catalytic Converter Degradation' },
+];
+
+interface DtcRule {
+  code: string;
+  hypothesisId: string;
+  relation: 'supports' | 'contradicts';
+  weight: number;
+}
+
+const DTC_RULES: DtcRule[] = [
+  { code: 'P0171', hypothesisId: 'vacuum-leak',      relation: 'supports',    weight: 0.6 },
+  { code: 'P0171', hypothesisId: 'fuel-delivery',    relation: 'supports',    weight: 0.5 },
+  { code: 'P0171', hypothesisId: 'rich-injector',    relation: 'contradicts', weight: 0.7 },
+  { code: 'P0174', hypothesisId: 'vacuum-leak',      relation: 'supports',    weight: 0.6 },
+  { code: 'P0174', hypothesisId: 'fuel-delivery',    relation: 'supports',    weight: 0.5 },
+  { code: 'P0174', hypothesisId: 'rich-injector',    relation: 'contradicts', weight: 0.7 },
+  { code: 'P0172', hypothesisId: 'rich-injector',    relation: 'supports',    weight: 0.7 },
+  { code: 'P0172', hypothesisId: 'vacuum-leak',      relation: 'contradicts', weight: 0.6 },
+  { code: 'P0172', hypothesisId: 'fuel-delivery',    relation: 'contradicts', weight: 0.4 },
+  { code: 'P0175', hypothesisId: 'rich-injector',    relation: 'supports',    weight: 0.6 },
+  { code: 'P0175', hypothesisId: 'vacuum-leak',      relation: 'contradicts', weight: 0.6 },
+  { code: 'P0300', hypothesisId: 'misfire-ignition', relation: 'supports',    weight: 0.8 },
+  { code: 'P0301', hypothesisId: 'misfire-ignition', relation: 'supports',    weight: 0.7 },
+  { code: 'P0302', hypothesisId: 'misfire-ignition', relation: 'supports',    weight: 0.7 },
+  { code: 'P0303', hypothesisId: 'misfire-ignition', relation: 'supports',    weight: 0.7 },
+  { code: 'P0304', hypothesisId: 'misfire-ignition', relation: 'supports',    weight: 0.7 },
+  { code: 'P0100', hypothesisId: 'maf-sensor',       relation: 'supports',    weight: 0.7 },
+  { code: 'P0101', hypothesisId: 'maf-sensor',       relation: 'supports',    weight: 0.8 },
+  { code: 'P0101', hypothesisId: 'fuel-delivery',    relation: 'supports',    weight: 0.3 },
+  { code: 'P0102', hypothesisId: 'maf-sensor',       relation: 'supports',    weight: 0.8 },
+  { code: 'P0103', hypothesisId: 'maf-sensor',       relation: 'supports',    weight: 0.8 },
+  { code: 'P0104', hypothesisId: 'maf-sensor',       relation: 'supports',    weight: 0.7 },
+  { code: 'P0420', hypothesisId: 'catalyst',         relation: 'supports',    weight: 0.8 },
+  { code: 'P0430', hypothesisId: 'catalyst',         relation: 'supports',    weight: 0.8 },
+];
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+@Injectable({ providedIn: 'root' })
+export class EvidenceGraphService {
+
+  // #89 — Build evidence graph linking DTCs, signals, and signatures
+  buildGraph(
+    dtcCodes: DtcCode[],
+    idleFrames: ObdLiveFrame[],
+    revFrames: ObdLiveFrame[],
+    signature: DriveSignature,
+    baseline: BaselineEnvelope = DEFAULT_BASELINE,
+  ): EvidenceGraph {
+    const nodes: EvidenceNode[] = [];
+    const edges: EvidenceEdge[] = [];
+
+    for (const h of HYPOTHESIS_TEMPLATES) {
+      nodes.push({ id: h.id, type: 'hypothesis', label: h.title });
+    }
+
+    this.addDtcNodes(dtcCodes, nodes, edges);
+    this.addSignalNodes(idleFrames, revFrames, nodes, edges);
+    this.addSignatureNodes(signature, baseline, nodes, edges);
+
+    return { nodes, edges };
+  }
+
+  // #91 — Detect contradictory signals/evidence
+  detectContradictions(
+    dtcCodes: DtcCode[],
+    idleFrames: ObdLiveFrame[],
+  ): ContradictionFinding[] {
+    const findings: ContradictionFinding[] = [];
+    const codes = new Set(dtcCodes.map(c => c.code));
+    const avgIdleStft = idleFrames.length
+      ? this.avg(idleFrames.map(f => f.stftB1))
+      : null;
+    const idleVariance = idleFrames.length >= 5
+      ? this.variance(idleFrames.map(f => f.rpm))
+      : null;
+
+    if ((codes.has('P0171') || codes.has('P0174')) && avgIdleStft !== null && avgIdleStft < -5) {
+      findings.push({
+        description: 'Lean DTC present but fuel trims are rich at idle — conflicting evidence, possible intermittent condition or sensor fault.',
+        nodeALabel: 'Lean fault code (P0171/P0174)',
+        nodeBLabel: `Rich idle STFT (${avgIdleStft.toFixed(1)}%)`,
+      });
+    }
+
+    const misfireCodes = [...codes].filter(c => c >= 'P0300' && c <= 'P0304');
+    if (misfireCodes.length && idleVariance !== null && idleVariance < 50 * 50) {
+      findings.push({
+        description: 'Misfire code present but idle RPM is stable — misfire may be intermittent or load-dependent.',
+        nodeALabel: `Misfire code (${misfireCodes.join(', ')})`,
+        nodeBLabel: `Stable idle RPM (σ: ${Math.round(Math.sqrt(idleVariance))} RPM)`,
+      });
+    }
+
+    if ((codes.has('P0172') || codes.has('P0175')) && avgIdleStft !== null && avgIdleStft > 10) {
+      findings.push({
+        description: 'Rich DTC present but fuel trims are lean at idle — conflicting evidence.',
+        nodeALabel: 'Rich fault code (P0172/P0175)',
+        nodeBLabel: `Lean idle STFT (${avgIdleStft.toFixed(1)}%)`,
+      });
+    }
+
+    return findings;
+  }
+
+  // #90 (confidence) + #92 (ranking) — Score and rank top-3 hypotheses
+  rankHypotheses(graph: EvidenceGraph): Hypothesis[] {
+    const hypothesisNodes = graph.nodes.filter(n => n.type === 'hypothesis');
+    const scored: Hypothesis[] = [];
+
+    for (const hyp of hypothesisNodes) {
+      const incoming = graph.edges.filter(e => e.toId === hyp.id);
+      const supportEdges    = incoming.filter(e => e.relation === 'supports');
+      const contradictEdges = incoming.filter(e => e.relation === 'contradicts');
+
+      if (!supportEdges.length) continue;
+
+      const sw = supportEdges.reduce((s, e) => s + e.weight, 0);
+      const cw = contradictEdges.reduce((s, e) => s + e.weight, 0);
+      const confidence = sw / (sw + cw + 0.001);
+
+      const labelFor = (e: EvidenceEdge) =>
+        graph.nodes.find(n => n.id === e.fromId)?.label ?? e.fromId;
+
+      scored.push({
+        id: hyp.id,
+        title: hyp.label,
+        confidence: Math.min(1, confidence),
+        rank: 0,
+        supports:      supportEdges.map(labelFor),
+        contradictions: contradictEdges.map(labelFor),
+      });
+    }
+
+    const ranked = scored.sort((a, b) => b.confidence - a.confidence).slice(0, 3);
+    ranked.forEach((h, i) => { h.rank = i + 1; });
+    return ranked;
+  }
+
+  // #93 — Generate explainable output report
+  generateReport(
+    hypotheses: Hypothesis[],
+    contradictions: ContradictionFinding[],
+  ): HypothesisReport {
+    return { hypotheses, contradictions, generatedAt: Date.now() };
+  }
+
+  // ── Node builders ─────────────────────────────────────────────────────────
+
+  private addDtcNodes(
+    dtcCodes: DtcCode[],
+    nodes: EvidenceNode[],
+    edges: EvidenceEdge[],
+  ): void {
+    for (const dtc of dtcCodes) {
+      const id = `dtc-${dtc.code}`;
+      nodes.push({ id, type: 'dtc', label: `${dtc.code}: ${dtc.title}` });
+      for (const rule of DTC_RULES) {
+        if (rule.code === dtc.code) {
+          edges.push({ fromId: id, toId: rule.hypothesisId, relation: rule.relation, weight: rule.weight });
+        }
+      }
+    }
+  }
+
+  private addSignalNodes(
+    idleFrames: ObdLiveFrame[],
+    revFrames: ObdLiveFrame[],
+    nodes: EvidenceNode[],
+    edges: EvidenceEdge[],
+  ): void {
+    if (!idleFrames.length && !revFrames.length) return;
+
+    const avgIdleStft = idleFrames.length ? this.avg(idleFrames.map(f => f.stftB1)) : null;
+    const avgRevStft  = revFrames.length  ? this.avg(revFrames.map(f => f.stftB1))  : null;
+    const avgIdleLtft = idleFrames.length ? this.avg(idleFrames.map(f => f.ltftB1)) : null;
+
+    if (avgIdleStft !== null && avgIdleStft > 10) {
+      const id = 'sig-lean-idle';
+      nodes.push({ id, type: 'signal', label: `Lean idle STFT (avg ${avgIdleStft.toFixed(1)}%)` });
+
+      if (avgRevStft !== null && avgRevStft < 5) {
+        // Lean at idle, normalises at load — vacuum leak pattern
+        edges.push({ fromId: id, toId: 'vacuum-leak',   relation: 'supports',    weight: 0.8 });
+        edges.push({ fromId: id, toId: 'fuel-delivery', relation: 'contradicts', weight: 0.3 });
+      } else {
+        // Lean across RPM range — fuel delivery
+        edges.push({ fromId: id, toId: 'vacuum-leak',   relation: 'supports', weight: 0.5 });
+        edges.push({ fromId: id, toId: 'fuel-delivery', relation: 'supports', weight: 0.6 });
+      }
+    }
+
+    if (avgIdleStft !== null && avgIdleStft < -10) {
+      const id = 'sig-rich-idle';
+      nodes.push({ id, type: 'signal', label: `Rich idle STFT (avg ${avgIdleStft.toFixed(1)}%)` });
+      edges.push({ fromId: id, toId: 'rich-injector', relation: 'supports',    weight: 0.7 });
+      edges.push({ fromId: id, toId: 'vacuum-leak',   relation: 'contradicts', weight: 0.5 });
+    }
+
+    if (avgIdleLtft !== null && avgIdleLtft > 15) {
+      const id = 'sig-high-ltft';
+      nodes.push({ id, type: 'signal', label: `Elevated long-term fuel trim (avg ${avgIdleLtft.toFixed(1)}%)` });
+      edges.push({ fromId: id, toId: 'fuel-delivery', relation: 'supports', weight: 0.6 });
+      edges.push({ fromId: id, toId: 'vacuum-leak',   relation: 'supports', weight: 0.4 });
+    }
+
+    // MAF not scaling with RPM
+    const idleMafVals = idleFrames.filter(f => f.maf != null).map(f => f.maf!);
+    const revMafVals  = revFrames.filter(f => f.maf != null).map(f => f.maf!);
+    const avgIdleRpm  = idleFrames.length ? this.avg(idleFrames.map(f => f.rpm)) : 0;
+    const avgRevRpm   = revFrames.length  ? this.avg(revFrames.map(f => f.rpm))  : 0;
+    if (
+      idleMafVals.length > 0 && revMafVals.length > 0 &&
+      avgRevRpm > avgIdleRpm + 500 &&
+      this.avg(revMafVals) < this.avg(idleMafVals) * 1.3
+    ) {
+      const id = 'sig-maf-flat';
+      nodes.push({ id, type: 'signal', label: 'MAF reading did not increase with RPM' });
+      edges.push({ fromId: id, toId: 'maf-sensor',    relation: 'supports', weight: 0.8 });
+      edges.push({ fromId: id, toId: 'fuel-delivery', relation: 'supports', weight: 0.3 });
+    }
+  }
+
+  private addSignatureNodes(
+    sig: DriveSignature,
+    baseline: BaselineEnvelope,
+    nodes: EvidenceNode[],
+    edges: EvidenceEdge[],
+  ): void {
+    if (sig.idleStability.variance > baseline.idleStability.maxVariance) {
+      const id = 'signat-idle-unstable';
+      nodes.push({ id, type: 'signature', label: `Idle instability (RPM σ²: ${Math.round(sig.idleStability.variance)})` });
+      edges.push({ fromId: id, toId: 'misfire-ignition', relation: 'supports', weight: 0.6 });
+      edges.push({ fromId: id, toId: 'vacuum-leak',      relation: 'supports', weight: 0.4 });
+    }
+
+    if (sig.revResponse.riseTimeMs > baseline.revResponse.maxRiseTimeMs) {
+      const id = 'signat-slow-rev';
+      nodes.push({ id, type: 'signature', label: `Slow rev response (${Math.round(sig.revResponse.riseTimeMs)}ms rise time)` });
+      edges.push({ fromId: id, toId: 'fuel-delivery', relation: 'supports', weight: 0.4 });
+      edges.push({ fromId: id, toId: 'maf-sensor',    relation: 'supports', weight: 0.3 });
+    }
+
+    if (sig.holdStability.variance > baseline.holdStability.maxVariance) {
+      const id = 'signat-hold-unstable';
+      nodes.push({ id, type: 'signature', label: `Hold instability at 2–3k RPM (σ²: ${Math.round(sig.holdStability.variance)})` });
+      edges.push({ fromId: id, toId: 'misfire-ignition', relation: 'supports', weight: 0.5 });
+    }
+
+    if (sig.revResponse.overshoot > baseline.revResponse.maxOvershoot) {
+      const id = 'signat-overshoot';
+      nodes.push({ id, type: 'signature', label: `Rev overshoot (${Math.round(sig.revResponse.overshoot)} RPM above target)` });
+      edges.push({ fromId: id, toId: 'misfire-ignition', relation: 'supports', weight: 0.3 });
+    }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private avg(arr: number[]): number {
+    return arr.reduce((s, v) => s + v, 0) / arr.length;
+  }
+
+  private variance(arr: number[]): number {
+    if (arr.length < 2) return 0;
+    const mean = this.avg(arr);
+    return arr.reduce((s, v) => s + Math.pow(v - mean, 2), 0) / arr.length;
+  }
+}

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.html
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.html
@@ -191,9 +191,9 @@
 
     <!-- Transition controls -->
     <div class="transition-controls" *ngIf="state.status === 'transitioning'">
-      <p class="countdown-text">Moving in {{ state.transitionCountdown }}s…</p>
+      <p class="countdown-text">Starting next test in {{ state.transitionCountdown }}s…</p>
       <div class="btn-row">
-        <button class="btn btn-sm btn-outline" (click)="moveNow()">Move Now</button>
+        <button class="btn btn-sm btn-outline" (click)="moveNow()">Start Next Step Now</button>
         <button class="btn btn-sm btn-ghost" (click)="stayOnStep()">Stay Here</button>
       </div>
     </div>

--- a/src/app/features/guided-tests/guided-tests-page.component.html
+++ b/src/app/features/guided-tests/guided-tests-page.component.html
@@ -91,9 +91,9 @@
 
             <!-- Transition UI -->
             <div class="transition-controls" *ngIf="state.status === 'transitioning'">
-              <p class="countdown-text">Moving to next step in {{ state.transitionCountdown }}...</p>
+              <p class="countdown-text">Starting next test in {{ state.transitionCountdown }}...</p>
               <div class="button-group">
-                <button class="btn-secondary" (click)="moveNow()">Move Now</button>
+                <button class="btn-secondary" (click)="moveNow()">Start Next Step Now</button>
                 <button class="btn-outline" (click)="stayOnCurrentStep()">Stay on This Step</button>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- **#62** — Replace confusing 'Move' wording in Diagnosis and Guided Test flows
- **#87** — Drive Signature Extractor
- **#88** — Baseline Envelope Definition
- **#89** — Evidence Graph Engine
- **#90** — Confidence Scoring System
- **#91** — Contradiction Detection
- **#92** — Hypothesis Ranking
- **#93** — Explainable Output Layer

## What changed

### Issue #62 — UI wording fix
Replaced vehicle-movement language in `diagnosis-report-page.component.html` and `guided-tests-page.component.html`:
- `"Move Now"` → `"Start Next Step Now"`
- `"Moving to next step in X..."` / `"Moving in Xs…"` → `"Starting next test in X..."`
No logic changed.

### Intelligence Sprint — new files

| File | Purpose |
|------|---------|
| `core/diagnostics/intelligence/baseline-envelope.ts` | `DEFAULT_BASELINE` constant — expected thresholds for each drive signature. Accepts `BaselineEnvelope` override for vehicle-specific tuning. |
| `core/diagnostics/intelligence/drive-signature.service.ts` | `DriveSignatureService.extract()` — computes idle stability (RPM variance/mean), rev response (rise time, overshoot), hold stability (2–3k RPM variance), and decel pattern (RPM drop rate) from idle and rev frame arrays. |
| `core/diagnostics/intelligence/evidence-graph.service.ts` | `EvidenceGraphService` — four public methods: `buildGraph()` (#89), `detectContradictions()` (#91), `rankHypotheses()` (#90, #92), `generateReport()` (#93). |

### Evidence graph logic
- **Nodes**: each DTC, computed signal observation (lean/rich STFT, high LTFT, flat MAF), and signature anomaly becomes a typed node (`dtc | signal | signature`). Six hypothesis nodes are pre-seeded (`vacuum-leak`, `fuel-delivery`, `rich-injector`, `misfire-ignition`, `maf-sensor`, `catalyst`).
- **Edges**: a static knowledge base of 24 DTC rules + dynamic signal/signature rules connects evidence to hypotheses with `supports | contradicts` weights.
- **Confidence** (#90): `supportWeight / (supportWeight + contradictWeight)`, normalised 0–1.
- **Contradictions** (#91): detects lean-code-but-rich-trims, stable-idle-but-misfire-code, rich-code-but-lean-trims.
- **Ranking** (#92): top 3 hypotheses sorted by confidence, rank assigned 1–3.
- **Explainable output** (#93): `HypothesisReport` carries per-hypothesis `{ title, confidence, supports[], contradictions[] }` plus global `ContradictionFinding[]`.

### Integration
`DeepDiagnosisService.aggregateResults()` now calls the full intelligence pipeline after existing DTC correlation. `driveSignature` and `hypothesisReport` are stored in `DeepDiagnosisState` and available to any view layer.

## Reviewer notes
- `diagnosis-intelligence.models.ts` has new exported types — no breaking changes to existing fields.
- All new services are `providedIn: 'root'` — no module changes needed.
- TypeScript strict mode passes with zero errors.