### PR TITLE
feat(ai): prepare AI QA infrastructure

### DIFF
--- a/src/app/core/ai/qa/ai-qa-runner.service.ts
+++ b/src/app/core/ai/qa/ai-qa-runner.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, inject } from '@angular/core';
+import { AiDiagnosisService } from '../ai-diagnosis.service';
+import { AiEvidence, AiInsight } from '../ai-diagnosis.models';
+import { DeepDiagnosisState } from '../../diagnostics/deep-diagnosis.service';
+import { AiScenario, ALL_SCENARIOS } from './scenario-fixtures';
+import { evaluateAiOutput, EvaluationResult } from './ai-output-evaluator';
+import { firstValueFrom, Observable, BehaviorSubject, filter } from 'rxjs';
+
+export interface QaRunResult {
+  scenarioId: string;
+  scenarioLabel: string;
+  expectedPrimaryKeywords: string[];
+  evaluation: EvaluationResult | null;
+  insight: AiInsight | null;
+  error?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AiQaRunnerService {
+  private aiService = inject(AiDiagnosisService);
+
+  private resultsSubject = new BehaviorSubject<QaRunResult[]>([]);
+  readonly results$ = this.resultsSubject.asObservable();
+
+  private isRunningSubject = new BehaviorSubject<boolean>(false);
+  readonly isRunning$ = this.isRunningSubject.asObservable();
+
+  async runAllFixtures(): Promise<void> {
+    if (this.isRunningSubject.value) return;
+    this.isRunningSubject.next(true);
+    this.resultsSubject.next([]);
+
+    const results: QaRunResult[] = [];
+
+    for (const scenario of ALL_SCENARIOS) {
+      const result = await this.runFixture(scenario);
+      results.push(result);
+      this.resultsSubject.next([...results]);
+    }
+
+    this.isRunningSubject.next(false);
+  }
+
+  private async runFixture(scenario: AiScenario): Promise<QaRunResult> {
+    const mockState = this.buildMockDiagnosisState(scenario.evidence);
+
+    // reset service to clear any previous insight
+    this.aiService.reset();
+
+    // trigger analysis
+    this.aiService.analyse(mockState);
+
+    try {
+      // Wait for it to complete (either ready, fallback, or error)
+      const insight = await firstValueFrom(
+        this.aiService.insight$.pipe(
+          filter(i => i.status === 'ready' || i.status === 'fallback' || i.status === 'error')
+        )
+      );
+
+      let evaluation: EvaluationResult | null = null;
+      if (insight.response) {
+        evaluation = evaluateAiOutput(insight.response, scenario);
+      }
+
+      return {
+        scenarioId: scenario.id,
+        scenarioLabel: scenario.label,
+        expectedPrimaryKeywords: scenario.expectedPrimaryKeywords,
+        evaluation,
+        insight
+      };
+    } catch (err: any) {
+      return {
+        scenarioId: scenario.id,
+        scenarioLabel: scenario.label,
+        expectedPrimaryKeywords: scenario.expectedPrimaryKeywords,
+        evaluation: null,
+        insight: null,
+        error: err.message || 'Unknown error occurred'
+      };
+    }
+  }
+
+  /**
+   * Constructs a DeepDiagnosisState that will map closely back to the original AiEvidence
+   * when passed through the EvidenceBuilderService.
+   * Note: This mapping ensures AiDiagnosisService can run normally without mocking core services.
+   */
+  private buildMockDiagnosisState(evidence: AiEvidence): DeepDiagnosisState {
+    const state: DeepDiagnosisState = {
+      status: 'completed',
+      step: 'completed',
+      dtcCodes: evidence.dtcs.map(d => ({ code: d.code, title: d.title, severity: d.severity as any, system: 'Engine' })),
+      severity: { score: evidence.severityScore, level: evidence.severityLevel as any, reasons: [] },
+      rootCauses: [],
+      correlationFindings: evidence.correlationFindings.map(msg => ({ message: msg, type: 'correlation', confidence: 'Medium' })),
+      recommendations: {
+        recommendedChecks: evidence.recommendedChecks,
+        nextSteps: []
+      },
+      isPartial: evidence.isPartial,
+      findings: [],
+      dtcFindings: [],
+      // Other state fields are left as default or empty as EvidenceBuilder doesn't heavily depend on them
+    } as any; // Using "any" assertion for omitted fields not strictly required by EvidenceBuilder
+
+    if (evidence.primaryCause) {
+      state.rootCauses!.push({
+        title: evidence.primaryCause.title,
+        confidence: evidence.primaryCause.confidence as any,
+        explanation: evidence.primaryCause.explanation,
+        rank: 1,
+        supportingEvidence: []
+      });
+    }
+
+    evidence.additionalCauses.forEach((cause, idx) => {
+      state.rootCauses!.push({
+        title: cause.title,
+        confidence: cause.confidence as any,
+        explanation: '', // fallback to empty string
+        rank: idx + 2,
+        supportingEvidence: []
+      });
+    });
+
+    if (evidence.fuelTrimNote) {
+      state.dtcFindings!.push(evidence.fuelTrimNote);
+    }
+
+    if (evidence.idleStabilityNote) {
+      state.dtcFindings!.push(evidence.idleStabilityNote);
+    }
+
+    return state;
+  }
+}

--- a/src/app/core/ai/qa/ai-qa-runner.service.ts
+++ b/src/app/core/ai/qa/ai-qa-runner.service.ts
@@ -54,7 +54,7 @@ export class AiQaRunnerService {
       // Wait for it to complete (either ready, fallback, or error)
       const insight = await firstValueFrom(
         this.aiService.insight$.pipe(
-          filter(i => i.status === 'ready' || i.status === 'fallback' || i.status === 'error')
+          filter(i => i.status === 'ready' || i.status === 'fallback' || i.status === 'error' || i.status === 'no_key')
         )
       );
 

--- a/src/app/core/ai/qa/scenario-fixtures.ts
+++ b/src/app/core/ai/qa/scenario-fixtures.ts
@@ -159,6 +159,153 @@ export const SCENARIO_CLEAN: AiScenario = {
   forbiddenKeywords: ['P0171', 'P0300', 'misfire', 'lean', 'rich'],
 };
 
+
+// ── Scenario 7: Evap System Leak (P0456) ──────────────────────────────────────
+export const SCENARIO_EVAP_LEAK: AiScenario = {
+  id: 'evap_leak',
+  label: 'Evap System Leak — P0456 minor leak detected',
+  evidence: {
+    severityScore: 25,
+    severityLevel: 'Low',
+    dtcs: [{ code: 'P0456', title: 'EVAP System Leak Detected (very small leak)', severity: 'Low' }],
+    primaryCause: {
+      title: 'Evaporative Emission System Leak',
+      confidence: 'Medium',
+      explanation: 'A very small leak in the EVAP system. Often caused by a loose or faulty gas cap, a cracked EVAP hose, or a failing purge valve.',
+    },
+    additionalCauses: [],
+    correlationFindings: ['EVAP monitor incomplete or failed during drive cycle'],
+    recommendedChecks: ['Check and tighten gas cap', 'Inspect EVAP hoses for cracks', 'Perform smoke test on EVAP system'],
+    fuelTrimNote: null,
+    idleStabilityNote: null,
+    isPartial: false,
+  },
+  expectedPrimaryKeywords: ['evap', 'evaporative', 'leak', 'gas cap'],
+  expectedConfidence: 'Medium',
+  forbiddenKeywords: ['misfire', 'catalyst', '£', '$'],
+};
+
+// ── Scenario 8: Oxygen Sensor Stuck Lean (P0134) ─────────────────────────────
+export const SCENARIO_O2_SENSOR: AiScenario = {
+  id: 'o2_sensor',
+  label: 'Oxygen Sensor No Activity — P0134',
+  evidence: {
+    severityScore: 40,
+    severityLevel: 'Medium',
+    dtcs: [{ code: 'P0134', title: 'O2 Sensor Circuit No Activity Detected (Bank 1 Sensor 1)', severity: 'Medium' }],
+    primaryCause: {
+      title: 'Upstream Oxygen Sensor Failure',
+      confidence: 'High',
+      explanation: 'The primary oxygen sensor is not responding. This affects fuel trim calculations and can cause poor fuel economy or rough running.',
+    },
+    additionalCauses: [{ title: 'Wiring/Connector Issue', confidence: 'Medium' }],
+    correlationFindings: ['O2S11 voltage stuck at 0.45V during warm-up and rev tests'],
+    recommendedChecks: ['Check O2 sensor wiring and connector', 'Test O2 sensor heater circuit', 'Replace upstream O2 sensor'],
+    fuelTrimNote: 'Fuel trims fixed in open-loop default values',
+    idleStabilityNote: null,
+    isPartial: false,
+  },
+  expectedPrimaryKeywords: ['oxygen', 'o2 sensor', 'sensor', 'activity'],
+  expectedConfidence: 'High',
+  forbiddenKeywords: ['P0171', 'misfire', 'MAF', '£', '$'],
+};
+
+// ── Scenario 9: Coolant Temperature Sensor (P0118) ───────────────────────────
+export const SCENARIO_ECT: AiScenario = {
+  id: 'ect_sensor',
+  label: 'Coolant Temp Sensor High — P0118',
+  evidence: {
+    severityScore: 50,
+    severityLevel: 'Medium',
+    dtcs: [{ code: 'P0118', title: 'Engine Coolant Temperature Sensor 1 Circuit High', severity: 'High' }],
+    primaryCause: {
+      title: 'ECT Sensor Fault / Open Circuit',
+      confidence: 'High',
+      explanation: 'The engine coolant temperature sensor is reading -40 degrees, indicating an open circuit or unplugged sensor. The engine will run very rich.',
+    },
+    additionalCauses: [],
+    correlationFindings: ['Coolant temp stuck at -40C despite engine running for 10 mins'],
+    recommendedChecks: ['Inspect ECT sensor connector', 'Check ECT wiring for open circuit', 'Replace ECT sensor'],
+    fuelTrimNote: 'Engine operating in rich warm-up mode constantly',
+    idleStabilityNote: 'Idle elevated (1100 RPM) due to cold enrichment strategy',
+    isPartial: false,
+  },
+  expectedPrimaryKeywords: ['coolant', 'temperature', 'ect', 'sensor'],
+  expectedConfidence: 'High',
+  forbiddenKeywords: ['vacuum', 'catalyst', '£', '$'],
+};
+
+// ── Scenario 10: Partial Data (Missing PIDs) ──────────────────────────────────
+export const SCENARIO_PARTIAL_DATA: AiScenario = {
+  id: 'partial_data',
+  label: 'Partial Data — Diagnosis aborted early',
+  evidence: {
+    severityScore: 10,
+    severityLevel: 'Low',
+    dtcs: [],
+    primaryCause: null,
+    additionalCauses: [],
+    correlationFindings: [],
+    recommendedChecks: ['Complete full diagnostic test cycle'],
+    fuelTrimNote: null,
+    idleStabilityNote: null,
+    isPartial: true,
+  },
+  expectedPrimaryKeywords: ['partial', 'incomplete', 'more data', 'no fault', 'clear'],
+  expectedConfidence: 'Low',
+  forbiddenKeywords: ['misfire', 'leak', 'rich', '£', '$'],
+};
+
+// ── Scenario 11: Throttle Position Sensor (P0122) ────────────────────────────
+export const SCENARIO_TPS: AiScenario = {
+  id: 'tps_fault',
+  label: 'Throttle Position Sensor Low — P0122',
+  evidence: {
+    severityScore: 60,
+    severityLevel: 'High',
+    dtcs: [{ code: 'P0122', title: 'Throttle/Pedal Position Sensor A Circuit Low', severity: 'High' }],
+    primaryCause: {
+      title: 'TPS Sensor Fault',
+      confidence: 'High',
+      explanation: 'Throttle position sensor voltage is too low, often caused by a short to ground or a failing sensor track. Can cause hesitation or stalling.',
+    },
+    additionalCauses: [],
+    correlationFindings: ['TPS reading 0% even when RPM increases during rev test'],
+    recommendedChecks: ['Check TPS wiring harness for shorts to ground', 'Test TPS signal voltage sweep', 'Replace throttle position sensor'],
+    fuelTrimNote: null,
+    idleStabilityNote: 'Engine stumbled during attempted rev test',
+    isPartial: false,
+  },
+  expectedPrimaryKeywords: ['throttle', 'position', 'tps', 'sensor'],
+  expectedConfidence: 'High',
+  forbiddenKeywords: ['evap', 'coolant', '£', '$'],
+};
+
+// ── Scenario 12: No DTC Abnormal Behavior (Stalling/Rough Idle) ───────────────
+export const SCENARIO_NO_DTC_ROUGH: AiScenario = {
+  id: 'no_dtc_rough',
+  label: 'No DTCs but Rough Idle Detected',
+  evidence: {
+    severityScore: 45,
+    severityLevel: 'Medium',
+    dtcs: [],
+    primaryCause: {
+      title: 'Unmetered Air or Idle Control Issue',
+      confidence: 'Medium',
+      explanation: 'No fault codes are present, but the engine idle is unstable. This could be an early sign of a vacuum leak, dirty throttle body, or failing idle air control valve.',
+    },
+    additionalCauses: [{ title: 'Dirty Throttle Body', confidence: 'Medium' }],
+    correlationFindings: ['Idle RPM fluctuating heavily without setting misfire codes'],
+    recommendedChecks: ['Clean throttle body and idle air control valve', 'Check for small vacuum leaks', 'Perform idle relearn procedure'],
+    fuelTrimNote: 'STFT fluctuating normally, no rich/lean condition confirmed',
+    idleStabilityNote: 'Idle RPM varied between 600 and 950 RPM',
+    isPartial: false,
+  },
+  expectedPrimaryKeywords: ['idle', 'throttle', 'air', 'unstable'],
+  expectedConfidence: 'Medium',
+  forbiddenKeywords: ['P0', '£', '$'],
+};
+
 export const ALL_SCENARIOS: AiScenario[] = [
   SCENARIO_VACUUM_LEAK,
   SCENARIO_MISFIRE,
@@ -166,4 +313,10 @@ export const ALL_SCENARIOS: AiScenario[] = [
   SCENARIO_CATALYST,
   SCENARIO_MAF,
   SCENARIO_CLEAN,
+  SCENARIO_EVAP_LEAK,
+  SCENARIO_O2_SENSOR,
+  SCENARIO_ECT,
+  SCENARIO_PARTIAL_DATA,
+  SCENARIO_TPS,
+  SCENARIO_NO_DTC_ROUGH,
 ];

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.html
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.html
@@ -458,6 +458,60 @@
 
     </section>
 
+
+    <!-- ── AI QA Runner Panel (dev mode only, local storage driven) ── -->
+    <section class="ai-debug-section qa-runner-section" *ngIf="showQaPanel">
+      <div class="results-card-header">
+        <h2><span class="sec-icon">🧪</span> AI QA Test Runner
+          <span class="ai-badge">DEV DEBUG</span>
+        </h2>
+        <div>
+          <button class="btn btn-sm btn-outline" (click)="runQaTests()" [disabled]="isQaRunning$ | async">
+            {{ (isQaRunning$ | async) ? 'Running...' : 'Run All Fixtures' }}
+          </button>
+          <button class="btn btn-sm btn-ghost" (click)="qaPanelExpanded = !qaPanelExpanded">
+            {{ qaPanelExpanded ? 'Hide' : 'Show' }}
+          </button>
+        </div>
+      </div>
+
+      <ng-container *ngIf="qaPanelExpanded">
+        <div class="debug-panel qa-panel" *ngIf="(qaResults$ | async) as results">
+          <p *ngIf="results.length === 0 && !(isQaRunning$ | async)" class="empty-msg">No results yet. Click "Run All Fixtures" to start.</p>
+
+          <div *ngFor="let res of results" class="qa-result-card" [ngClass]="{'pass': res.evaluation?.pass, 'fail': res.evaluation && !res.evaluation.pass}">
+            <div class="qa-result-header">
+              <h3>{{ res.scenarioLabel }}</h3>
+              <span class="pass-badge" *ngIf="res.evaluation?.pass">PASS ({{ res.evaluation?.score }}%)</span>
+              <span class="fail-badge" *ngIf="res.evaluation && !res.evaluation.pass">FAIL ({{ res.evaluation.score }}%)</span>
+              <span class="error-badge" *ngIf="res.error">ERROR</span>
+            </div>
+
+            <p class="qa-expected"><strong>Expected Primary Issue:</strong> {{ res.expectedPrimaryKeywords.join(', ') }}</p>
+
+            <div *ngIf="res.insight?.response as response" class="qa-response">
+              <p><strong>AI Primary Issue:</strong> {{ response.primary_issue }} ({{ response.confidence }})</p>
+              <p><strong>Explanation:</strong> {{ response.explanation }}</p>
+
+              <details class="qa-checks-details" *ngIf="res.evaluation">
+                <summary>Evaluation Checks</summary>
+                <ul class="qa-checks-list">
+                  <li *ngFor="let check of res.evaluation.checks" [ngClass]="{'check-pass': check.pass, 'check-fail': !check.pass}">
+                    <span class="check-icon">{{ check.pass ? '✓' : '✗' }}</span>
+                    <span class="check-name">{{ check.name }}</span>
+                    <span class="check-detail">{{ check.detail }}</span>
+                  </li>
+                </ul>
+              </details>
+            </div>
+
+            <p class="qa-error" *ngIf="res.error">Error: {{ res.error }}</p>
+
+          </div>
+        </div>
+      </ng-container>
+    </section>
+
     <!-- ── AI Debug Panel (dev mode only) ──────────────────────────────── -->
     <section class="ai-debug-section" *ngIf="isDev">
       <div class="results-card-header">

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.scss
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.scss
@@ -1390,3 +1390,112 @@
   justify-content: flex-start;
   padding-top: $spacing-sm;
 }
+
+
+.qa-runner-section {
+  margin-top: 1.5rem;
+}
+
+.qa-result-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  margin-bottom: 1rem;
+
+  &.pass {
+    border-left: 4px solid var(--success-color, #10b981);
+  }
+
+  &.fail {
+    border-left: 4px solid var(--danger-color, #ef4444);
+  }
+}
+
+.qa-result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+
+  h3 {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--text-primary);
+  }
+}
+
+.pass-badge, .fail-badge, .error-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-sm);
+}
+
+.pass-badge {
+  background: rgba(16, 185, 129, 0.1);
+  color: #10b981;
+}
+
+.fail-badge {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+}
+
+.error-badge {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+}
+
+.qa-expected, .qa-response p {
+  margin: 0.25rem 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.qa-checks-details {
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+
+  summary {
+    cursor: pointer;
+    color: var(--primary-color);
+    font-weight: 500;
+  }
+}
+
+.qa-checks-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0 0;
+
+  li {
+    display: flex;
+    align-items: flex-start;
+    padding: 0.25rem 0;
+    border-bottom: 1px solid var(--border-color-light, rgba(255,255,255,0.05));
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .check-icon {
+    margin-right: 0.5rem;
+    font-weight: bold;
+  }
+
+  .check-pass .check-icon { color: #10b981; }
+  .check-fail .check-icon { color: #ef4444; }
+
+  .check-name {
+    flex: 1;
+    color: var(--text-primary);
+  }
+
+  .check-detail {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin-left: 1rem;
+  }
+}

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.ts
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.ts
@@ -16,6 +16,7 @@ import { ReplacePipe } from '../../shared/pipes/replace.pipe';
 import { ConfidenceLevel, RepairStep } from '../../core/diagnostics/intelligence/diagnosis-intelligence.models';
 import { AiDiagnosisService, AiDebugSnapshot } from '../../core/ai/ai-diagnosis.service';
 import { AiConfigService } from '../../core/ai/ai-config.service';
+import { AiQaRunnerService, QaRunResult } from '../../core/ai/qa/ai-qa-runner.service';
 import { AiInsight } from '../../core/ai/ai-diagnosis.models';
 import { isDevMode } from '@angular/core';
 
@@ -54,6 +55,7 @@ export class DiagnosisReportPageComponent implements OnInit, OnDestroy {
   private obdAdapter       = inject<ObdAdapter>(OBD_ADAPTER);
   private aiService        = inject(AiDiagnosisService);
   private aiConfig         = inject(AiConfigService);
+  private qaRunner         = inject(AiQaRunnerService);
   private router           = inject(Router);
 
   readonly state$:            Observable<DeepDiagnosisState>                             = this.diagnosisService.state$;
@@ -63,6 +65,11 @@ export class DiagnosisReportPageComponent implements OnInit, OnDestroy {
   readonly aiInsight$:   Observable<AiInsight>        = this.aiService.insight$;
   readonly aiDebug$:     Observable<AiDebugSnapshot>  = this.aiService.debug$;
   readonly isDev = isDevMode();
+
+  readonly qaResults$: Observable<QaRunResult[]> = this.qaRunner.results$;
+  readonly isQaRunning$: Observable<boolean> = this.qaRunner.isRunning$;
+  get showQaPanel(): boolean { return localStorage.getItem('obd_ai_debug') === 'true'; }
+  qaPanelExpanded = false;
 
   readonly steps = STEPS;
 
@@ -175,6 +182,11 @@ export class DiagnosisReportPageComponent implements OnInit, OnDestroy {
   }
 
   // ── Actions ──────────────────────────────────────────────────────────────
+
+  runQaTests(): void {
+    this.qaPanelExpanded = true;
+    this.qaRunner.runAllFixtures();
+  }
 
   async connectAdapter(): Promise<void> {
     try { await this.obdAdapter.connect(); } catch { /* reflected in connectionStatus$ */ }

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.ts
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.ts
@@ -68,7 +68,7 @@ export class DiagnosisReportPageComponent implements OnInit, OnDestroy {
 
   readonly qaResults$: Observable<QaRunResult[]> = this.qaRunner.results$;
   readonly isQaRunning$: Observable<boolean> = this.qaRunner.isRunning$;
-  get showQaPanel(): boolean { return localStorage.getItem('obd_ai_debug') === 'true'; }
+  get showQaPanel(): boolean { return this.isDev && localStorage.getItem('obd_ai_debug') === 'true'; }
   qaPanelExpanded = false;
 
   readonly steps = STEPS;


### PR DESCRIPTION
This branch prepares the AI QA infrastructure cleanly and transparently:
- **Test Fixtures**: Expanded `ALL_SCENARIOS` from 6 to 12 in `scenario-fixtures.ts` representing realistic use cases.
- **QA Runner Service**: Added `ai-qa-runner.service.ts` which successfully triggers the existing `AiDiagnosisService` without core logic changes.
- **UI Exposure**: Added a dev-only debug panel inside `diagnosis-report-page.component` triggered using `localStorage.setItem('obd_ai_debug', 'true')`.

**Handoff / Next steps for Claude:**
To test:
1. Open the console on the dashboard and run `localStorage.setItem('obd_ai_debug', 'true')` then refresh.
2. Navigate to a diagnostic report page to see the `AI QA Test Runner` section.
3. Click "Run All Fixtures". It will use Anthropic if an API Key is set; else it will run the deterministic fallback.
4. You can use these fixtures for future prompt calibration, fine tuning `SYSTEM_PROMPT` rules or assessing edge case confidence.

---
*PR created automatically by Jules for task [12700415456002188572](https://jules.google.com/task/12700415456002188572) started by @jawwadHussain302*