### PR TITLE
Add smart test orchestration to optimize diagnostic flow

### DIFF
--- a/src/app/core/diagnostics/deep-diagnosis.service.ts
+++ b/src/app/core/diagnostics/deep-diagnosis.service.ts
@@ -18,6 +18,7 @@ import { DiagnosisTimelineService } from './intelligence/diagnosis-timeline.serv
 import { DriveSignatureService } from './intelligence/drive-signature.service';
 import { EvidenceGraphService } from './intelligence/evidence-graph.service';
 import { CorrelationFinding, DiagnosisSeverity, DiagnosisRecommendation, DiagnosisSummary, DriveSignature, HypothesisReport, TimelineEvent } from './intelligence/diagnosis-intelligence.models';
+import { SmartTestOrchestratorService, TestPlan } from '../test-orchestrator/smart-test-orchestrator.service';
 
 export type DiagnosisStepId =
   | 'baseline_scan'
@@ -47,6 +48,7 @@ export interface DeepDiagnosisState {
   timelineEvents?: TimelineEvent[];
   driveSignature?: DriveSignature;
   hypothesisReport?: HypothesisReport;
+  testPlan?: TestPlan;
 }
 
 @Injectable({
@@ -82,6 +84,7 @@ export class DeepDiagnosisService {
     private timeline: DiagnosisTimelineService,
     private driveSignatureService: DriveSignatureService,
     private evidenceGraphService: EvidenceGraphService,
+    private smartOrchestrator: SmartTestOrchestratorService,
   ) {}
 
   public startDiagnosis(): void {
@@ -163,11 +166,16 @@ export class DeepDiagnosisService {
           if (!this.sessionActive) return;
           await this.retrieveAndDecodeDtcs();
           if (!this.sessionActive) return;
-          if (latestFrame) {
-            latestFrame.coolantTemp < 70 ? this.runWarmupMonitoring() : this.runIdleTest();
-          } else {
+          if (!latestFrame) {
             this.handleError('No data received during baseline scan.');
+            return;
           }
+          const plan = this.smartOrchestrator.buildPlan(
+            this.stateSubject.value.dtcCodes ?? [],
+            latestFrame
+          );
+          this.updateState({ testPlan: plan });
+          latestFrame.coolantTemp < 70 ? this.runWarmupMonitoring() : this.runFirstStep(plan);
         }
       })
     );
@@ -199,7 +207,9 @@ export class DeepDiagnosisService {
           this.updateState({ progress: Math.min(Math.round((elapsed / timeoutMs) * 100), 100) });
           if (frame.coolantTemp >= 75 || elapsed >= timeoutMs) {
             this.recordResult(warmupTest.evaluate(collectedFrames));
-            this.startTransition('Warm-up complete. Moving to Idle Test...', 'idle_test');
+            const plan = this.stateSubject.value.testPlan;
+            const nextStep = plan?.runIdleTest ?? true ? 'idle_test' : 'driving_prompt';
+            this.startTransition('Warm-up complete. Moving to next step...', nextStep);
           }
         })
       ).subscribe()
@@ -250,8 +260,12 @@ export class DeepDiagnosisService {
           summaryLower.includes('rich') || result.details?.some(d => d.toLowerCase().includes('trim'))
         );
 
+        // Use the pre-computed plan when available; fall back to trim heuristic
+        const plan = this.stateSubject.value.testPlan;
+        const runRev = plan ? plan.runRevTest : abnormalTrims;
+
         this.clearStepSubscriptions();
-        abnormalTrims ? this.runRevTest() : this.runDrivingPrompt();
+        runRev ? this.runRevTest() : this.runDrivingPrompt();
       })
     );
   }
@@ -409,10 +423,16 @@ export class DeepDiagnosisService {
     if (!this.sessionActive) return;
     const target = this.nextTargetStep;
     this.nextTargetStep = null;
-    if (target === 'idle_test')       this.runIdleTest();
-    else if (target === 'rev_test')   this.runRevTest();
+    if (target === 'idle_test')           this.runIdleTest();
+    else if (target === 'rev_test')       this.runRevTest();
     else if (target === 'driving_prompt') this.runDrivingPrompt();
-    else this.aggregateResults();
+    else                                  this.aggregateResults();
+  }
+
+  private runFirstStep(plan: TestPlan): void {
+    if (plan.runIdleTest) this.runIdleTest();
+    else if (plan.runRevTest) this.runRevTest();
+    else this.runDrivingPrompt();
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────

--- a/src/app/core/test-orchestrator/smart-test-orchestrator.service.ts
+++ b/src/app/core/test-orchestrator/smart-test-orchestrator.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@angular/core';
+import { DtcCode } from '../diagnostics/dtc/dtc-code.model';
+import { ObdLiveFrame } from '../models/obd-live-frame.model';
+import { DiagnosisStepId } from '../diagnostics/deep-diagnosis.service';
+
+export interface TestPlan {
+  runIdleTest: boolean;
+  runRevTest: boolean;
+  skippedSteps: DiagnosisStepId[];
+  priorityRationale: string[];
+}
+
+type DtcCategory = 'lean' | 'rich' | 'misfire' | 'maf' | 'catalyst' | 'other';
+
+@Injectable({ providedIn: 'root' })
+export class SmartTestOrchestratorService {
+
+  buildPlan(dtcCodes: DtcCode[], baselineFrame: ObdLiveFrame | null): TestPlan {
+    const categories = this.categorizeDtcs(dtcCodes);
+    const rationale: string[] = [];
+    const skippedSteps: DiagnosisStepId[] = [];
+
+    // Catalyst-only: idle/rev add no diagnostic value — skip both and go to driving
+    if (categories.has('catalyst') && categories.size === 1) {
+      skippedSteps.push('idle_test', 'rev_test');
+      rationale.push('Catalyst efficiency fault only — driving analysis is the most diagnostic next step; idle and rev tests skipped.');
+      return { runIdleTest: false, runRevTest: false, skippedSteps, priorityRationale: rationale };
+    }
+
+    const runIdleTest = this.needsIdleTest(categories, baselineFrame, rationale);
+    const runRevTest = this.needsRevTest(categories, rationale);
+
+    if (!runIdleTest) skippedSteps.push('idle_test');
+    if (!runRevTest) skippedSteps.push('rev_test');
+
+    // Flag critical combinations so the UI can surface urgency
+    if (categories.has('misfire') && (categories.has('lean') || categories.has('rich'))) {
+      rationale.push('Critical combination: misfire with fuel fault — unburned fuel may degrade the catalytic converter. Idle test prioritized.');
+    }
+
+    return { runIdleTest, runRevTest, skippedSteps, priorityRationale: rationale };
+  }
+
+  private needsIdleTest(
+    categories: Set<DtcCategory>,
+    frame: ObdLiveFrame | null,
+    rationale: string[]
+  ): boolean {
+    if (categories.has('lean') || categories.has('rich') || categories.has('misfire')) {
+      rationale.push('Idle test included: fuel trim or misfire DTCs require stationary RPM/trim baseline.');
+      return true;
+    }
+    if (frame && (Math.abs(frame.stftB1) > 8 || Math.abs(frame.ltftB1) > 8)) {
+      rationale.push('Idle test included: baseline frame shows elevated fuel trims before any DTC is set.');
+      return true;
+    }
+    if (categories.size === 0) {
+      rationale.push('No DTCs detected — idle test included as standard health check.');
+      return true;
+    }
+    // MAF or other without fuel trim anomaly: skip idle, go straight to rev or driving
+    rationale.push('Idle test skipped: no fuel trim or misfire indicators present.');
+    return false;
+  }
+
+  private needsRevTest(categories: Set<DtcCategory>, rationale: string[]): boolean {
+    if (categories.has('lean')) {
+      rationale.push('Rev test included: lean DTCs require load-differential trim comparison to distinguish vacuum leak from fuel delivery fault.');
+      return true;
+    }
+    if (categories.has('maf')) {
+      rationale.push('Rev test included: MAF fault needs RPM-differential airflow response analysis.');
+      return true;
+    }
+    if (categories.has('misfire') && categories.has('rich')) {
+      rationale.push('Rev test included: misfire with rich condition requires load-based evaluation.');
+      return true;
+    }
+    return false;
+  }
+
+  private categorizeDtcs(dtcCodes: DtcCode[]): Set<DtcCategory> {
+    const categories = new Set<DtcCategory>();
+    for (const dtc of dtcCodes) {
+      const code = dtc.code;
+      if (code === 'P0171' || code === 'P0174')              categories.add('lean');
+      else if (code === 'P0172' || code === 'P0175')         categories.add('rich');
+      else if (code >= 'P0300' && code <= 'P0304')           categories.add('misfire');
+      else if (code >= 'P0100' && code <= 'P0104')           categories.add('maf');
+      else if (code === 'P0420' || code === 'P0430')         categories.add('catalyst');
+      else                                                    categories.add('other');
+    }
+    return categories;
+  }
+}


### PR DESCRIPTION
## Summary
Introduces intelligent test planning to the diagnostic workflow by analyzing DTC codes and baseline telemetry to determine which tests are necessary, reducing unnecessary steps and improving diagnostic efficiency.

## Key Changes
- **New SmartTestOrchestratorService**: Analyzes DTC codes and baseline OBD frames to build an optimized `TestPlan` that determines whether idle and rev tests should be run
  - Categorizes DTCs into fuel trim (lean/rich), misfire, MAF, catalyst, and other faults
  - Skips idle/rev tests for catalyst-only faults (driving analysis is more diagnostic)
  - Includes idle test for fuel trim or misfire DTCs, or when baseline frame shows elevated fuel trims
  - Includes rev test for lean DTCs (to distinguish vacuum leak from fuel delivery), MAF faults, or misfire+rich combinations
  - Generates diagnostic rationale for each decision to surface in the UI

- **Updated DeepDiagnosisService**: Integrates test planning into the diagnostic flow
  - Calls `smartOrchestrator.buildPlan()` after baseline scan and DTC retrieval
  - Stores the `TestPlan` in diagnostic state
  - Routes to the first appropriate test based on the plan (idle → rev → driving) instead of always starting with idle
  - Uses pre-computed plan decisions instead of heuristic-based trim analysis when available
  - Adds `runFirstStep()` helper to execute the initial test from the plan

## Notable Implementation Details
- Test plan is computed once after baseline scan and reused throughout the session
- Catalyst-only faults trigger an early exit to driving analysis, skipping stationary tests entirely
- Critical combinations (misfire + fuel fault) are flagged in rationale for UI urgency signaling
- Fallback to trim-based heuristic preserved for backward compatibility if plan is unavailable
- Warm-up monitoring now routes to the planned next step rather than hardcoded idle test

https://claude.ai/code/session_013VnTcHCQ6R9TJMxuc5d4QB