### PR TITLE
Edge Case Handling Sprint (Issues #126–#130)

### DIFF
--- a/src/app/core/diagnostics/deep-diagnosis.service.ts
+++ b/src/app/core/diagnostics/deep-diagnosis.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject, OnDestroy } from '@angular/core';
 import { Observable, BehaviorSubject, Subject, Subscription, timer, combineLatest, of } from 'rxjs';
-import { takeUntil, map, first, tap, takeWhile, delay, catchError } from 'rxjs/operators';
+import { takeUntil, map, first, tap, takeWhile, delay, catchError, filter, distinctUntilChanged } from 'rxjs/operators';
 import { ObdAdapter, OBD_ADAPTER } from '../adapters/obd-adapter.interface';
 import { ObdLiveFrame } from '../models/obd-live-frame.model';
 import { GuidedTestService, GuidedTestResult } from './guided-test.service';
@@ -53,6 +53,10 @@ export interface DeepDiagnosisState {
   rootCauses?: RootCauseCandidate[];
   repairInsights?: RepairInsightReport;
   lastError?: AppError;
+  /** True when diagnosis completed with at least one step that could not finish */
+  isPartial?: boolean;
+  /** Which steps were skipped or incomplete, shown in the report */
+  incompleteSteps?: string[];
 }
 
 @Injectable({
@@ -114,6 +118,22 @@ export class DeepDiagnosisService implements OnDestroy {
     this.runGeneration++;
     this.timeline.reset();
     this.stateSubject.next(this.getInitialState());
+
+    // Cancel gracefully if the adapter disconnects mid-diagnosis
+    this.stepSubscription.add(
+      this.obdAdapter.connectionStatus$.pipe(
+        distinctUntilChanged(),
+        filter(status => status === 'disconnected' || status === 'error'),
+        first(),
+        takeUntil(this.stopSubject),
+      ).subscribe(() => {
+        if (this.sessionActive) {
+          const currentStep = this.stateSubject.value.currentStep;
+          this.aggregatePartialResults(currentStep, 'Adapter disconnected during diagnosis.');
+        }
+      })
+    );
+
     this.runBaselineScan();
   }
 
@@ -191,19 +211,21 @@ export class DeepDiagnosisService implements OnDestroy {
             const dtcCodes = this.stateSubject.value.dtcCodes ?? [];
             this.orchestrationPlan = this.testOrchestrator.plan(dtcCodes);
 
-            if (latestFrame) {
-              if (this.orchestrationPlan.skipSteps.includes('idle_test')) {
-                this.updateState({
-                  findings: this.orchestrationPlan.priorityReason
-                    ? [...this.stateSubject.value.findings, this.orchestrationPlan.priorityReason]
-                    : this.stateSubject.value.findings,
-                });
-                this.runDrivingPrompt();
-              } else {
-                latestFrame.coolantTemp < 70 ? this.runWarmupMonitoring() : this.runIdleTest();
-              }
+            const frameToUse = latestFrame ?? this.makeDefaultFrame();
+            if (!latestFrame) {
+              this.updateState({
+                findings: [...this.stateSubject.value.findings, 'No live data received during baseline scan — proceeding with limited information.'],
+              });
+            }
+            if (this.orchestrationPlan.skipSteps.includes('idle_test')) {
+              this.updateState({
+                findings: this.orchestrationPlan.priorityReason
+                  ? [...this.stateSubject.value.findings, this.orchestrationPlan.priorityReason]
+                  : this.stateSubject.value.findings,
+              });
+              this.runDrivingPrompt();
             } else {
-              this.handleStepFailure('baseline_scan', 'No data received during baseline scan.');
+              frameToUse.coolantTemp < 70 ? this.runWarmupMonitoring() : this.runIdleTest();
             }
           } catch (err) {
             this.handleStepFailure('baseline_scan', 'Failed to retrieve vehicle metadata.');
@@ -373,7 +395,7 @@ export class DeepDiagnosisService implements OnDestroy {
       this.stepRetryMap.set(step, retries + 1);
       this.timeline.log('error', `Retrying step ${step}: ${message}`);
       this.clearStepSubscriptions();
-      
+
       const generation = this.runGeneration;
       this.retryTimeoutId = setTimeout(() => {
         this.retryTimeoutId = null;
@@ -394,7 +416,8 @@ export class DeepDiagnosisService implements OnDestroy {
         timestamp: Date.now()
       };
       this.updateState({ lastError: error });
-      this.handleError(message);
+      // Produce a partial report with whatever data was collected so far
+      this.aggregatePartialResults(step, message);
     }
   }
 
@@ -409,6 +432,52 @@ export class DeepDiagnosisService implements OnDestroy {
   }
 
   // ── Result aggregation ───────────────────────────────────────────────────
+
+  private aggregatePartialResults(failedStep: DiagnosisStepId, reason: string): void {
+    if (!this.sessionActive) return;
+
+    const state = this.stateSubject.value;
+    const dtcCodes = state.dtcCodes ?? [];
+    const incompleteSteps = [...(state.incompleteSteps ?? []), failedStep];
+
+    // Run correlation on whatever frames were collected
+    const correlationFindings = this.dtcCorrelation.correlate(dtcCodes, this.idleFrames, this.revFrames);
+    const dtcFindings = correlationFindings.map(f => f.message);
+
+    const severity = this.severityEngine.score(
+      dtcCodes, correlationFindings,
+      this.revFrames[this.revFrames.length - 1] ?? this.idleFrames[this.idleFrames.length - 1] ?? null
+    );
+    const recommendations = this.recommendationEngine.recommend(dtcCodes, correlationFindings, severity.level);
+    const diagnosisSummary = this.summaryService.generate(correlationFindings, severity);
+
+    const dtcCount = dtcCodes.length;
+    const summary = `Partial diagnosis — step "${failedStep}" could not complete. ${dtcCount > 0 ? `${dtcCount} fault code${dtcCount !== 1 ? 's' : ''} detected.` : 'No fault codes detected.'}`;
+
+    const finalResult: GuidedTestResult = {
+      status: dtcCount > 0 || state.results.some(r => r.status === 'fail') ? 'fail'
+            : state.results.some(r => r.status === 'warning') ? 'warning' : 'warning',
+      summary,
+      details: [...state.findings, ...dtcFindings, `Incomplete: ${reason}`],
+      confidence: 0.5
+    };
+
+    this.timeline.log('error', `Partial: ${reason}`);
+    const timelineEvents = this.timeline.getEvents();
+    this.finalResultSubject.next(finalResult);
+    this.updateState({
+      status: 'completed',
+      dtcFindings,
+      correlationFindings,
+      severity,
+      recommendations,
+      diagnosisSummary,
+      timelineEvents,
+      isPartial: true,
+      incompleteSteps,
+    });
+    this.sessionActive = false;
+  }
 
   private aggregateResults(): void {
     if (!this.sessionActive) return;
@@ -545,7 +614,23 @@ export class DeepDiagnosisService implements OnDestroy {
       findings: [],
       results: [],
       dtcCodes: [],
-      dtcFindings: []
+      dtcFindings: [],
+      isPartial: false,
+      incompleteSteps: [],
+    };
+  }
+
+  private makeDefaultFrame(): ObdLiveFrame {
+    return {
+      timestamp: Date.now(),
+      rpm: 0,
+      speed: 0,
+      engineLoad: 0,
+      coolantTemp: 20,
+      intakeAirTemp: 20,
+      stftB1: 0,
+      ltftB1: 0,
+      throttlePosition: 0,
     };
   }
 }

--- a/src/app/core/diagnostics/diagnostic-engine.service.ts
+++ b/src/app/core/diagnostics/diagnostic-engine.service.ts
@@ -9,6 +9,7 @@ import { LeanConditionRule } from './diagnostic-rules/lean-condition.rule';
 import { RichConditionRule } from './diagnostic-rules/rich-condition.rule';
 import { VacuumLeakPatternRule } from './diagnostic-rules/vacuum-leak-pattern.rule';
 import { WarmupIssueRule } from './diagnostic-rules/warmup-issue.rule';
+import { SignalValidator } from '../utils/signal-validator';
 
 @Injectable({
   providedIn: 'root'
@@ -45,8 +46,8 @@ export class DiagnosticEngineService {
   }
 
   public processFrame(frame: ObdLiveFrame): void {
-    this.frameBuffer.push(frame);
-    
+    this.frameBuffer.push(SignalValidator.sanitizeFrame(frame));
+
     if (this.frameBuffer.length > this.MAX_BUFFER_SIZE) {
       this.frameBuffer.shift();
     }

--- a/src/app/core/replay/session-replay.service.ts
+++ b/src/app/core/replay/session-replay.service.ts
@@ -1,9 +1,11 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { ObdLiveFrame } from '../models/obd-live-frame.model';
 import { DiagnosticResult } from '../models/diagnostic-result.model';
 
 const STORAGE_KEY = 'obd2_last_replay_session';
+/** Maximum frames stored per session to prevent unbounded memory growth. */
+const MAX_SESSION_FRAMES = 3000;
 
 export interface ReplaySession {
   savedAt: number;
@@ -17,7 +19,7 @@ export interface ReplaySession {
  * No backend — persists to localStorage.
  */
 @Injectable({ providedIn: 'root' })
-export class SessionReplayService {
+export class SessionReplayService implements OnDestroy {
 
   // ─── Stored session ────────────────────────────────────────────────────────
 
@@ -51,10 +53,15 @@ export class SessionReplayService {
   ): void {
     if (!frames.length) return;
 
+    // Trim to the most recent MAX_SESSION_FRAMES to cap memory and localStorage usage
+    const cappedFrames = frames.length > MAX_SESSION_FRAMES
+      ? frames.slice(frames.length - MAX_SESSION_FRAMES)
+      : [...frames];
+
     const session: ReplaySession = {
       savedAt: Date.now(),
-      durationMs: frames[frames.length - 1].timestamp - frames[0].timestamp,
-      frames: [...frames],
+      durationMs: cappedFrames[cappedFrames.length - 1].timestamp - cappedFrames[0].timestamp,
+      frames: cappedFrames,
       diagnosticResults: [...diagnosticResults],
     };
 
@@ -116,6 +123,10 @@ export class SessionReplayService {
     if (wasPlaying) this.pause();
     this.speedSubject.next(speed);
     if (wasPlaying) this.play();
+  }
+
+  public ngOnDestroy(): void {
+    this.stop();
   }
 
   // ─── Private ───────────────────────────────────────────────────────────────

--- a/src/app/core/utils/signal-validator.ts
+++ b/src/app/core/utils/signal-validator.ts
@@ -1,7 +1,46 @@
+import { ObdLiveFrame } from '../models/obd-live-frame.model';
+
 /**
  * Utility for validating and smoothing OBD signal data.
  */
 export class SignalValidator {
+
+  /**
+   * Sanitizes a live frame by clamping all fields to safe ranges and filling
+   * in safe defaults for undefined optional fields. This prevents extreme
+   * values from distorting charts or triggering false diagnostic alerts.
+   */
+  public static sanitizeFrame(frame: ObdLiveFrame): ObdLiveFrame {
+    const sanitized: ObdLiveFrame = {
+      timestamp:        frame.timestamp || Date.now(),
+      rpm:              this.validateRpm(frame.rpm),
+      speed:            this.clamp(frame.speed, 0, 300, 0),
+      engineLoad:       this.validatePercent(frame.engineLoad),
+      coolantTemp:      this.validateTemp(frame.coolantTemp),
+      intakeAirTemp:    this.validateTemp(frame.intakeAirTemp),
+      stftB1:           this.validateFuelTrim(frame.stftB1),
+      ltftB1:           this.validateFuelTrim(frame.ltftB1),
+      throttlePosition: this.validatePercent(frame.throttlePosition),
+    };
+    // Preserve optional fields only when present and valid
+    if (frame.maf !== undefined)               sanitized.maf               = this.clamp(frame.maf, 0, 655, 0);
+    if (frame.map !== undefined)               sanitized.map               = this.clamp(frame.map, 0, 300, 0);
+    if (frame.batteryVoltage !== undefined)    sanitized.batteryVoltage    = this.clamp(frame.batteryVoltage, 0, 20, 12);
+    if (frame.connectionQuality !== undefined) sanitized.connectionQuality = this.clamp(frame.connectionQuality, 0, 100, 100);
+    return sanitized;
+  }
+
+  /**
+   * Returns a list of human-readable labels for optional PIDs that are missing
+   * from the frame, used to surface fallback messaging in the UI.
+   */
+  public static missingOptionalPids(frame: ObdLiveFrame): string[] {
+    const missing: string[] = [];
+    if (frame.maf === undefined)            missing.push('MAF');
+    if (frame.map === undefined)            missing.push('MAP');
+    if (frame.batteryVoltage === undefined) missing.push('Battery Voltage');
+    return missing;
+  }
   
   /**
    * Clamps a value within a specified range and ensures it's a valid number.

--- a/src/app/features/dashboard/dashboard-page.component.ts
+++ b/src/app/features/dashboard/dashboard-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { CommonModule, TitleCasePipe } from '@angular/common';
 import { Observable, Subscription } from 'rxjs';
+import { filter, distinctUntilChanged } from 'rxjs/operators';
 import { ChartData, ChartOptions } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
 import { ObdAdapter, OBD_ADAPTER, ObdDebugInfo } from '../../core/adapters/obd-adapter.interface';
@@ -12,6 +13,7 @@ import { DiagnosticResult } from '../../core/models/diagnostic-result.model';
 import { MetricCardComponent } from '../../shared/components/metric-card/metric-card.component';
 import { MultiSignalChartComponent } from '../../shared/components/multi-signal-chart/multi-signal-chart.component';
 import { StftStatusPipe, StftBadgePipe, LtftStatusPipe } from '../../shared/pipes/telemetry-status.pipe';
+import { SignalValidator } from '../../core/utils/signal-validator';
 
 function makeLineData(label: string, color: string): ChartData<'line'> {
   return {
@@ -110,9 +112,19 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
       this.adapterMode = mode;
     });
 
+    // Reset display state when adapter disconnects so the UI doesn't show stale data
+    const disconnectSubscription = this.obdAdapter.connectionStatus$.pipe(
+      distinctUntilChanged(),
+      filter(status => status === 'disconnected' || status === 'error')
+    ).subscribe(() => {
+      this.latestFrame = null;
+      this.dataState = 'no_data';
+    });
+
     this.subscriptions.add(dataSubscription);
     this.subscriptions.add(diagSubscription);
     this.subscriptions.add(modeSubscription);
+    this.subscriptions.add(disconnectSubscription);
   }
 
   public ngOnDestroy(): void {
@@ -161,11 +173,15 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
 
   // ─── Private ─────────────────────────────────────────────────────────────
 
-  private handleNewFrame(frame: ObdLiveFrame): void {
+  private handleNewFrame(rawFrame: ObdLiveFrame): void {
+    const frame = SignalValidator.sanitizeFrame(rawFrame);
     this.latestFrame = frame;
     this.dataState = 'receiving';
 
-    this.frames = [...this.frames, frame].slice(-60);
+    this.frames.push(frame);
+    if (this.frames.length > 60) {
+      this.frames.shift();
+    }
 
     this.frameCount++;
     if (this.frameCount % 2 === 0) {


### PR DESCRIPTION
## Summary

Implements all 5 edge case hardening issues for the OBD diagnostic system. The pipeline now handles missing PIDs, extreme sensor values, partial diagnosis completion, adapter disconnects, and unbounded memory growth in long sessions.

- **No Data / Missing PID handling** — sanitise frames at ingestion; diagnosis proceeds with a warning instead of blocking on missing data (#126)
- **Extreme value clamping** — `SignalValidator.sanitizeFrame()` applied at the diagnostic engine and dashboard entry points; outlier spikes never reach charts or rules (#127)
- **Partial diagnosis** — `aggregatePartialResults()` always emits a `completed` state with `isPartial: true` when a step exhausts its retries; report page always renders (#128)
- **State recovery on disconnect** — `connectionStatus$` monitor in `startDiagnosis()` fires `aggregatePartialResults()` on adapter drop; dashboard clears stale metric values immediately (#129)
- **Long session stability** — frame buffer capped at 3 000; `SessionReplayService` cleans up its `setInterval` timer on destroy; dashboard uses `push/shift` instead of per-frame spread allocation (#130)

## Test plan

- [ ] Start simulator, let it run 10+ minutes — no memory growth or UI jank
- [ ] Disconnect adapter mid-diagnosis — report page renders a partial result, no hanging state
- [ ] Connect with no OBD data flowing — baseline scan warns and continues rather than blocking
- [ ] Observe dashboard metric cards reset to zero on disconnect
- [ ] `ng build` passes with zero errors