### PR TITLE
feat: Add guided diagnostic engine foundation

### DIFF
--- a/src/app/core/diagnostics/diagnostic-engine.service.spec.ts
+++ b/src/app/core/diagnostics/diagnostic-engine.service.spec.ts
@@ -1,0 +1,170 @@
+import { DiagnosticEngineService } from './diagnostic-engine.service';
+import { KnowledgePack } from './diagnostic-types';
+
+describe('DiagnosticEngineService (Guided Engine)', () => {
+  let service: DiagnosticEngineService;
+
+  beforeEach(() => {
+    service = new DiagnosticEngineService();
+  });
+
+  it('should initialize correctly and state should be null initially', () => {
+    expect(service.getState()).toBeNull();
+  });
+
+  it('should start a pack and set initial state', () => {
+    const pack: KnowledgePack = {
+      id: 'no_start_pack',
+      title: 'No Start Engine',
+      hypotheses: [
+        { id: 'fuel_pump_failure', initialConfidence: 0.1 },
+        { id: 'dead_battery', initialConfidence: 0.5 }
+      ],
+      steps: [
+        {
+          id: 'step_1',
+          instruction: 'Turn the key to ON.',
+          question: 'Do you hear the fuel pump priming?',
+          options: [
+            { label: 'Yes', effect: { 'fuel_pump_failure': -0.4 }, next: 'step_2' },
+            { label: 'No', effect: { 'fuel_pump_failure': 0.6 }, next: 'step_3' }
+          ]
+        },
+        {
+          id: 'step_2',
+          instruction: 'Check battery voltage.',
+          question: 'Is battery voltage > 12V?',
+          options: [
+            { label: 'Yes', effect: { 'dead_battery': -0.5 } },
+            { label: 'No', effect: { 'dead_battery': 0.5 } }
+          ]
+        },
+        {
+          id: 'step_3',
+          instruction: 'Check fuel pump fuse.',
+          question: 'Is the fuse blown?',
+          options: [
+            { label: 'Yes', effect: { 'fuel_pump_failure': 0.8 } },
+            { label: 'No', effect: { 'fuel_pump_failure': -0.1 } }
+          ]
+        }
+      ]
+    };
+
+    service.startPack(pack);
+
+    const state = service.getState();
+    expect(state).toBeTruthy();
+    expect(state?.activePackId).toBe('no_start_pack');
+    expect(state?.hypothesisScores).toEqual({
+      'fuel_pump_failure': 0.1,
+      'dead_battery': 0.5
+    });
+    expect(state?.currentStepId).toBe('step_1');
+    expect(state?.history).toEqual([]);
+
+    expect(service.getCurrentStep()?.id).toBe('step_1');
+  });
+
+  it('should apply an answer, update scores and move to next step', () => {
+    const pack: KnowledgePack = {
+      id: 'no_start_pack',
+      title: 'No Start Engine',
+      hypotheses: [
+        { id: 'fuel_pump_failure', initialConfidence: 0.1 },
+        { id: 'dead_battery', initialConfidence: 0.5 }
+      ],
+      steps: [
+        {
+          id: 'step_1',
+          instruction: 'Turn the key to ON.',
+          question: 'Do you hear the fuel pump priming?',
+          options: [
+            { label: 'Yes', effect: { 'fuel_pump_failure': -0.4 }, next: 'step_2' },
+            { label: 'No', effect: { 'fuel_pump_failure': 0.6 }, next: 'step_3' }
+          ]
+        },
+        {
+          id: 'step_2',
+          instruction: 'Check battery voltage.',
+          question: 'Is battery voltage > 12V?',
+          options: [
+            { label: 'Yes', effect: { 'dead_battery': -0.5 } },
+            { label: 'No', effect: { 'dead_battery': 0.5 } }
+          ]
+        }
+      ]
+    };
+
+    service.startPack(pack);
+
+    // Apply "Yes" to step_1
+    service.applyAnswer(pack.steps[0].options[0]);
+
+    const state = service.getState();
+    expect(state?.hypothesisScores['fuel_pump_failure']).toBeCloseTo(-0.3); // 0.1 - 0.4
+    expect(state?.hypothesisScores['dead_battery']).toBe(0.5); // unchanged
+    expect(state?.currentStepId).toBe('step_2');
+    expect(state?.history.length).toBe(1);
+    expect(state?.history[0]).toEqual({ stepId: 'step_1', selectedOption: 'Yes' });
+  });
+
+  it('should auto-advance to next step in array if next is not provided', () => {
+    const pack: KnowledgePack = {
+      id: 'pack_1',
+      title: 'Pack 1',
+      hypotheses: [
+        { id: 'hyp_1', initialConfidence: 0 }
+      ],
+      steps: [
+        {
+          id: 'step_1',
+          instruction: 'Instruction 1',
+          question: 'Question 1',
+          options: [
+            { label: 'Opt 1', effect: { 'hyp_1': 0.5 } }
+          ]
+        },
+        {
+          id: 'step_2',
+          instruction: 'Instruction 2',
+          question: 'Question 2',
+          options: [
+             { label: 'Opt 2', effect: { 'hyp_1': 0.5 } }
+          ]
+        }
+      ]
+    };
+
+    service.startPack(pack);
+    service.applyAnswer(pack.steps[0].options[0]);
+
+    expect(service.getState()?.currentStepId).toBe('step_2');
+  });
+
+  it('should end pack when applying answer on last step without next', () => {
+     const pack: KnowledgePack = {
+      id: 'pack_1',
+      title: 'Pack 1',
+      hypotheses: [
+        { id: 'hyp_1', initialConfidence: 0 }
+      ],
+      steps: [
+        {
+          id: 'step_1',
+          instruction: 'Instruction 1',
+          question: 'Question 1',
+          options: [
+            { label: 'Opt 1', effect: { 'hyp_1': 0.5 } }
+          ]
+        }
+      ]
+    };
+
+    service.startPack(pack);
+    service.applyAnswer(pack.steps[0].options[0]);
+
+    expect(service.getState()?.currentStepId).toBe('');
+    expect(service.getCurrentStep()).toBeNull();
+  });
+});

--- a/src/app/core/diagnostics/diagnostic-engine.service.ts
+++ b/src/app/core/diagnostics/diagnostic-engine.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { ObdLiveFrame } from '../models/obd-live-frame.model';
 import { DiagnosticResult } from '../models/diagnostic-result.model';
+import { KnowledgePack, StepOption, DiagnosticState, Step, Hypothesis } from './diagnostic-types';
 import { DiagnosticRule } from './diagnostic-rule.interface';
 import { BatteryHealthRule } from './diagnostic-rules/battery-health.rule';
 import { IdleStabilityRule } from './diagnostic-rules/idle-stability.rule';
@@ -15,6 +16,10 @@ import { SignalValidator } from '../utils/signal-validator';
   providedIn: 'root'
 })
 export class DiagnosticEngineService {
+  private diagnosticStateSubject = new BehaviorSubject<DiagnosticState | null>(null);
+  public readonly diagnosticState$: Observable<DiagnosticState | null> = this.diagnosticStateSubject.asObservable();
+  private currentPack: KnowledgePack | null = null;
+
   private activeResultsSubject = new BehaviorSubject<DiagnosticResult[]>([]);
   public readonly activeResults$: Observable<DiagnosticResult[]> = this.activeResultsSubject.asObservable();
   
@@ -85,5 +90,72 @@ export class DiagnosticEngineService {
     }
 
     this.activeResultsSubject.next(results);
+  }
+// ─── Guided Diagnostic Engine ──────────────────────────────────────────────
+
+  public startPack(pack: KnowledgePack): void {
+    this.currentPack = pack;
+    const initialScores: Record<string, number> = {};
+    pack.hypotheses.forEach(h => {
+      initialScores[h.id] = h.initialConfidence;
+    });
+
+    const initialState: DiagnosticState = {
+      activePackId: pack.id,
+      hypothesisScores: initialScores,
+      currentStepId: pack.steps.length > 0 ? pack.steps[0].id : '',
+      history: []
+    };
+
+    this.diagnosticStateSubject.next(initialState);
+  }
+
+  public applyAnswer(option: StepOption): void {
+    const currentState = this.diagnosticStateSubject.value;
+    if (!currentState || !this.currentPack) return;
+
+    this.updateHypothesisScores(option.effect, currentState);
+
+    // Add to history
+    currentState.history.push({
+      stepId: currentState.currentStepId,
+      selectedOption: option.label
+    });
+
+    // Advance to next step
+    if (option.next) {
+      currentState.currentStepId = option.next;
+    } else {
+      // Find the current step index and move to the next one in the array
+      const currentIndex = this.currentPack.steps.findIndex(s => s.id === currentState.currentStepId);
+      if (currentIndex !== -1 && currentIndex < this.currentPack.steps.length - 1) {
+        currentState.currentStepId = this.currentPack.steps[currentIndex + 1].id;
+      } else {
+         // Pack is complete
+         currentState.currentStepId = '';
+      }
+    }
+
+    this.diagnosticStateSubject.next({ ...currentState });
+  }
+
+  public updateHypothesisScores(effect: Record<string, number>, currentState: DiagnosticState = this.diagnosticStateSubject.value!): void {
+     if (!currentState) return;
+     for (const [hypothesisId, scoreChange] of Object.entries(effect)) {
+        if (currentState.hypothesisScores[hypothesisId] !== undefined) {
+           currentState.hypothesisScores[hypothesisId] += scoreChange;
+        }
+     }
+  }
+
+  public getCurrentStep(): Step | null {
+    const currentState = this.diagnosticStateSubject.value;
+    if (!currentState || !this.currentPack || !currentState.currentStepId) return null;
+
+    return this.currentPack.steps.find(s => s.id === currentState.currentStepId) || null;
+  }
+
+  public getState(): DiagnosticState | null {
+    return this.diagnosticStateSubject.value;
   }
 }

--- a/src/app/core/diagnostics/diagnostic-engine.service.ts
+++ b/src/app/core/diagnostics/diagnostic-engine.service.ts
@@ -114,29 +114,36 @@ export class DiagnosticEngineService {
     const currentState = this.diagnosticStateSubject.value;
     if (!currentState || !this.currentPack) return;
 
-    this.updateHypothesisScores(option.effect, currentState);
+    // Create a deep copy to avoid mutating the nested hypothesisScores object
+    const newState = {
+      ...currentState,
+      hypothesisScores: { ...currentState.hypothesisScores },
+      history: [...currentState.history]
+    };
+
+    this.updateHypothesisScores(option.effect, newState);
 
     // Add to history
-    currentState.history.push({
-      stepId: currentState.currentStepId,
+    newState.history.push({
+      stepId: newState.currentStepId,
       selectedOption: option.label
     });
 
     // Advance to next step
     if (option.next) {
-      currentState.currentStepId = option.next;
+      newState.currentStepId = option.next;
     } else {
       // Find the current step index and move to the next one in the array
-      const currentIndex = this.currentPack.steps.findIndex(s => s.id === currentState.currentStepId);
+      const currentIndex = this.currentPack.steps.findIndex(s => s.id === newState.currentStepId);
       if (currentIndex !== -1 && currentIndex < this.currentPack.steps.length - 1) {
-        currentState.currentStepId = this.currentPack.steps[currentIndex + 1].id;
+        newState.currentStepId = this.currentPack.steps[currentIndex + 1].id;
       } else {
          // Pack is complete
-         currentState.currentStepId = '';
+         newState.currentStepId = '';
       }
     }
 
-    this.diagnosticStateSubject.next({ ...currentState });
+    this.diagnosticStateSubject.next(newState);
   }
 
   public updateHypothesisScores(effect: Record<string, number>, currentState: DiagnosticState = this.diagnosticStateSubject.value!): void {

--- a/src/app/core/diagnostics/diagnostic-types.ts
+++ b/src/app/core/diagnostics/diagnostic-types.ts
@@ -1,0 +1,34 @@
+export interface KnowledgePack {
+  id: string;
+  title: string;
+  hypotheses: Hypothesis[];
+  steps: Step[];
+}
+
+export interface Hypothesis {
+  id: string;
+  initialConfidence: number;
+}
+
+export interface Step {
+  id: string;
+  instruction: string;
+  question: string;
+  options: StepOption[];
+}
+
+export interface StepOption {
+  label: string;
+  effect: Record<string, number>;
+  next?: string;
+}
+
+export interface DiagnosticState {
+  activePackId: string;
+  hypothesisScores: Record<string, number>;
+  currentStepId: string;
+  history: {
+    stepId: string;
+    selectedOption: string;
+  }[];
+}


### PR DESCRIPTION
This PR introduces the foundational data structures and state management for guided diagnostic workflows.

### Changes:
- **`diagnostic-types.ts`:** Added interfaces for `KnowledgePack`, `Hypothesis`, `Step`, `StepOption`, and `DiagnosticState`.
- **`diagnostic-engine.service.ts`:** Added the state and progression logic for the guided diagnostic engine (`startPack`, `applyAnswer`, `updateHypothesisScores`, `getCurrentStep`, `getState`), without modifying the existing live OBD rule engine logic.
- **`diagnostic-engine.service.spec.ts`:** Provides an example hardcoded Knowledge Pack, simulates an example state progression, and demonstrates testing the engine in isolation.

No UI or AI integrations were added. The logic remains clean and isolated as per requirements.

---
*PR created automatically by Jules for task [12971945496498494311](https://jules.google.com/task/12971945496498494311) started by @jawwadHussain302*