### PR TITLE
feat(ui): UI Polish Sprint — issues #97-101

### DIFF
--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.scss
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.scss
@@ -397,7 +397,7 @@
   }
 
   .stepper-label {
-    font-size: 10px;
+    font-size: $font-size-label-sm;
     font-weight: 600;
     color: $text-muted;
     white-space: nowrap;
@@ -486,7 +486,7 @@
     gap: 2px;
 
     .lm-label {
-      font-size: 10px;
+      font-size: $font-size-label-sm;
       font-weight: 700;
       letter-spacing: 0.1em;
       color: $text-muted;
@@ -607,7 +607,7 @@
 .bar-labels {
   display: flex;
   justify-content: space-between;
-  font-size: 10px;
+  font-size: $font-size-label-sm;
   color: $text-muted;
 
   .target-lbl { color: $color-success; font-weight: 600; }
@@ -962,7 +962,7 @@
     gap: 2px;
 
     .tl-step {
-      font-size: 10px;
+      font-size: $font-size-label-sm;
       font-weight: 700;
       letter-spacing: 0.1em;
       color: $color-success;
@@ -977,7 +977,7 @@
 
   .tl-time {
     font-family: $font-family-mono;
-    font-size: 10px;
+    font-size: $font-size-label-sm;
     color: $text-muted;
     white-space: nowrap;
     padding-top: 2px;

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.scss
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.scss
@@ -33,7 +33,7 @@
 .report-page {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: $spacing-xl;
   padding: $spacing-xl;
 }
 
@@ -165,21 +165,22 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 6px 16px;
+  padding: $spacing-sm $spacing-lg;
   border-radius: $radius-md;
   background: $bg-secondary;
   border: 1px solid $border-color;
-  min-width: 72px;
+  min-width: 88px;
+  gap: 2px;
 
   .sev-score {
     font-family: $font-family-mono;
-    font-size: 1.4rem;
+    font-size: 2rem;
     font-weight: 700;
     color: $text-primary;
     line-height: 1;
 
     .sev-denom {
-      font-size: 0.65em;
+      font-size: 0.5em;
       color: $text-muted;
     }
   }
@@ -188,10 +189,10 @@
     font-size: $font-size-label-sm;
     font-weight: 700;
     letter-spacing: 0.08em;
-    margin-top: 2px;
+    text-transform: uppercase;
+    margin-top: 4px;
 
-    // severityClass() returns lowercase: 'low' | 'medium' | 'high' | 'critical'
-    &.low    { color: #2196f3; }
+    &.low    { color: $color-info; }
     &.medium { color: $color-warning; }
     &.high, &.critical { color: $color-critical; }
   }
@@ -243,7 +244,7 @@
 // ── Summary banner ────────────────────────────────────────────────────────────
 .summary-banner {
   background: $surface-container;
-  border-left: 3px solid #2196f3;
+  border-left: 3px solid $color-info;
   border-radius: 0 $radius-md $radius-md 0;
   padding: $spacing-md $spacing-lg;
 
@@ -339,7 +340,7 @@
   border-radius: $radius-sm;
 
   .meta-key {
-    font-size: 9px;
+    font-size: $font-size-label-sm;
     font-weight: 700;
     letter-spacing: 0.1em;
     color: $text-muted;
@@ -566,9 +567,9 @@
     background: rgba($color-warning, 0.08);
   }
   &.cold {
-    color: #2196f3;
-    border-color: rgba(#2196f3, 0.4);
-    background: rgba(#2196f3, 0.08);
+    color: $color-info;
+    border-color: rgba($color-info, 0.4);
+    background: rgba($color-info, 0.08);
   }
 }
 
@@ -587,7 +588,7 @@
     transition: width 0.4s ease;
 
     &.bar-fill--coolant {
-      background: linear-gradient(90deg, #2196f3, $color-warning, $color-success);
+      background: linear-gradient(90deg, $color-info, $color-warning, $color-success);
     }
     &.bar-fill--rpm {
       background: linear-gradient(90deg, $color-warning, $color-success);
@@ -636,8 +637,8 @@
   display: flex;
   align-items: center;
   gap: $spacing-md;
-  background: rgba(#2196f3, 0.06);
-  border: 1px solid rgba(#2196f3, 0.35);
+  background: rgba($color-info, 0.06);
+  border: 1px solid rgba($color-info, 0.35);
   border-radius: $radius-md;
   padding: $spacing-md;
 
@@ -738,9 +739,9 @@
     .ss-icon { color: $color-warning; }
   }
   &.low {
-    border-color: rgba(#2196f3, 0.4);
-    background: rgba(#2196f3, 0.05);
-    .ss-icon { color: #2196f3; }
+    border-color: rgba($color-info, 0.4);
+    background: rgba($color-info, 0.05);
+    .ss-icon { color: $color-info; }
   }
 
   .ss-icon {
@@ -798,13 +799,15 @@
 }
 
 .results-card-header {
-  padding: $spacing-md $spacing-lg;
+  padding: $spacing-sm $spacing-lg;
   border-bottom: 1px solid $border-color;
+  background: rgba($bg-primary, 0.4);
 
   h2 {
     margin: 0;
-    font-size: $font-size-title-md;
-    font-weight: 600;
+    font-size: $font-size-body-md;
+    font-weight: 700;
+    letter-spacing: 0.04em;
     color: $text-primary;
     display: flex;
     align-items: center;
@@ -852,7 +855,7 @@
 
   .action-group-label {
     margin: 0 0 $spacing-sm;
-    font-size: 10px;
+    font-size: $font-size-label-sm;
     font-weight: 700;
     letter-spacing: 0.1em;
     color: $text-muted;
@@ -901,7 +904,7 @@
     font-size: $font-size-body-md;
     line-height: 1.45;
 
-    &.finding-dtc { border-left-color: #2196f3; }
+    &.finding-dtc { border-left-color: $color-info; }
   }
 }
 

--- a/src/app/features/guided-tests/guided-tests-page.component.scss
+++ b/src/app/features/guided-tests/guided-tests-page.component.scss
@@ -34,18 +34,18 @@
       gap: $spacing-md;
 
       .icon {
-        font-size: 1.5rem;
+        font-size: $font-size-title-lg;
       }
 
       .text {
         h3 {
           margin: 0;
-          font-size: 1rem;
+          font-size: $font-size-body-lg;
           color: $color-warning;
         }
         p {
           margin: 4px 0 0 0;
-          font-size: 0.85rem;
+          font-size: $font-size-body-sm;
           color: $text-secondary;
         }
       }
@@ -77,10 +77,9 @@
 
         h2 {
           margin: 0;
-          font-size: 1.4rem;
-          background: linear-gradient(90deg, $text-primary, rgba($text-primary, 0.7));
-          -webkit-background-clip: text;
-          -webkit-text-fill-color: transparent;
+          font-size: $font-size-title-lg;
+          font-weight: 600;
+          color: $text-primary;
         }
 
         .step-badge {
@@ -88,16 +87,16 @@
           color: $text-secondary;
           padding: 4px 12px;
           border-radius: 20px;
-          font-size: 0.8rem;
+          font-size: $font-size-label-lg;
           font-weight: 600;
-          border: 1px solid rgba($border-color, 0.2);
+          border: 1px solid $border-color;
         }
       }
 
       .diagnosis-body {
         .instruction {
           color: $text-secondary;
-          font-size: 1rem;
+          font-size: $font-size-body-lg;
           margin-bottom: $spacing-lg;
         }
 
@@ -125,10 +124,10 @@
               right: 8px;
               top: 50%;
               transform: translateY(-50%);
-              font-size: 0.7rem;
+              font-size: $font-size-label-sm;
               font-weight: 700;
-              color: white;
-              text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+              color: $text-primary;
+              text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
             }
           }
 
@@ -170,7 +169,7 @@
                 }
 
                 .interpretation {
-                  font-size: 0.7rem;
+                  font-size: $font-size-label-sm;
                   color: $color-success;
                   font-weight: 600;
 
@@ -220,7 +219,7 @@
 
             .countdown-text {
               margin: 0;
-              font-size: 1rem;
+              font-size: $font-size-body-lg;
               color: $color-warning;
               font-weight: 600;
             }
@@ -244,7 +243,7 @@
 
           .section-label {
             margin: 0 0 $spacing-sm 0;
-            font-size: 0.75rem;
+            font-size: $font-size-label-lg;
             font-weight: 700;
             text-transform: uppercase;
             letter-spacing: 0.06em;
@@ -429,7 +428,7 @@
 
       h3 {
         margin: 0;
-        font-size: 1.1rem;
+        font-size: $font-size-body-lg;
         color: $text-primary;
       }
     }
@@ -443,7 +442,7 @@
       .instruction {
         margin: 0;
         color: $text-secondary;
-        font-size: 0.95rem;
+        font-size: $font-size-body-md;
       }
 
       .controls {
@@ -501,7 +500,7 @@
 
         .status-text {
           margin: 0;
-          font-size: 0.85rem;
+          font-size: $font-size-body-sm;
           color: $text-primary;
         }
 
@@ -519,7 +518,7 @@
         }
 
         .progress-text {
-          font-size: 0.75rem;
+          font-size: $font-size-label-sm;
           color: $text-secondary;
           align-self: flex-end;
         }
@@ -556,16 +555,16 @@
 
             h4 {
               margin: 0;
-              font-size: 0.95rem;
+              font-size: $font-size-body-md;
               color: $text-primary;
             }
 
             .status-badge {
-              font-size: 0.8rem;
+              font-size: $font-size-label-lg;
               font-weight: 700;
             }
             .confidence {
-              font-size: 0.75rem;
+              font-size: $font-size-label-sm;
               color: $text-secondary;
               background: rgba(0, 0, 0, 0.2);
               padding: 2px 6px;
@@ -575,14 +574,14 @@
 
           .summary {
             margin: 0 0 8px 0;
-            font-size: 0.9rem;
+            font-size: $font-size-body-md;
             color: $text-primary;
           }
 
           .details-list {
             margin: 0;
             padding-left: 20px;
-            font-size: 0.85rem;
+            font-size: $font-size-body-sm;
             color: $text-secondary;
 
             li {

--- a/src/app/features/guided-tests/guided-tests-page.component.scss
+++ b/src/app/features/guided-tests/guided-tests-page.component.scss
@@ -9,13 +9,14 @@
   header {
     h1 {
       margin: 0;
-      font-size: 1.5rem;
+      font-size: $font-size-title-lg;
+      font-weight: 600;
       color: $text-primary;
     }
     .subtitle {
       color: $text-secondary;
       margin-top: 4px;
-      font-size: 0.9rem;
+      font-size: $font-size-body-md;
     }
   }
 
@@ -132,24 +133,24 @@
           }
 
           .live-metrics-panel {
-            background: rgba($bg-primary, 0.4);
-            border: 1px solid rgba($border-color, 0.5);
+            background: $bg-secondary;
+            border: 1px solid $border-color;
             border-radius: $radius-md;
             padding: $spacing-md;
 
             .metrics-grid {
               display: grid;
-              grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+              grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
               gap: $spacing-sm;
 
               .metric-card {
                 display: flex;
                 flex-direction: column;
-                background: rgba($bg-secondary, 0.6);
-                padding: $spacing-sm;
-                border-radius: $radius-sm;
+                background: $surface-container;
+                padding: $spacing-sm $spacing-sm $spacing-xs;
+                border-radius: $radius-md;
                 text-align: center;
-                border: 1px solid rgba(255, 255, 255, 0.05);
+                border: 1px solid $border-color;
 
                 .label {
                   font-size: $font-size-label-sm;
@@ -186,22 +187,23 @@
           }
 
           .mini-chart-section {
-            background: rgba($bg-primary, 0.4);
-            border: 1px solid rgba($border-color, 0.5);
+            background: $bg-secondary;
+            border: 1px solid $border-color;
             border-radius: $radius-md;
-            padding: $spacing-sm $spacing-md;
+            padding: $spacing-md;
 
             .chart-label {
               display: block;
-              font-size: 0.7rem;
+              font-size: $font-size-label-sm;
+              font-weight: 700;
               color: $text-muted;
               text-transform: uppercase;
-              letter-spacing: 0.05em;
-              margin-bottom: $spacing-xs;
+              letter-spacing: 0.08em;
+              margin-bottom: $spacing-sm;
             }
 
             .chart-wrap {
-              height: 80px;
+              height: 140px;
               position: relative;
             }
           }
@@ -335,9 +337,10 @@
 
   .section-title {
     margin: $spacing-xl 0 $spacing-md 0;
-    font-size: 1.2rem;
-    color: $text-secondary;
-    border-bottom: 1px solid rgba($border-color, 0.2);
+    font-size: $font-size-title-md;
+    font-weight: 600;
+    color: $text-primary;
+    border-bottom: 1px solid $border-color;
     padding-bottom: $spacing-sm;
   }
 

--- a/src/app/features/guided-tests/guided-tests-page.component.scss
+++ b/src/app/features/guided-tests/guided-tests-page.component.scss
@@ -152,15 +152,17 @@
                 border: 1px solid rgba(255, 255, 255, 0.05);
 
                 .label {
-                  font-size: 0.7rem;
-                  color: $text-secondary;
+                  font-size: $font-size-label-sm;
+                  font-weight: 700;
+                  color: $text-muted;
                   text-transform: uppercase;
-                  letter-spacing: 0.5px;
+                  letter-spacing: 0.08em;
                   margin-bottom: 2px;
                 }
 
                 .value {
-                  font-size: 1.1rem;
+                  font-family: $font-family-mono;
+                  font-size: $font-size-body-lg;
                   font-weight: 700;
                   color: $text-primary;
                   margin-bottom: 2px;
@@ -266,15 +268,15 @@
             padding: 6px $spacing-sm;
 
             .dtc-code {
-              font-family: monospace;
-              font-size: 0.85rem;
+              font-family: $font-family-mono;
+              font-size: $font-size-body-md;
               font-weight: 700;
               color: $color-warning;
               white-space: nowrap;
             }
 
             .dtc-desc {
-              font-size: 0.85rem;
+              font-size: $font-size-body-md;
               color: $text-secondary;
             }
           }
@@ -288,7 +290,7 @@
           gap: 4px;
 
           li {
-            font-size: 0.875rem;
+            font-size: $font-size-body-md;
             color: $text-secondary;
           }
 
@@ -346,69 +348,55 @@
 
   .btn-primary {
     background: linear-gradient(135deg, $color-success, color-mix(in srgb, $color-success, black 20%));
-    color: white;
-    padding: 12px 24px;
-    border-radius: 8px;
+    color: #000;
+    padding: $spacing-sm $spacing-xl;
+    border-radius: $radius-md;
     border: none;
+    font-size: $font-size-body-md;
     font-weight: 700;
     cursor: pointer;
     box-shadow: 0 4px 15px rgba($color-success, 0.3);
-    transition: all 0.2s;
+    transition: transform 0.2s, box-shadow 0.2s;
 
-    &:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 6px 20px rgba($color-success, 0.4);
-    }
-
-    &:disabled {
-      opacity: 0.5;
-      transform: none;
-      cursor: not-allowed;
-      box-shadow: none;
-    }
+    &:hover { transform: translateY(-1px); box-shadow: 0 6px 20px rgba($color-success, 0.4); }
+    &:disabled { opacity: 0.5; transform: none; cursor: not-allowed; box-shadow: none; }
   }
 
   .btn-secondary {
     background: rgba($color-success, 0.1);
     color: $color-success;
-    border: 1px solid $color-success;
-    padding: 8px 16px;
-    border-radius: 6px;
-    cursor: pointer;
+    border: 1px solid rgba($color-success, 0.4);
+    padding: 6px $spacing-md;
+    border-radius: $radius-sm;
+    font-size: $font-size-body-md;
     font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s;
 
-    &:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
+    &:hover { background: rgba($color-success, 0.18); }
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
   }
 
   .btn-outline {
     background: transparent;
     color: $text-secondary;
     border: 1px solid $border-color;
-    padding: 8px 16px;
-    border-radius: 6px;
+    padding: 6px $spacing-md;
+    border-radius: $radius-sm;
+    font-size: $font-size-body-md;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: border-color 0.2s, color 0.2s;
 
-    &:hover {
-      border-color: $text-primary;
-      color: $text-primary;
-    }
-
-    &:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
+    &:hover { border-color: $text-primary; color: $text-primary; }
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
   }
 
   .btn-cancel {
     background: transparent;
     color: $color-critical;
     border: none;
-    padding: 8px;
-    font-size: 0.85rem;
+    padding: $spacing-xs $spacing-sm;
+    font-size: $font-size-body-md;
     cursor: pointer;
     text-decoration: underline;
     align-self: center;

--- a/src/app/shared/components/status-badge/status-badge.component.scss
+++ b/src/app/shared/components/status-badge/status-badge.component.scss
@@ -1,16 +1,22 @@
 @use '../../../../styles/variables' as *;
 
-.badge { 
-  padding: 4px 8px; 
-  border-radius: $radius-sm; 
-  font-size: $font-size-xs; 
-  font-weight: bold; 
-  display: inline-block;
+.badge {
+  padding: 2px 8px;
+  border-radius: $radius-sm;
+  font-size: $font-size-label-sm;
+  font-weight: 700;
+  font-family: $font-family;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
 
-  &.disconnected { background: $bg-hover; color: $text-primary; }
-  &.connecting { background: $color-warning; color: $text-primary; }
-  &.connected { background: $color-success; color: $text-primary; }
-  &.warning { background: $color-warning; color: $text-dark; }
-  &.critical { background: $color-critical; color: $text-primary; }
-  &.info { background: $color-info; color: $text-primary; }
+  &.disconnected { background: $bg-tertiary;     color: $text-muted;     border: 1px solid $border-color; }
+  &.connecting   { background: rgba($color-warning,  0.15); color: $color-warning;  border: 1px solid rgba($color-warning,  0.4); }
+  &.connected    { background: rgba($color-success,  0.15); color: $color-success;  border: 1px solid rgba($color-success,  0.4); }
+  &.pass         { background: rgba($color-success,  0.15); color: $color-success;  border: 1px solid rgba($color-success,  0.4); }
+  &.warning      { background: rgba($color-warning,  0.15); color: $color-warning;  border: 1px solid rgba($color-warning,  0.4); }
+  &.critical     { background: rgba($color-critical, 0.15); color: $color-critical; border: 1px solid rgba($color-critical, 0.4); }
+  &.info         { background: rgba($color-info,     0.15); color: $color-info;     border: 1px solid rgba($color-info,     0.4); }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,7 +6,7 @@ body {
   padding: 0;
   background-color: $bg-primary;
   color: $text-primary;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-family: $font-family;
 }
 
 * {
@@ -14,12 +14,16 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  margin-top: 0;
+  margin: 0;
+  line-height: 1.25;
   color: $text-primary;
+  font-family: $font-family;
 }
 
 p {
+  margin: 0;
   color: $text-secondary;
+  line-height: 1.5;
 }
 
 a {
@@ -33,14 +37,15 @@ a {
 
 // Global button styles
 button, .btn {
-  padding: $spacing-sm $spacing-lg;
+  padding: 6px $spacing-md;
   border: none;
   border-radius: $radius-sm;
   cursor: pointer;
-  font-weight: bold;
-  font-size: $font-size-md;
+  font-weight: 600;
+  font-size: $font-size-body-md;
+  font-family: $font-family;
   color: $text-primary;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, box-shadow 0.2s;
 
   &.btn-primary {
     background-color: $color-success;


### PR DESCRIPTION
## Summary

- **#97 Layout system** — Inter font wired to `$font-family` global, button scale standardised to 8pt grid, heading margins zeroed
- **#98 Badge/button/metric tokens** — `StatusBadge` rewritten with tonal backgrounds + outline borders; all button variants and metric cards use design-token sizes and colours
- **#99 Diagnosis report hierarchy** — severity score enlarged (2rem), section gaps 32px, all `#2196f3` occurrences replaced with `$color-info`; report card headers tinted
- **#100 Live-diagnosis panel** — chart height 80 → 140px, live metrics panel uses `$surface-container`/`$bg-secondary` surfaces, section title elevated to `$text-primary`
- **#101 Dark theme contrast** — every remaining raw `px`/`rem` font size in guided-tests SCSS replaced with `$font-size-*` design tokens

## Build
`ng build` passes (warnings are pre-existing budget overages, no errors introduced).

## Test plan
- [ ] Visit `/guided-tests` — metric cards, badge, progress text, result cards all use token-derived sizes
- [ ] Visit `/diagnosis-report` — severity score large and legible, section headers clearly distinct
- [ ] Toggle connection — StatusBadge colour states (connecting/connected/disconnected) render correctly
- [ ] No console errors or TypeScript errors