### PR TITLE
feat(intelligence): Intelligence Upgrade — root cause inference, confidence scoring, test orchestration, repair insights (#103-#107)

### DIFF
--- a/src/app/core/diagnostics/deep-diagnosis.service.ts
+++ b/src/app/core/diagnostics/deep-diagnosis.service.ts
@@ -17,7 +17,10 @@ import { DiagnosticSummaryService } from './intelligence/diagnostic-summary.serv
 import { DiagnosisTimelineService } from './intelligence/diagnosis-timeline.service';
 import { DriveSignatureService } from './intelligence/drive-signature.service';
 import { EvidenceGraphService } from './intelligence/evidence-graph.service';
-import { CorrelationFinding, DiagnosisSeverity, DiagnosisRecommendation, DiagnosisSummary, DriveSignature, HypothesisReport, TimelineEvent } from './intelligence/diagnosis-intelligence.models';
+import { RootCauseInferenceService } from './intelligence/root-cause-inference.service';
+import { RepairInsightService } from './intelligence/repair-insight.service';
+import { TestOrchestratorService } from './intelligence/test-orchestrator.service';
+import { CorrelationFinding, DiagnosisSeverity, DiagnosisRecommendation, DiagnosisSummary, DriveSignature, HypothesisReport, RepairInsight, RootCauseCandidate, TestOrchestrationPlan, TimelineEvent } from './intelligence/diagnosis-intelligence.models';
 
 export type DiagnosisStepId =
   | 'baseline_scan'
@@ -47,6 +50,9 @@ export interface DeepDiagnosisState {
   timelineEvents?: TimelineEvent[];
   driveSignature?: DriveSignature;
   hypothesisReport?: HypothesisReport;
+  rootCauses?: RootCauseCandidate[];
+  repairInsights?: RepairInsight[];
+  testOrchestrationPlan?: TestOrchestrationPlan;
 }
 
 @Injectable({
@@ -70,6 +76,9 @@ export class DeepDiagnosisService {
   private idleFrames: ObdLiveFrame[] = [];
   private revFrames: ObdLiveFrame[] = [];
 
+  // Orchestration plan determined after baseline DTC scan
+  private orchestrationPlan: TestOrchestrationPlan | null = null;
+
   constructor(
     @Inject(OBD_ADAPTER) private obdAdapter: ObdAdapter,
     private guidedTestService: GuidedTestService,
@@ -82,6 +91,9 @@ export class DeepDiagnosisService {
     private timeline: DiagnosisTimelineService,
     private driveSignatureService: DriveSignatureService,
     private evidenceGraphService: EvidenceGraphService,
+    private rootCauseInference: RootCauseInferenceService,
+    private repairInsightService: RepairInsightService,
+    private testOrchestrator: TestOrchestratorService,
   ) {}
 
   public startDiagnosis(): void {
@@ -90,6 +102,7 @@ export class DeepDiagnosisService {
     this.stopSubject = new Subject<void>();
     this.idleFrames = [];
     this.revFrames = [];
+    this.orchestrationPlan = null;
     this.finalResultSubject.next(null);
     this.timeline.reset();
     this.stateSubject.next(this.getInitialState());
@@ -251,7 +264,14 @@ export class DeepDiagnosisService {
         );
 
         this.clearStepSubscriptions();
-        abnormalTrims ? this.runRevTest() : this.runDrivingPrompt();
+        const skipDriving = this.orchestrationPlan?.skipSteps.includes('driving_prompt') ?? false;
+        if (abnormalTrims) {
+          this.runRevTest();
+        } else if (skipDriving) {
+          this.aggregateResults();
+        } else {
+          this.runDrivingPrompt();
+        }
       })
     );
   }
@@ -294,7 +314,8 @@ export class DeepDiagnosisService {
           findings: result.status !== 'pass' ? [...s.findings, result.summary] : s.findings
         });
         this.clearStepSubscriptions();
-        this.runDrivingPrompt();
+        const skipDriving = this.orchestrationPlan?.skipSteps.includes('driving_prompt') ?? false;
+        skipDriving ? this.aggregateResults() : this.runDrivingPrompt();
       })
     );
   }
@@ -327,7 +348,8 @@ export class DeepDiagnosisService {
 
       const dtcCodes = this.dtcDecoder.decodeMany([...rawCodes], manufacturer);
       dtcCodes.filter(d => d.source === 'unknown').forEach(d => this.unknownDtcLogger.log(d.code));
-      this.updateState({ dtcCodes });
+      this.orchestrationPlan = this.testOrchestrator.plan(dtcCodes);
+      this.updateState({ dtcCodes, testOrchestrationPlan: this.orchestrationPlan });
     } catch {
       this.updateState({ dtcCodes: [] });
     }
@@ -354,6 +376,8 @@ export class DeepDiagnosisService {
     const contradictions = this.evidenceGraphService.detectContradictions(dtcCodes, this.idleFrames);
     const hypotheses     = this.evidenceGraphService.rankHypotheses(evidenceGraph);
     const hypothesisReport = this.evidenceGraphService.generateReport(hypotheses, contradictions);
+    const rootCauses     = this.rootCauseInference.infer(dtcCodes, correlationFindings, severity, driveSignature);
+    const repairInsights = this.repairInsightService.generate(dtcCodes, rootCauses, severity);
 
     let finalStatus: 'pass' | 'warning' | 'fail' = 'pass';
     if (state.results.some(r => r.status === 'fail') || dtcCodes.length > 0) {
@@ -377,7 +401,7 @@ export class DeepDiagnosisService {
     this.timeline.log('completed');
     const timelineEvents = this.timeline.getEvents();
     this.finalResultSubject.next(finalResult);
-    this.updateState({ status: 'completed', dtcFindings, correlationFindings, severity, recommendations, diagnosisSummary, timelineEvents, driveSignature, hypothesisReport });
+    this.updateState({ status: 'completed', dtcFindings, correlationFindings, severity, recommendations, diagnosisSummary, timelineEvents, driveSignature, hypothesisReport, rootCauses, repairInsights });
     this.sessionActive = false;
   }
 

--- a/src/app/core/diagnostics/deep-diagnosis.service.ts
+++ b/src/app/core/diagnostics/deep-diagnosis.service.ts
@@ -265,13 +265,12 @@ export class DeepDiagnosisService {
 
         this.clearStepSubscriptions();
         const skipDriving = this.orchestrationPlan?.skipSteps.includes('driving_prompt') ?? false;
-        if (abnormalTrims) {
-          this.runRevTest();
-        } else if (skipDriving) {
-          this.aggregateResults();
-        } else {
-          this.runDrivingPrompt();
-        }
+        // P1 fix: always run rev test before aggregation when driving is skipped — rev frames are
+        //         required for idle-vs-rev comparisons (MAF noResponse, lean pattern, etc.)
+        // P2 fix: misfire focusArea forces rev test even when idle trims look normal, giving the
+        //         orchestrator a unique control signal beyond the shared skipSteps: [] value
+        const forceRevTest = abnormalTrims || skipDriving || this.orchestrationPlan?.focusArea === 'misfire';
+        forceRevTest ? this.runRevTest() : this.runDrivingPrompt();
       })
     );
   }

--- a/src/app/core/diagnostics/intelligence/diagnosis-intelligence.models.ts
+++ b/src/app/core/diagnostics/intelligence/diagnosis-intelligence.models.ts
@@ -1,9 +1,12 @@
 import { DiagnosisStepId } from '../deep-diagnosis.service';
 
+export type ConfidenceLevel = 'Low' | 'Medium' | 'High';
+
 export interface CorrelationFinding {
   codes: string[];
   message: string;
   upgradesSeverity: boolean;
+  confidence?: ConfidenceLevel;
 }
 
 export interface DiagnosisSeverity {
@@ -82,4 +85,39 @@ export interface HypothesisReport {
   hypotheses: Hypothesis[];
   contradictions: ContradictionFinding[];
   generatedAt: number;
+}
+
+// ── #103 Root Cause Inference ─────────────────────────────────────────────────
+
+export interface RootCauseCandidate {
+  rank: number;
+  title: string;
+  explanation: string;
+  confidence: ConfidenceLevel;
+  supportingEvidence: string[];
+}
+
+// ── #106 Test Orchestration ───────────────────────────────────────────────────
+
+export interface TestOrchestrationPlan {
+  skipSteps: import('../deep-diagnosis.service').DiagnosisStepId[];
+  focusArea: 'general' | 'fuel-trim' | 'misfire' | 'maf' | 'idle';
+  priorityReason: string;
+}
+
+// ── #107 Repair Insight ───────────────────────────────────────────────────────
+
+export interface RepairStep {
+  stepNumber: number;
+  action: string;
+  toolRequired?: string;
+}
+
+export interface RepairInsight {
+  category: string;
+  title: string;
+  steps: RepairStep[];
+  estimatedTime: string;
+  difficulty: 'Easy' | 'Moderate' | 'Professional';
+  urgency: 'Monitor' | 'Soon' | 'Urgent' | 'Critical';
 }

--- a/src/app/core/diagnostics/intelligence/dtc-correlation.service.ts
+++ b/src/app/core/diagnostics/intelligence/dtc-correlation.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { DtcCode } from '../dtc/dtc-code.model';
 import { ObdLiveFrame } from '../../models/obd-live-frame.model';
-import { CorrelationFinding } from './diagnosis-intelligence.models';
+import { ConfidenceLevel, CorrelationFinding } from './diagnosis-intelligence.models';
 
 @Injectable({ providedIn: 'root' })
 export class DtcCorrelationService {
@@ -15,19 +15,22 @@ export class DtcCorrelationService {
 
     const findings: CorrelationFinding[] = [];
     const codes = new Set(dtcCodes.map(c => c.code));
+    const hasIdleData = idleFrames.length > 0;
+    const hasRevData  = revFrames.length > 0;
 
     // ── Lean condition: P0171 / P0174 ────────────────────────────────────────
     const leanCodes = ['P0171', 'P0174'].filter(c => codes.has(c));
     if (leanCodes.length) {
-      const idleStft = idleFrames.length ? this.avg(idleFrames.map(f => f.stftB1)) : null;
+      const idleStft = hasIdleData ? this.avg(idleFrames.map(f => f.stftB1)) : null;
       if (idleStft === null) {
         findings.push({
           codes: leanCodes,
           message: `${leanCodes.join(', ')}: Lean code present but no idle frame data captured — cannot confirm with live trims. Evaluate under test conditions.`,
           upgradesSeverity: false,
+          confidence: 'Low',
         });
       } else if (idleStft > 10) {
-        const revStft = revFrames.length ? this.avg(revFrames.map(f => f.stftB1)) : null;
+        const revStft = hasRevData ? this.avg(revFrames.map(f => f.stftB1)) : null;
         if (revStft !== null && revStft < 5) {
           findings.push({
             codes: leanCodes,
@@ -35,6 +38,7 @@ export class DtcCorrelationService {
               `${leanCodes.join(', ')}: Lean at idle, trims normalise under load — vacuum leak pattern. ` +
               'Inspect intake hoses, PCV valve, and intake manifold gaskets.',
             upgradesSeverity: true,
+            confidence: 'High',
           });
         } else {
           findings.push({
@@ -43,6 +47,7 @@ export class DtcCorrelationService {
               `${leanCodes.join(', ')}: Lean condition across RPM range — possible fuel delivery fault or contaminated MAF sensor. ` +
               'Check fuel pressure and MAF sensor.',
             upgradesSeverity: true,
+            confidence: hasRevData ? 'High' : 'Medium',
           });
         }
       } else {
@@ -50,6 +55,7 @@ export class DtcCorrelationService {
           codes: leanCodes,
           message: `${leanCodes.join(', ')}: Lean code present but trims within normal range during test — condition may be intermittent.`,
           upgradesSeverity: false,
+          confidence: 'Medium',
         });
       }
     }
@@ -57,12 +63,13 @@ export class DtcCorrelationService {
     // ── Rich condition: P0172 / P0175 ────────────────────────────────────────
     const richCodes = ['P0172', 'P0175'].filter(c => codes.has(c));
     if (richCodes.length) {
-      const idleStft = idleFrames.length ? this.avg(idleFrames.map(f => f.stftB1)) : null;
+      const idleStft = hasIdleData ? this.avg(idleFrames.map(f => f.stftB1)) : null;
       if (idleStft === null) {
         findings.push({
           codes: richCodes,
           message: `${richCodes.join(', ')}: Rich code present but no idle frame data captured — cannot confirm with live trims. Inspect fuel injectors and check fuel pressure.`,
           upgradesSeverity: false,
+          confidence: 'Low',
         });
       } else {
         const confirmed = idleStft < -10;
@@ -72,6 +79,7 @@ export class DtcCorrelationService {
             ? `${richCodes.join(', ')}: Rich condition confirmed — possible leaking injector, high fuel pressure, or faulty coolant temp sensor.`
             : `${richCodes.join(', ')}: Rich code present but trims within normal range during test — inspect fuel injectors and check fuel pressure.`,
           upgradesSeverity: confirmed,
+          confidence: confirmed ? 'High' : 'Medium',
         });
       }
     }
@@ -85,6 +93,7 @@ export class DtcCorrelationService {
           codes: misfireCodes,
           message: `${misfireCodes.join(', ')}: Misfire code present but insufficient idle data to evaluate RPM stability — inspect spark plugs and coils.`,
           upgradesSeverity: false,
+          confidence: 'Low',
         });
       } else {
         const active = rpmStdDev > 80;
@@ -95,6 +104,7 @@ export class DtcCorrelationService {
               'Inspect spark plugs, ignition coils, and fuel injectors.'
             : `${misfireCodes.join(', ')}: Misfire code present but RPM stable during test — condition may be intermittent. Inspect spark plugs and coils.`,
           upgradesSeverity: active,
+          confidence: active ? 'High' : 'Medium',
         });
       }
     }
@@ -104,11 +114,12 @@ export class DtcCorrelationService {
     if (mafCodes.length) {
       const idleMaf  = idleFrames.filter(f => f.maf != null).map(f => f.maf!);
       const revMaf   = revFrames.filter(f => f.maf != null).map(f => f.maf!);
-      const rpmIdle  = idleFrames.length ? this.avg(idleFrames.map(f => f.rpm)) : 0;
-      const rpmRev   = revFrames.length  ? this.avg(revFrames.map(f => f.rpm))  : 0;
+      const rpmIdle  = hasIdleData ? this.avg(idleFrames.map(f => f.rpm)) : 0;
+      const rpmRev   = hasRevData  ? this.avg(revFrames.map(f => f.rpm))  : 0;
       const noResponse = idleMaf.length > 0 && revMaf.length > 0 &&
                          rpmRev > rpmIdle + 500 &&
                          this.avg(revMaf) < this.avg(idleMaf) * 1.3;
+      const mafConfidence: ConfidenceLevel = noResponse ? 'High' : hasIdleData ? 'Medium' : 'Low';
       findings.push({
         codes: mafCodes,
         message: noResponse
@@ -116,6 +127,7 @@ export class DtcCorrelationService {
             'Inspect air filter and MAF sensor wiring.'
           : `${mafCodes.join(', ')}: MAF code detected — clean or replace MAF sensor, inspect air filter.`,
         upgradesSeverity: noResponse,
+        confidence: mafConfidence,
       });
     }
 
@@ -128,6 +140,7 @@ export class DtcCorrelationService {
           `${catCodes.join(', ')}: Catalyst efficiency below threshold. ` +
           'Compare upstream/downstream O2 sensor waveforms and check for oil or coolant burning.',
         upgradesSeverity: false,
+        confidence: 'Low',
       });
     }
 
@@ -144,6 +157,7 @@ export class DtcCorrelationService {
         codes: ['P0171', 'P0101'],
         message: 'P0171 + P0101: Combined lean and MAF fault — likely air intake or airflow restriction. Inspect MAF sensor, air filter, and intake ducts for leaks.',
         upgradesSeverity: true,
+        confidence: 'High',
       });
     }
 
@@ -152,6 +166,7 @@ export class DtcCorrelationService {
         codes: ['P0300', 'P0171'],
         message: 'P0300 + P0171: Random misfire with lean condition — lean fuel mixture likely starving cylinders. Resolve lean fault first; inspect fuel delivery and vacuum integrity.',
         upgradesSeverity: true,
+        confidence: 'High',
       });
     }
 
@@ -160,6 +175,7 @@ export class DtcCorrelationService {
         codes: ['P0300', 'P0172'],
         message: 'P0300 + P0172: Random misfire with rich condition — excess fuel may be washing cylinder walls. Inspect injectors and fuel pressure regulator.',
         upgradesSeverity: true,
+        confidence: 'High',
       });
     }
 
@@ -168,6 +184,7 @@ export class DtcCorrelationService {
         codes: ['P0420', 'P0300'],
         message: 'P0420 + P0300: Catalyst inefficiency alongside misfire — unburned fuel from misfires may be degrading the catalytic converter. Resolve misfire fault first.',
         upgradesSeverity: false,
+        confidence: 'High',
       });
     }
 

--- a/src/app/core/diagnostics/intelligence/repair-insight.service.ts
+++ b/src/app/core/diagnostics/intelligence/repair-insight.service.ts
@@ -1,0 +1,138 @@
+import { Injectable } from '@angular/core';
+import { DtcCode } from '../dtc/dtc-code.model';
+import { DiagnosisSeverity, RepairInsight, RootCauseCandidate } from './diagnosis-intelligence.models';
+
+@Injectable({ providedIn: 'root' })
+export class RepairInsightService {
+
+  generate(
+    dtcCodes: DtcCode[],
+    rootCauses: RootCauseCandidate[],
+    severity: DiagnosisSeverity
+  ): RepairInsight[] {
+    const codes = new Set(dtcCodes.map(c => c.code));
+    const isUrgent = severity.level === 'High' || severity.level === 'Critical';
+    const insights: RepairInsight[] = [];
+
+    for (const cause of rootCauses) {
+      if (cause.title.includes('Vacuum') || cause.title.includes('Intake Leak')) {
+        insights.push({
+          category: 'Intake System',
+          title: 'Locate and Seal Vacuum Leak',
+          steps: [
+            { stepNumber: 1, action: 'Visually inspect all vacuum hoses and intake ducting for cracks or loose clamps' },
+            { stepNumber: 2, action: 'Perform smoke test on intake manifold with engine running', toolRequired: 'Smoke machine' },
+            { stepNumber: 3, action: 'Check PCV valve and breather hose for deterioration — replace if collapsed or cracked' },
+            { stepNumber: 4, action: 'Inspect intake manifold gaskets at cylinder head mating surface for leaks' },
+            { stepNumber: 5, action: 'Clear DTCs after repair and verify STFT returns to ±5% at idle', toolRequired: 'OBD scan tool' },
+          ],
+          estimatedTime: '1–3 hours',
+          difficulty: 'Moderate',
+          urgency: isUrgent ? 'Urgent' : 'Soon',
+        });
+      }
+
+      if (cause.title.includes('Fuel Delivery')) {
+        insights.push({
+          category: 'Fuel System',
+          title: 'Inspect Fuel Delivery System',
+          steps: [
+            { stepNumber: 1, action: 'Measure fuel rail pressure at idle — spec is typically 40–60 psi', toolRequired: 'Fuel pressure gauge' },
+            { stepNumber: 2, action: 'Check pressure hold after engine off — should hold >30 psi for 5 minutes (rules out leaking injector or regulator)' },
+            { stepNumber: 3, action: 'Inspect fuel filter for restriction — replace if mileage exceeds service interval' },
+            { stepNumber: 4, action: 'Test fuel pump current draw — high current indicates a failing pump', toolRequired: 'Clamp ammeter' },
+          ],
+          estimatedTime: '1–2 hours',
+          difficulty: 'Moderate',
+          urgency: isUrgent ? 'Urgent' : 'Soon',
+        });
+      }
+
+      if (cause.title.includes('Rich') || cause.title.includes('Leaking Injector')) {
+        insights.push({
+          category: 'Fuel System',
+          title: 'Diagnose Rich Fuel Condition',
+          steps: [
+            { stepNumber: 1, action: 'Check fuel pressure regulator — remove vacuum line, fuel should not drip from port' },
+            { stepNumber: 2, action: 'Perform injector leak-down test with fuel pump running and ignition off', toolRequired: 'Injector tester' },
+            { stepNumber: 3, action: 'Monitor LTFT and STFT after extended idle — negative values confirm rich condition' },
+            { stepNumber: 4, action: 'Check for engine oil with petrol smell — a sign of injectors flooding cylinders' },
+            { stepNumber: 5, action: 'Verify coolant temp sensor reading is accurate — faulty ECT causes rich running when cold', toolRequired: 'Multimeter' },
+          ],
+          estimatedTime: '1–2 hours',
+          difficulty: 'Moderate',
+          urgency: 'Soon',
+        });
+      }
+
+      if (cause.title.includes('Misfire')) {
+        insights.push({
+          category: 'Ignition System',
+          title: 'Diagnose and Repair Misfire',
+          steps: [
+            { stepNumber: 1, action: 'Inspect all spark plugs for wear, fouling, or incorrect gap', toolRequired: 'Spark plug socket, feeler gauge' },
+            { stepNumber: 2, action: 'Swap ignition coil from suspect cylinder to a known-good cylinder and retest — if misfire follows coil, replace coil' },
+            { stepNumber: 3, action: 'Perform cylinder compression test — low compression indicates mechanical fault', toolRequired: 'Compression tester' },
+            { stepNumber: 4, action: 'Check injector pulse on misfiring cylinder using noid light', toolRequired: 'Noid light' },
+            { stepNumber: 5, action: 'Inspect for vacuum leaks at intake manifold on suspect cylinder' },
+          ],
+          estimatedTime: '2–4 hours',
+          difficulty: 'Moderate',
+          urgency: severity.level === 'Critical' ? 'Critical' : 'Urgent',
+        });
+      }
+
+      if (cause.title.includes('MAF')) {
+        insights.push({
+          category: 'Air Intake / Sensors',
+          title: 'Clean or Replace MAF Sensor',
+          steps: [
+            { stepNumber: 1, action: 'Remove MAF sensor from air intake pipe' },
+            { stepNumber: 2, action: 'Spray sensing element with MAF-safe cleaner — do NOT touch the wire element', toolRequired: 'MAF sensor cleaner spray' },
+            { stepNumber: 3, action: 'Reinstall and verify live MAF readings: ~2–3 g/s at idle, scales with RPM', toolRequired: 'OBD scan tool' },
+            { stepNumber: 4, action: 'If readings remain erratic or out-of-range, replace MAF sensor' },
+            { stepNumber: 5, action: 'Inspect air filter and intake duct for holes, blockages, or post-MAF leaks' },
+          ],
+          estimatedTime: '30–60 minutes',
+          difficulty: 'Easy',
+          urgency: 'Soon',
+        });
+      }
+
+      if (cause.title.includes('Catalytic')) {
+        insights.push({
+          category: 'Exhaust System',
+          title: 'Verify Catalyst Efficiency Before Replacement',
+          steps: [
+            { stepNumber: 1, action: 'Compare upstream vs downstream O2 sensor waveforms — downstream should be stable if catalyst is functioning', toolRequired: 'OBD scan tool' },
+            { stepNumber: 2, action: 'Check for oil or coolant burning — catalyst poisoning is a common cause of premature failure' },
+            { stepNumber: 3, action: 'Inspect catalyst for physical damage, rattle noise, or substrate meltdown (tap test)' },
+            { stepNumber: 4, action: 'If upstream and downstream waveforms mirror each other, replace catalytic converter' },
+            { stepNumber: 5, action: 'Resolve any misfire or rich condition first — running a damaged engine will destroy a new catalyst' },
+          ],
+          estimatedTime: '1–2 hours diagnosis; replacement 2–4 hours',
+          difficulty: 'Professional',
+          urgency: 'Monitor',
+        });
+      }
+    }
+
+    // Fallback when no root cause matches a specific repair template
+    if (!insights.length && dtcCodes.length) {
+      insights.push({
+        category: 'General',
+        title: 'Professional Diagnostic Scan Recommended',
+        steps: [
+          { stepNumber: 1, action: 'Perform full bi-directional scan to check all modules and freeze-frame data', toolRequired: 'Advanced scan tool' },
+          { stepNumber: 2, action: 'Review manufacturer service information for each stored DTC' },
+          { stepNumber: 3, action: 'Monitor live data during a road test to replicate fault conditions' },
+        ],
+        estimatedTime: '1–2 hours',
+        difficulty: 'Professional',
+        urgency: severity.level === 'Critical' ? 'Critical' : severity.level === 'High' ? 'Urgent' : 'Soon',
+      });
+    }
+
+    return insights;
+  }
+}

--- a/src/app/core/diagnostics/intelligence/root-cause-inference.service.ts
+++ b/src/app/core/diagnostics/intelligence/root-cause-inference.service.ts
@@ -1,0 +1,127 @@
+import { Injectable } from '@angular/core';
+import { DtcCode } from '../dtc/dtc-code.model';
+import { ConfidenceLevel, CorrelationFinding, DiagnosisSeverity, DriveSignature, RootCauseCandidate } from './diagnosis-intelligence.models';
+
+const CONFIDENCE_SCORE: Record<ConfidenceLevel, number> = { High: 3, Medium: 2, Low: 1 };
+
+@Injectable({ providedIn: 'root' })
+export class RootCauseInferenceService {
+
+  infer(
+    dtcCodes: DtcCode[],
+    correlationFindings: CorrelationFinding[],
+    severity: DiagnosisSeverity,
+    driveSignature?: DriveSignature
+  ): RootCauseCandidate[] {
+    const codes = new Set(dtcCodes.map(c => c.code));
+    const candidates: RootCauseCandidate[] = [];
+
+    const hasLean = codes.has('P0171') || codes.has('P0174');
+    const hasRich = codes.has('P0172') || codes.has('P0175');
+    const misfireCodes = dtcCodes.filter(c => /^P030[0-9]$/.test(c.code));
+    const mafCodes = dtcCodes.filter(c => /^P010[0-4]$/.test(c.code));
+    const hasCatalyst = codes.has('P0420') || codes.has('P0430');
+
+    const vacuumLeakPattern = correlationFindings.some(f => f.message.includes('vacuum leak pattern'));
+    const leanAcrossRpm = correlationFindings.some(f =>
+      f.message.includes('across RPM') || f.message.includes('fuel delivery fault') || f.message.includes('fuel delivery')
+    );
+    const idleUnstable = driveSignature ? driveSignature.idleStability.stdDev > 150 : false;
+
+    // ── Vacuum / intake leak ──────────────────────────────────────────────────
+    if (hasLean) {
+      candidates.push({
+        rank: 0,
+        title: 'Vacuum / Intake Leak',
+        explanation: vacuumLeakPattern
+          ? 'Lean condition at idle that normalises under load is the classic vacuum leak signature. Inspect intake hoses, PCV valve, and manifold gaskets.'
+          : 'Lean code present — possible intake air leak, low fuel pressure, or contaminated MAF sensor.',
+        confidence: vacuumLeakPattern ? 'High' : 'Medium',
+        supportingEvidence: [
+          ...dtcCodes.filter(c => ['P0171', 'P0174'].includes(c.code)).map(c => `${c.code}: ${c.title}`),
+          ...(vacuumLeakPattern ? ['STFT lean at idle, trims normalise at higher RPM'] : []),
+        ],
+      });
+    }
+
+    // ── Fuel delivery ─────────────────────────────────────────────────────────
+    if (hasLean && leanAcrossRpm) {
+      candidates.push({
+        rank: 0,
+        title: 'Fuel Delivery Fault',
+        explanation: 'Lean condition persists across the RPM range, suggesting insufficient fuel delivery. Check fuel pump pressure and injector flow.',
+        confidence: 'Medium',
+        supportingEvidence: ['Lean codes present', 'Trim correction persists across RPM range'],
+      });
+    }
+
+    // ── Rich injector / fuel mixture ──────────────────────────────────────────
+    if (hasRich) {
+      const confirmed = correlationFindings.some(f => f.upgradesSeverity && f.codes.some(c => ['P0172', 'P0175'].includes(c)));
+      candidates.push({
+        rank: 0,
+        title: 'Rich Fuel Mixture / Leaking Injector',
+        explanation: 'Rich condition detected. A leaking injector, faulty fuel pressure regulator, or excess fuel delivery is likely.',
+        confidence: confirmed ? 'High' : 'Medium',
+        supportingEvidence: dtcCodes.filter(c => ['P0172', 'P0175'].includes(c.code)).map(c => `${c.code}: ${c.title}`),
+      });
+    }
+
+    // ── Misfire / ignition ────────────────────────────────────────────────────
+    if (misfireCodes.length) {
+      const randomMisfire = misfireCodes.some(c => c.code === 'P0300');
+      candidates.push({
+        rank: 0,
+        title: 'Misfire / Ignition System Fault',
+        explanation: randomMisfire
+          ? 'Random multi-cylinder misfire. Could be worn spark plugs, a failing coil pack, or fuel delivery issue.'
+          : `Cylinder-specific misfire on ${misfireCodes.map(c => c.code).join(', ')}. Swap coil to isolate fault.`,
+        confidence: idleUnstable ? 'High' : 'Medium',
+        supportingEvidence: [
+          ...misfireCodes.map(c => `${c.code}: ${c.title}`),
+          ...(idleUnstable ? [`Idle RPM instability confirmed (σ = ${driveSignature!.idleStability.stdDev.toFixed(0)} RPM)`] : []),
+        ],
+      });
+    }
+
+    // ── MAF sensor ────────────────────────────────────────────────────────────
+    if (mafCodes.length) {
+      candidates.push({
+        rank: 0,
+        title: 'MAF Sensor Fault / Intake Restriction',
+        explanation: 'MAF sensor circuit or signal fault detected. Dirty element, air leaks downstream of MAF, or sensor failure.',
+        confidence: 'Medium',
+        supportingEvidence: mafCodes.map(c => `${c.code}: ${c.title}`),
+      });
+    }
+
+    // ── Catalytic converter ───────────────────────────────────────────────────
+    if (hasCatalyst) {
+      candidates.push({
+        rank: 0,
+        title: 'Catalytic Converter Degradation',
+        explanation: 'Catalyst efficiency below threshold. Compare O2 sensor waveforms before replacing — misfires or oil burning can trigger false P0420.',
+        confidence: 'Medium',
+        supportingEvidence: dtcCodes.filter(c => ['P0420', 'P0430'].includes(c.code)).map(c => `${c.code}: ${c.title}`),
+      });
+    }
+
+    // ── Fallback ──────────────────────────────────────────────────────────────
+    if (!candidates.length && dtcCodes.length) {
+      candidates.push({
+        rank: 1,
+        title: 'Unclassified Powertrain Fault',
+        explanation: `${dtcCodes.length} fault code${dtcCodes.length > 1 ? 's' : ''} detected. Review DTC descriptions for component-specific diagnostics.`,
+        confidence: 'Low',
+        supportingEvidence: dtcCodes.map(c => `${c.code}: ${c.title}`),
+      });
+    }
+
+    return candidates
+      .sort((a, b) =>
+        (CONFIDENCE_SCORE[b.confidence] - CONFIDENCE_SCORE[a.confidence]) ||
+        (b.supportingEvidence.length - a.supportingEvidence.length)
+      )
+      .map((c, i) => ({ ...c, rank: i + 1 }));
+  }
+}

--- a/src/app/core/diagnostics/intelligence/test-orchestrator.service.ts
+++ b/src/app/core/diagnostics/intelligence/test-orchestrator.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { DtcCode } from '../dtc/dtc-code.model';
+import { TestOrchestrationPlan } from './diagnosis-intelligence.models';
+import { DiagnosisStepId } from '../deep-diagnosis.service';
+
+@Injectable({ providedIn: 'root' })
+export class TestOrchestratorService {
+
+  plan(dtcCodes: DtcCode[]): TestOrchestrationPlan {
+    if (!dtcCodes.length) {
+      return {
+        skipSteps: [],
+        focusArea: 'general',
+        priorityReason: 'No fault codes detected — running full test sequence.',
+      };
+    }
+
+    const codes = new Set(dtcCodes.map(c => c.code));
+    const hasMisfire = dtcCodes.some(c => /^P030[0-9]$/.test(c.code));
+    const hasLean    = codes.has('P0171') || codes.has('P0174');
+    const hasRich    = codes.has('P0172') || codes.has('P0175');
+    const hasMaf     = dtcCodes.some(c => /^P010[0-4]$/.test(c.code));
+    const hasCatalyst = codes.has('P0420') || codes.has('P0430');
+
+    // Misfire codes → full sequence needed to characterise load behaviour
+    if (hasMisfire) {
+      return {
+        skipSteps: [],
+        focusArea: 'misfire',
+        priorityReason: 'Misfire code detected — full idle + rev + driving sequence required to characterise fault under load.',
+      };
+    }
+
+    // Lean / rich fuel codes → idle & rev tests provide all needed trim data
+    if (hasLean || hasRich) {
+      const skipSteps: DiagnosisStepId[] = ['driving_prompt'];
+      return {
+        skipSteps,
+        focusArea: 'fuel-trim',
+        priorityReason: `Fuel trim code${hasLean ? ' (lean)' : ''}${hasRich ? ' (rich)' : ''} detected — idle and rev tests capture key STFT/LTFT data. Road test skipped.`,
+      };
+    }
+
+    // MAF codes → idle + rev comparison sufficient
+    if (hasMaf) {
+      const skipSteps: DiagnosisStepId[] = ['driving_prompt'];
+      return {
+        skipSteps,
+        focusArea: 'maf',
+        priorityReason: 'MAF sensor code detected — idle and rev tests provide MAF g/s comparison data. Road test skipped.',
+      };
+    }
+
+    // Catalyst only → extended idle is most diagnostic
+    if (hasCatalyst) {
+      const skipSteps: DiagnosisStepId[] = ['driving_prompt'];
+      return {
+        skipSteps,
+        focusArea: 'idle',
+        priorityReason: 'Catalyst efficiency code detected — extended idle test is most diagnostic. Road test not required.',
+      };
+    }
+
+    // Mixed or unrecognised codes → run everything
+    return {
+      skipSteps: [],
+      focusArea: 'general',
+      priorityReason: 'Mixed or unrecognised fault codes — running full test sequence for complete diagnosis.',
+    };
+  }
+}


### PR DESCRIPTION
<img src="https://avatars.githubusercontent.com/u/11847006?v=4" width="32" height="32" style="border-radius:50%;vertical-align:middle;" /> **jawwadHussain**

## Summary

Four new intelligence services wired into the diagnosis pipeline, all rule-based with no AI/model calls.

- **#103 Root Cause Inference Engine** — `RootCauseInferenceService` ranks probable root causes from DTCs, correlation findings, severity, and drive signature. Covers vacuum leak, fuel delivery, rich injector, misfire/ignition, MAF sensor, and catalytic converter. Candidates sorted by confidence (`High → Medium → Low`) then evidence count. Exposed as `DeepDiagnosisState.rootCauses`.

- **#104 Confidence Scoring** — `ConfidenceLevel = 'Low' | 'Medium' | 'High'` type added to `CorrelationFinding`. `DtcCorrelationService` now stamps every finding: signal-confirmed → `High`, intermittent → `Medium`, no live frame data → `Low`. Multi-DTC patterns always emit `High`.

- **#105 Toyota DTC Support** — Already implemented (closed without code changes). `toyota-dtc-map.ts` and manufacturer-aware `DtcDecoderService` were in place.

- **#106 Smart Test Orchestration** — `TestOrchestratorService` builds a `TestOrchestrationPlan` after the baseline DTC scan. Skips `driving_prompt` for fuel-trim / MAF / catalyst codes; runs the full sequence for misfires; exposed as `DeepDiagnosisState.testOrchestrationPlan`. The plan is acted on in `DeepDiagnosisService` — `driving_prompt` is bypassed and `aggregateResults()` called directly when the orchestrator says to skip it.

- **#107 Repair Insight Layer** — `RepairInsightService` maps root cause candidates to structured repair plans. Each `RepairInsight` has: category, title, numbered steps (with optional tool required), estimated time, difficulty (`Easy / Moderate / Professional`), and urgency (`Monitor / Soon / Urgent / Critical`). Exposed as `DeepDiagnosisState.repairInsights`.

## Files changed

| File | Change |
|------|--------|
| `intelligence/diagnosis-intelligence.models.ts` | Added `ConfidenceLevel`, `RootCauseCandidate`, `TestOrchestrationPlan`, `RepairStep`, `RepairInsight` |
| `intelligence/root-cause-inference.service.ts` | New — rule-based root cause ranking |
| `intelligence/repair-insight.service.ts` | New — structured repair step generator |
| `intelligence/test-orchestrator.service.ts` | New — DTC-driven test sequence planner |
| `intelligence/dtc-correlation.service.ts` | Added `confidence` field to all `CorrelationFinding` outputs |
| `core/diagnostics/deep-diagnosis.service.ts` | Injected 3 new services; added `rootCauses`, `repairInsights`, `testOrchestrationPlan` to state; orchestrator-driven step skipping |

## Test plan
- [x] Run full diagnosis with mock adapter (fault mode active) — verify `rootCauses` populated in state
- [x] Confirm `correlationFindings` each have a `confidence` field
- [x] Verify `driving_prompt` step is skipped for lean/rich/MAF/catalyst-only DTCs
- [ ] Verify `driving_prompt` runs normally when misfire codes are present
- [ ] Confirm `repairInsights` populated with steps matching the top root cause
- [ ] `ng build` passes with no errors