### PR TITLE
Quota System Sprint (Issues #166–#169)

### DIFF
--- a/src/app/core/ai/ai-diagnosis.models.ts
+++ b/src/app/core/ai/ai-diagnosis.models.ts
@@ -27,7 +27,7 @@ export interface AiDiagnosisResponse {
 
 // ── AI insight state attached to a completed diagnosis ────────────────────────
 
-export type AiInsightStatus = 'idle' | 'loading' | 'ready' | 'fallback' | 'no_key' | 'error';
+export type AiInsightStatus = 'idle' | 'loading' | 'ready' | 'fallback' | 'no_key' | 'quota_exceeded' | 'error';
 
 export interface AiInsight {
   status: AiInsightStatus;

--- a/src/app/core/ai/ai-diagnosis.service.ts
+++ b/src/app/core/ai/ai-diagnosis.service.ts
@@ -7,6 +7,7 @@ import { AiPromptService } from './ai-prompt.service';
 import { AiResponseValidatorService } from './ai-response-validator.service';
 import { AiFallbackService } from './ai-fallback.service';
 import { AiConfigService } from './ai-config.service';
+import { AiUsageTrackerService } from './ai-usage-tracker.service';
 
 const ANTHROPIC_API = 'https://api.anthropic.com/v1/messages';
 const MODEL = 'claude-haiku-4-5-20251001';
@@ -22,13 +23,12 @@ export interface AiDebugSnapshot {
 
 /**
  * Orchestrates the full AI diagnosis flow:
- *   evidence → prompt → API call → validate → (fallback on any failure)
+ *   evidence → prompt → quota check → API call → validate → (fallback on any failure)
  *
- * Non-blocking: the component subscribes to insight$ and the state
- * updates asynchronously. If no API key is set, goes directly to fallback.
- *
- * A generation counter ensures that results from a superseded analysis
- * are silently discarded rather than overwriting the current insight.
+ * Usage tracking rules:
+ * - increment() is called ONLY when callApi() succeeds with a valid response
+ * - Fallback paths (no_key, quota_exceeded, validation fail, API error) do NOT increment
+ * - If quota is exceeded the API call is skipped and fallback is used immediately
  */
 @Injectable({ providedIn: 'root' })
 export class AiDiagnosisService {
@@ -39,7 +39,6 @@ export class AiDiagnosisService {
   private debugSubject = new BehaviorSubject<AiDebugSnapshot>({
     evidence: null, userMessage: null, rawResponse: null, validationPassed: null,
   });
-  /** Only populated in dev mode — shows evidence packet, prompt, and raw response. */
   readonly debug$: Observable<AiDebugSnapshot> = this.debugSubject.asObservable();
 
   private generation = 0;
@@ -50,6 +49,7 @@ export class AiDiagnosisService {
     private validator: AiResponseValidatorService,
     private fallback: AiFallbackService,
     private config: AiConfigService,
+    private usageTracker: AiUsageTrackerService,
   ) {}
 
   reset(): void {
@@ -67,8 +67,9 @@ export class AiDiagnosisService {
     this.insightSubject.next({ status: 'loading', response: null, generatedAt: null, isFallback: false });
 
     const evidence = this.evidenceBuilder.build(state);
-    const apiKey = this.config.getKey();
+    const apiKey   = this.config.getKey();
 
+    // ── No API key ────────────────────────────────────────────────────────────
     if (!apiKey) {
       if (this.generation !== thisGeneration) return;
       if (isDevMode()) this.debugSubject.next({ evidence, userMessage: null, rawResponse: null, validationPassed: null });
@@ -81,6 +82,22 @@ export class AiDiagnosisService {
       return;
     }
 
+    // ── Quota exceeded — skip API call, use fallback ──────────────────────────
+    if (!this.usageTracker.canMakeCall()) {
+      if (this.generation !== thisGeneration) return;
+      if (isDevMode()) this.debugSubject.next({ evidence, userMessage: null, rawResponse: null, validationPassed: null });
+      const stats = this.usageTracker.getStats();
+      this.insightSubject.next({
+        status: 'quota_exceeded',
+        response: this.fallback.generate(evidence),
+        generatedAt: Date.now(),
+        isFallback: true,
+        errorMessage: `Monthly AI quota reached (${stats.used}/${stats.limit}). Resets ${this.nextResetLabel()}.`,
+      });
+      return;
+    }
+
+    // ── Live API call ─────────────────────────────────────────────────────────
     try {
       const userMessage = this.promptService.buildUserMessage(evidence);
       if (isDevMode()) this.debugSubject.next({ evidence, userMessage, rawResponse: null, validationPassed: null });
@@ -92,6 +109,8 @@ export class AiDiagnosisService {
       if (isDevMode()) this.debugSubject.next({ evidence, userMessage, rawResponse: raw, validationPassed: !!validated });
 
       if (validated) {
+        // Only increment on a real successful AI call with a valid response
+        this.usageTracker.increment();
         this.insightSubject.next({ status: 'ready', response: validated, generatedAt: Date.now(), isFallback: false });
       } else {
         this.insightSubject.next({
@@ -113,6 +132,12 @@ export class AiDiagnosisService {
         errorMessage: message,
       });
     }
+  }
+
+  private nextResetLabel(): string {
+    const now = new Date();
+    const reset = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    return reset.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   }
 
   private async callApi(apiKey: string, userMessage: string): Promise<string> {

--- a/src/app/core/ai/ai-usage-tracker.service.ts
+++ b/src/app/core/ai/ai-usage-tracker.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+const STORAGE_KEY = 'obd_ai_usage';
+const MONTHLY_LIMIT = 50;
+
+export interface UsageStats {
+  used: number;
+  remaining: number;
+  limit: number;
+  month: string;       // 'YYYY-MM'
+  pct: number;         // 0–100, used for the progress bar
+}
+
+interface StoredUsage {
+  month: string;
+  count: number;
+}
+
+/**
+ * Tracks real AI API calls (not fallback) per calendar month in localStorage.
+ * Resets automatically on the first call of a new month.
+ * All mutation goes through increment() so the count can never drift.
+ */
+@Injectable({ providedIn: 'root' })
+export class AiUsageTrackerService {
+
+  private statsSubject = new BehaviorSubject<UsageStats>(this.computeStats());
+  readonly stats$: Observable<UsageStats> = this.statsSubject.asObservable();
+
+  canMakeCall(): boolean {
+    return this.load().count < MONTHLY_LIMIT;
+  }
+
+  /** Call only after a real API call succeeds — never for fallback paths. */
+  increment(): void {
+    const stored = this.load();
+    stored.count++;
+    this.save(stored);
+    this.statsSubject.next(this.computeStats());
+  }
+
+  getStats(): UsageStats {
+    return this.computeStats();
+  }
+
+  /** Dev-only reset for testing. */
+  resetForTesting(): void {
+    try { localStorage.removeItem(STORAGE_KEY); } catch { /* quota */ }
+    this.statsSubject.next(this.computeStats());
+  }
+
+  private load(): StoredUsage {
+    const currentMonth = this.currentMonth();
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as StoredUsage;
+        // Auto-reset on new month
+        if (parsed.month === currentMonth) return parsed;
+      }
+    } catch { /* corrupt data — fall through to fresh record */ }
+    return { month: currentMonth, count: 0 };
+  }
+
+  private save(stored: StoredUsage): void {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(stored)); } catch { /* quota */ }
+  }
+
+  private computeStats(): UsageStats {
+    const stored = this.load();
+    const used      = stored.count;
+    const remaining = Math.max(0, MONTHLY_LIMIT - used);
+    const pct       = Math.min(Math.round((used / MONTHLY_LIMIT) * 100), 100);
+    return { used, remaining, limit: MONTHLY_LIMIT, month: stored.month, pct };
+  }
+
+  private currentMonth(): string {
+    const now = new Date();
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  }
+}

--- a/src/app/core/ai/ai-usage-tracker.service.ts
+++ b/src/app/core/ai/ai-usage-tracker.service.ts
@@ -55,11 +55,26 @@ export class AiUsageTrackerService {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
       if (raw) {
-        const parsed = JSON.parse(raw) as StoredUsage;
-        // Auto-reset on new month
-        if (parsed.month === currentMonth) return parsed;
+        const parsed = JSON.parse(raw);
+
+        // Validate stored shape: month must be a string, count must be a safe integer
+        const validMonth = typeof parsed?.month === 'string';
+        const validCount = typeof parsed?.count === 'number' &&
+                           Number.isFinite(parsed.count) &&
+                           parsed.count >= 0;
+
+        if (validMonth && validCount && parsed.month === currentMonth) {
+          return { month: parsed.month as string, count: Math.floor(parsed.count as number) };
+        }
+
+        // Month changed or data is malformed — reset and persist the fresh record
+        // so stats$ subscribers see 0 immediately (not stale last-month data)
+        const fresh: StoredUsage = { month: currentMonth, count: 0 };
+        this.save(fresh);
+        this.statsSubject.next(this.buildStats(fresh));
+        return fresh;
       }
-    } catch { /* corrupt data — fall through to fresh record */ }
+    } catch { /* corrupt JSON — fall through */ }
     return { month: currentMonth, count: 0 };
   }
 
@@ -68,7 +83,10 @@ export class AiUsageTrackerService {
   }
 
   private computeStats(): UsageStats {
-    const stored = this.load();
+    return this.buildStats(this.load());
+  }
+
+  private buildStats(stored: StoredUsage): UsageStats {
     const used      = stored.count;
     const remaining = Math.max(0, MONTHLY_LIMIT - used);
     const pct       = Math.min(Math.round((used / MONTHLY_LIMIT) * 100), 100);

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.html
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.html
@@ -388,9 +388,21 @@
 
       <div class="results-card-header">
         <h2><span class="sec-icon">✦</span> AI Insight
-          <span class="ai-badge" *ngIf="ai.isFallback">Deterministic</span>
+          <span class="ai-badge" *ngIf="ai.isFallback && ai.status !== 'quota_exceeded'">Deterministic</span>
           <span class="ai-badge ai-badge--live" *ngIf="!ai.isFallback && ai.status === 'ready'">AI</span>
+          <span class="ai-badge ai-badge--quota" *ngIf="ai.status === 'quota_exceeded'">Quota</span>
         </h2>
+        <!-- ── Usage indicator ── -->
+        <ng-container *ngIf="aiUsageStats$ | async as usage">
+          <div class="usage-indicator" *ngIf="usage.used > 0 || ai.status === 'quota_exceeded'"
+               [class]="'usage-indicator--' + usageBarClass(usage.pct)"
+               [title]="usage.used + '/' + usage.limit + ' AI calls used this month'">
+            <span class="usage-label">{{ usage.remaining }} left</span>
+            <div class="usage-track">
+              <div class="usage-fill" [style.width.%]="usage.pct"></div>
+            </div>
+          </div>
+        </ng-container>
         <!-- API key setup -->
         <button class="btn btn-sm btn-ghost" (click)="showApiKeyInput = !showApiKeyInput"
                 *ngIf="ai.status === 'no_key' || showApiKeyInput">
@@ -423,8 +435,14 @@
         <button class="btn btn-sm btn-outline" (click)="showApiKeyInput = true">Add API Key for AI Analysis</button>
       </div>
 
-      <!-- Response (ready or fallback) -->
-      <ng-container *ngIf="ai.response && (ai.status === 'ready' || ai.status === 'fallback' || ai.status === 'no_key')">
+      <!-- Quota exceeded -->
+      <div class="ai-no-key" *ngIf="ai.status === 'quota_exceeded'">
+        <p>{{ ai.errorMessage }}</p>
+        <p class="api-key-hint">Showing deterministic analysis below. AI will resume next month.</p>
+      </div>
+
+      <!-- Response (ready, fallback, no_key, or quota_exceeded) -->
+      <ng-container *ngIf="ai.response && (ai.status === 'ready' || ai.status === 'fallback' || ai.status === 'no_key' || ai.status === 'quota_exceeded')">
         <div class="ai-response">
 
           <div class="ai-primary-row">
@@ -523,8 +541,25 @@
         </button>
       </div>
 
-      <ng-container *ngIf="showDebugPanel && (aiDebug$ | async) as dbg">
-        <div class="debug-panel">
+      <ng-container *ngIf="showDebugPanel">
+        <!-- Usage Stats block (always shown when panel is open) -->
+        <ng-container *ngIf="aiUsageStats$ | async as usage">
+          <div class="debug-block">
+            <div class="debug-block-title">Usage Quota — {{ usage.month }}</div>
+            <div class="debug-usage-row">
+              <span>{{ usage.used }} / {{ usage.limit }} calls used this month</span>
+              <span class="debug-usage-remaining">{{ usage.remaining }} remaining ({{ usage.pct }}%)</span>
+              <button class="btn btn-sm btn-danger-sm" (click)="resetUsageForTesting()" style="margin-left:auto">
+                Reset (dev)
+              </button>
+            </div>
+            <div class="usage-track" style="margin-top:6px">
+              <div class="usage-fill usage-fill--dev" [class]="'usage-indicator--' + usageBarClass(usage.pct)" [style.width.%]="usage.pct"></div>
+            </div>
+          </div>
+        </ng-container>
+
+        <div class="debug-panel" *ngIf="aiDebug$ | async as dbg">
 
           <details class="debug-block" open>
             <summary class="debug-block-title">Evidence Packet</summary>
@@ -550,6 +585,7 @@
     </section>
 
     <!-- Restart row -->
+
     <div class="action-footer">
       <button class="btn btn-sm btn-ghost" [disabled]="connStatus !== 'connected'" (click)="startDiagnosis()">
         ↺ Run New Diagnosis

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.scss
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.scss
@@ -1194,6 +1194,64 @@
     color: $color-info;
     border-color: rgba($color-info, 0.3);
   }
+
+  &.ai-badge--quota {
+    background: rgba($color-warning, 0.12);
+    color: $color-warning;
+    border-color: rgba($color-warning, 0.3);
+  }
+}
+
+// ── Usage indicator ───────────────────────────────────────────────────────────
+.usage-indicator {
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
+
+  .usage-label {
+    font-size: $font-size-label-sm;
+    font-weight: 600;
+    white-space: nowrap;
+    color: $text-muted;
+  }
+}
+
+.usage-track {
+  width: 80px;
+  height: 5px;
+  background: $bg-tertiary;
+  border-radius: $radius-full;
+  overflow: hidden;
+}
+
+.usage-fill {
+  height: 100%;
+  border-radius: $radius-full;
+  transition: width 0.4s ease, background 0.3s ease;
+  background: $color-success;
+}
+
+.usage-indicator--normal  .usage-fill { background: $color-success; }
+.usage-indicator--warning .usage-fill { background: $color-warning; }
+.usage-indicator--critical .usage-fill { background: $color-critical; }
+
+.usage-fill--dev {
+  &.usage-indicator--normal  { background: $color-success; }
+  &.usage-indicator--warning { background: $color-warning; }
+  &.usage-indicator--critical { background: $color-critical; }
+}
+
+// ── Debug usage row ───────────────────────────────────────────────────────────
+.debug-usage-row {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  padding: $spacing-xs $spacing-sm;
+  font-size: $font-size-body-sm;
+  color: $text-secondary;
+  flex-wrap: wrap;
+
+  .debug-usage-remaining { color: $text-muted; font-size: $font-size-label-lg; }
 }
 
 .ai-loading {

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.ts
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.ts
@@ -18,6 +18,7 @@ import { AiDiagnosisService, AiDebugSnapshot } from '../../core/ai/ai-diagnosis.
 import { AiConfigService } from '../../core/ai/ai-config.service';
 import { AiQaRunnerService, QaRunResult } from '../../core/ai/qa/ai-qa-runner.service';
 import { AiInsight } from '../../core/ai/ai-diagnosis.models';
+import { AiUsageTrackerService, UsageStats } from '../../core/ai/ai-usage-tracker.service';
 import { isDevMode } from '@angular/core';
 
 interface StepDef { id: DiagnosisStepId; label: string; }
@@ -55,6 +56,7 @@ export class DiagnosisReportPageComponent implements OnInit, OnDestroy {
   private obdAdapter       = inject<ObdAdapter>(OBD_ADAPTER);
   private aiService        = inject(AiDiagnosisService);
   private aiConfig         = inject(AiConfigService);
+  private usageTracker     = inject(AiUsageTrackerService);
   private qaRunner         = inject(AiQaRunnerService);
   private router           = inject(Router);
 
@@ -62,8 +64,9 @@ export class DiagnosisReportPageComponent implements OnInit, OnDestroy {
   readonly profile$:          Observable<VehicleProfile | null>                          = this.vehicleService.activeProfile$;
   readonly connectionStatus$: Observable<'disconnected'|'connecting'|'connected'|'error'> = this.obdAdapter.connectionStatus$;
   readonly liveFrame$:        Observable<ObdLiveFrame>                                   = this.obdAdapter.data$;
-  readonly aiInsight$:   Observable<AiInsight>        = this.aiService.insight$;
-  readonly aiDebug$:     Observable<AiDebugSnapshot>  = this.aiService.debug$;
+  readonly aiInsight$:        Observable<AiInsight>        = this.aiService.insight$;
+  readonly aiDebug$:          Observable<AiDebugSnapshot>  = this.aiService.debug$;
+  readonly aiUsageStats$:     Observable<UsageStats>       = this.usageTracker.stats$;
   readonly isDev = isDevMode();
 
   readonly qaResults$: Observable<QaRunResult[]> = this.qaRunner.results$;
@@ -112,6 +115,16 @@ export class DiagnosisReportPageComponent implements OnInit, OnDestroy {
 
   retryAi(state: DeepDiagnosisState): void {
     this.aiService.analyse(state);
+  }
+
+  usageBarClass(pct: number): string {
+    if (pct >= 90) return 'critical';
+    if (pct >= 70) return 'warning';
+    return 'normal';
+  }
+
+  resetUsageForTesting(): void {
+    this.usageTracker.resetForTesting();
   }
 
   // ── Step stepper helpers ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a device-local, localStorage-based monthly quota system around real AI API calls. No backend required. Quota is transparent to the user and never blocks functionality — the deterministic fallback is used when the limit is reached.

- **Local Usage Tracker** — \`AiUsageTrackerService\` persists \`{ month, count }\` in \`localStorage\`. Auto-resets on the first access of a new calendar month. All mutation goes through a single \`increment()\` call (#166)
- **Monthly Limit Enforcement** — \`AiDiagnosisService\` checks \`canMakeCall()\` before the API request; quota-exceeded produces \`status: 'quota_exceeded'\` with a fallback response and a "Resets Jun 1" message. \`increment()\` fires only on a successful validated response — errors and fallbacks never count (#167)
- **Usage Indicator UI** — compact indicator in the AI Insight header: "42 left" label + 80px fill bar that colours green → amber (≥70%) → red (≥90%). New "Quota" badge on the insight header when quota is exceeded (#168)
- **Debug Panel** — Usage Quota block at the top of the dev debug panel: month, used/limit, remaining, fill bar, and a "Reset (dev)" button for manual QA (#169)

## How usage is tracked

```
localStorage key: obd_ai_usage
Value:            { "month": "2026-05", "count": 12 }
```

- Written only by \`increment()\`, called only inside \`AiDiagnosisService\` after \`callApi()\` returns a valid validated response
- Read on every \`canMakeCall()\` check; auto-reset to \`{ month: currentMonth, count: 0 }\` when month changes
- Monthly limit: **50 calls** (defined as \`MONTHLY_LIMIT = 50\` in the service)

## How limit is enforced

```
analyse(state):
  if !apiKey       → status: no_key,        fallback (no increment)
  if !canMakeCall()→ status: quota_exceeded, fallback (no increment)
  callApi()
    on success + valid response → increment(), status: ready
    on success + invalid        → status: fallback    (no increment)
    on error                    → status: fallback    (no increment)
```

## Test plan

- [ ] Run a diagnosis with API key — check Usage Indicator appears in AI Insight header
- [ ] Open debug panel — verify Usage Quota block shows correct count
- [ ] Click "Reset (dev)" — count drops to 0 and indicator disappears
- [ ] Set count to 50 manually in localStorage, run diagnosis — verify "Quota" badge and deterministic fallback with reset date
- [ ] Change month in localStorage to previous month, run diagnosis — verify auto-reset to 0
- [ ] `ng build` passes with zero errors