### PR TITLE
feat: add ai-diagnose firebase functions endpoint

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,14 +9,14 @@ export const aiProxy = onRequest((request, response) => {
 
 export const aiDiagnose = onRequest((request, response) => {
   if (request.method !== "POST") {
-    response.status(405).send({ error: "Method Not Allowed" });
+    response.status(405).send();
     return;
   }
 
   const evidence = request.body?.evidence;
 
   if (!evidence) {
-    response.status(400).send({ error: "Missing evidence in request body" });
+    response.status(400).send();
     return;
   }
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,3 +6,23 @@ export const aiProxy = onRequest((request, response) => {
   logger.info("AI Proxy placeholder called!", { structuredData: true });
   response.send({ status: "success", message: "AI Proxy is not yet implemented" });
 });
+
+export const aiDiagnose = onRequest((request, response) => {
+  if (request.method !== "POST") {
+    response.status(405).send({ error: "Method Not Allowed" });
+    return;
+  }
+
+  const evidence = request.body?.evidence;
+
+  if (!evidence) {
+    response.status(400).send({ error: "Missing evidence in request body" });
+    return;
+  }
+
+  response.status(200).send({
+    status: "ok",
+    message: "AI diagnose endpoint ready",
+    receivedEvidence: true
+  });
+});


### PR DESCRIPTION
Creates a skeleton Firebase Functions endpoint `/ai-diagnose` for AI diagnosis as requested in Issue #172.

### Endpoint Details
- **Name/Path:** `aiDiagnose` (reachable typically via `/aiDiagnose` locally depending on emulator config, or mapping to `/ai-diagnose`)
- **Example Request:**
  ```bash
  curl -X POST -H "Content-Type: application/json" -d '{"evidence": {"dtc": "P0171"}}' http://localhost:5001/<project-id>/<region>/aiDiagnose
  ```
- **Example Response:**
  ```json
  {
    "status": "ok",
    "message": "AI diagnose endpoint ready",
    "receivedEvidence": true
  }
  ```
- **How to run locally:**
  1. Navigate to the `functions` directory: `cd functions`
  2. Build the TypeScript code: `npm run build`
  3. Start the Firebase emulator: `npm run serve` (or `firebase emulators:start --only functions`)

---
*PR created automatically by Jules for task [939035416829096990](https://jules.google.com/task/939035416829096990) started by @jawwadHussain302*