### PR TITLE
fix: clean-diagnosis fallback bug + OpenRouter error parsing

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "obd2-f5a03"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ Thumbs.db
 .claude/worktrees/ecstatic-ride-f0c8de/code-review-graph/
 functions/node_modules
 functions/lib
+functions/.env*

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,7 +14,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.94.0",
     "firebase-admin": "^13.8.0",
     "firebase-functions": "^6.6.0"
   },

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,14 +1,17 @@
 import { onRequest } from "firebase-functions/v2/https";
 import * as logger from "firebase-functions/logger";
-import Anthropic from "@anthropic-ai/sdk";
+import { defineSecret } from "firebase-functions/params";
 import { randomUUID } from "crypto";
 
-const MODEL = "claude-haiku-4-5-20251001";
-
-// Reject any payload larger than 64 KB — real evidence objects are well under 4 KB.
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const MODEL = "openai/gpt-4o-mini";
+const MAX_TOKENS = 512;
+const TIMEOUT_MS = 30_000;
 const MAX_PAYLOAD_BYTES = 64 * 1024;
 
-// ── System prompt (v3 — must stay in sync with AiPromptService) ───────────────
+const openRouterKey = defineSecret("OPENROUTER_API_KEY");
+
+// ── System prompt ─────────────────────────────────────────────────────────────
 const SYSTEM_PROMPT = `You are a vehicle diagnostic assistant inside a professional OBD2 tool used by mechanics and workshops.
 
 RULES — follow every rule without exception:
@@ -18,14 +21,14 @@ RULES — follow every rule without exception:
 4. "primary_issue": when a fault code is present, start with the code: e.g. "P0171 — Lean Condition (Vacuum Leak)". When no code, use the cause title directly. Max 80 chars.
 5. "explanation" (20–120 words): open with what the car is actually doing, not the DTC system. Start with "Your engine...", "The fuel mixture...", or similar owner-facing language. Name the fault code if one is present.
 6. "evidence": each item must cite a DTC code, a measured signal value, or a verbatim correlation finding. NEVER write generic phrases like "vehicle has a fault" or "fault detected".
-7. "confidence": use the primaryCause confidence exactly. If the diagnosis is partial, drop one level (High → Medium, Medium → Low). If no primaryCause, use "Low".
+7. "confidence": use the primaryCause confidence level. If partial, drop one level (high → medium, medium → low). If no primaryCause, use "low". Always lowercase.
 8. "next_steps": workshop-ready actions, ordered Immediate first, then Soon, then Routine. Max 4 items. Never write "check the vehicle" or "consult a garage".
-9. Clean diagnosis (no fault codes, no findings): set primary_issue to "No fault detected", confidence "Low", first next_step "No immediate action required — monitor and schedule routine service".
+9. Clean diagnosis (no fault codes, no findings): set primary_issue to "No fault detected", confidence "low", first next_step "No immediate action required — monitor and schedule routine service".
 
 SCHEMA:
 {
   "primary_issue": "<DTC + short title if applicable, ≤80 chars>",
-  "confidence": "High" | "Medium" | "Low",
+  "confidence": "high" | "medium" | "low",
   "evidence": ["<DTC code / signal value / finding>", ...],
   "explanation": "<20–120 words, owner-facing language>",
   "next_steps": ["<Immediate action>", "<Soon action>", ...]
@@ -34,17 +37,11 @@ SCHEMA:
 GOOD EXAMPLE (vacuum leak scenario):
 {
   "primary_issue": "P0171 — Lean Condition (Vacuum / Intake Leak)",
-  "confidence": "High",
+  "confidence": "high",
   "evidence": ["P0171: System Too Lean (Bank 1)", "STFT B1 +18% at idle, drops to +4% at 2500 RPM", "Vacuum leak pattern: trims improve at higher RPM"],
   "explanation": "Your engine is pulling in extra unmetered air through a gap in the intake system. The short-term fuel trim is very high at idle but normalises under load, which is the classic signature of a vacuum or intake leak rather than a fuel delivery problem.",
   "next_steps": ["Perform intake smoke test with engine running to locate air leak", "Inspect PCV valve and breather hose for cracks", "Check all intake hoses between air filter and throttle body", "Clear DTC and verify STFT returns to ±5% after repair"]
-}
-
-NEGATIVE EXAMPLES — never produce:
-  BAD evidence:    "The vehicle shows signs of a fault"     → GENERIC
-  BAD next_step:   "Check the car at a garage"             → VAGUE
-  BAD explanation: "The engine management system has detected P0171..." → TEXTBOOK
-  BAD primary_issue: "Engine fault detected"               → NOT SPECIFIC`;
+}`;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -70,14 +67,14 @@ interface RequestContext {
 interface DiagnosisResponse {
   requestId: string;
   primary_issue: string;
-  confidence: "High" | "Medium" | "Low";
+  confidence: "low" | "medium" | "high";
   explanation: string;
   next_steps: string[];
   warnings: string[];
   evidence: string[];
 }
 
-// ── Input validation & coercion ───────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
 function isNonNullObject(val: unknown): val is Record<string, unknown> {
   return typeof val === "object" && val !== null && !Array.isArray(val);
@@ -91,12 +88,26 @@ function coerceStringArray(val: unknown, max: number, maxItemLen = 200): string[
     .slice(0, max);
 }
 
+function buildFallback(requestId: string, warnings: string[]): DiagnosisResponse {
+  return {
+    requestId,
+    primary_issue: "Unable to determine",
+    confidence: "low",
+    explanation: "Insufficient or unclear data",
+    next_steps: ["Check basic conditions", "Retry diagnosis"],
+    warnings,
+    evidence: [],
+  };
+}
+
+// ── Input coercion ────────────────────────────────────────────────────────────
+
 function coerceEvidence(raw: Record<string, unknown>): SafeEvidence {
   const dtcArr = Array.isArray(raw["dtcs"]) ? (raw["dtcs"] as unknown[]) : [];
   const dtcs = dtcArr
     .filter(isNonNullObject)
     .map(d => ({
-      code: typeof d["code"] === "string" ? d["code"].slice(0, 10) : "",
+      code:  typeof d["code"]  === "string" ? d["code"].slice(0, 10)  : "",
       title: typeof d["title"] === "string" ? d["title"].slice(0, 80) : "",
       ...(typeof d["severity"] === "string" ? { severity: d["severity"].slice(0, 20) } : {}),
     }))
@@ -107,15 +118,9 @@ function coerceEvidence(raw: Record<string, unknown>): SafeEvidence {
   const primaryCause =
     rawPc !== null && typeof rawPc["title"] === "string" && rawPc["title"].trim()
       ? {
-          title: rawPc["title"].trim().slice(0, 100),
-          confidence:
-            typeof rawPc["confidence"] === "string"
-              ? rawPc["confidence"].slice(0, 20)
-              : "Low",
-          explanation:
-            typeof rawPc["explanation"] === "string"
-              ? rawPc["explanation"].slice(0, 400)
-              : "",
+          title:       rawPc["title"].trim().slice(0, 100),
+          confidence:  typeof rawPc["confidence"]  === "string" ? rawPc["confidence"].slice(0, 20)  : "low",
+          explanation: typeof rawPc["explanation"] === "string" ? rawPc["explanation"].slice(0, 400) : "",
         }
       : null;
 
@@ -124,10 +129,8 @@ function coerceEvidence(raw: Record<string, unknown>): SafeEvidence {
   )
     .filter(isNonNullObject)
     .map(c => ({
-      title:
-        typeof c["title"] === "string" ? c["title"].slice(0, 100) : "",
-      confidence:
-        typeof c["confidence"] === "string" ? c["confidence"].slice(0, 20) : "Low",
+      title:      typeof c["title"]      === "string" ? c["title"].slice(0, 100)      : "",
+      confidence: typeof c["confidence"] === "string" ? c["confidence"].slice(0, 20) : "low",
     }))
     .filter(c => c.title.length > 0)
     .slice(0, 5);
@@ -138,22 +141,16 @@ function coerceEvidence(raw: Record<string, unknown>): SafeEvidence {
         ? Math.min(100, Math.max(0, Math.round(raw["severityScore"])))
         : 0,
     severityLevel:
-      typeof raw["severityLevel"] === "string"
-        ? raw["severityLevel"].slice(0, 20)
-        : "Unknown",
+      typeof raw["severityLevel"] === "string" ? raw["severityLevel"].slice(0, 20) : "Unknown",
     dtcs,
     primaryCause,
     additionalCauses,
     correlationFindings: coerceStringArray(raw["correlationFindings"], 10),
-    recommendedChecks: coerceStringArray(raw["recommendedChecks"], 10),
+    recommendedChecks:   coerceStringArray(raw["recommendedChecks"],   10),
     fuelTrimNote:
-      typeof raw["fuelTrimNote"] === "string"
-        ? raw["fuelTrimNote"].slice(0, 200)
-        : null,
+      typeof raw["fuelTrimNote"] === "string" ? raw["fuelTrimNote"].slice(0, 200) : null,
     idleStabilityNote:
-      typeof raw["idleStabilityNote"] === "string"
-        ? raw["idleStabilityNote"].slice(0, 200)
-        : null,
+      typeof raw["idleStabilityNote"] === "string" ? raw["idleStabilityNote"].slice(0, 200) : null,
     isPartial: raw["isPartial"] === true,
   };
 }
@@ -162,14 +159,11 @@ function coerceContext(raw: unknown): RequestContext {
   if (!isNonNullObject(raw)) return {};
   return {
     ...(typeof raw["vehicle"] === "string" && raw["vehicle"].trim()
-      ? { vehicle: raw["vehicle"].trim().slice(0, 100) }
-      : {}),
+      ? { vehicle: raw["vehicle"].trim().slice(0, 100) } : {}),
     ...(typeof raw["engine"] === "string" && raw["engine"].trim()
-      ? { engine: raw["engine"].trim().slice(0, 50) }
-      : {}),
+      ? { engine: raw["engine"].trim().slice(0, 50) } : {}),
     ...(typeof raw["source"] === "string" && raw["source"].trim()
-      ? { source: raw["source"].trim().slice(0, 50) }
-      : {}),
+      ? { source: raw["source"].trim().slice(0, 50) } : {}),
   };
 }
 
@@ -184,9 +178,7 @@ function buildUserMessage(evidence: SafeEvidence, context: RequestContext): stri
   lines.push(`Severity: ${evidence.severityLevel} (score ${evidence.severityScore}/100)`);
 
   if (evidence.isPartial) {
-    lines.push(
-      "⚠ Partial diagnosis — not all test steps completed. Reduce confidence by one level."
-    );
+    lines.push("⚠ Partial diagnosis — not all test steps completed. Reduce confidence by one level.");
   }
 
   if (evidence.dtcs.length) {
@@ -203,14 +195,12 @@ function buildUserMessage(evidence: SafeEvidence, context: RequestContext): stri
     lines.push(`  Title: ${evidence.primaryCause.title}`);
     lines.push(`  Detail: ${evidence.primaryCause.explanation}`);
   } else {
-    lines.push('\nPrimary Root Cause: Not identified — use "Low" confidence');
+    lines.push('\nPrimary Root Cause: Not identified — use "low" confidence');
   }
 
   if (evidence.additionalCauses.length) {
     lines.push("\nOther Candidates (lower priority):");
-    evidence.additionalCauses.forEach(c =>
-      lines.push(`  - ${c.title} [${c.confidence}]`)
-    );
+    evidence.additionalCauses.forEach(c => lines.push(`  - ${c.title} [${c.confidence}]`));
   }
 
   if (evidence.correlationFindings.length) {
@@ -219,21 +209,15 @@ function buildUserMessage(evidence: SafeEvidence, context: RequestContext): stri
   }
 
   if (evidence.fuelTrimNote) {
-    lines.push(
-      `\nFuel Trim Signal (cite the % values in evidence): ${evidence.fuelTrimNote}`
-    );
+    lines.push(`\nFuel Trim Signal (cite the % values in evidence): ${evidence.fuelTrimNote}`);
   }
 
   if (evidence.idleStabilityNote) {
-    lines.push(
-      `Idle Stability Signal (cite RPM variance in evidence): ${evidence.idleStabilityNote}`
-    );
+    lines.push(`Idle Stability Signal (cite RPM variance in evidence): ${evidence.idleStabilityNote}`);
   }
 
   if (evidence.recommendedChecks.length) {
-    lines.push(
-      "\nRecommended Checks — use as basis for next_steps, Immediate priority first:"
-    );
+    lines.push("\nRecommended Checks — use as basis for next_steps, Immediate priority first:");
     evidence.recommendedChecks.forEach((c, i) => lines.push(`  ${i + 1}. ${c}`));
   } else if (!evidence.dtcs.length && !evidence.correlationFindings.length) {
     lines.push("\nRecommended Checks: None — vehicle appears clean.");
@@ -243,28 +227,13 @@ function buildUserMessage(evidence: SafeEvidence, context: RequestContext): stri
   return lines.join("\n");
 }
 
-// ── Response parsing & validation ─────────────────────────────────────────────
-
-function buildFallback(requestId: string, warnings: string[]): DiagnosisResponse {
-  return {
-    requestId,
-    primary_issue: "Diagnostic analysis unavailable",
-    confidence: "Low",
-    explanation:
-      "The AI diagnostic service is temporarily unavailable. Please review the diagnostic data manually or try again later.",
-    next_steps: [
-      "Review any stored fault codes manually",
-      "Consult a qualified mechanic if fault codes are present",
-      "Retry the AI analysis when the service is available",
-    ],
-    warnings,
-    evidence: [],
-  };
-}
+// ── Response validation ───────────────────────────────────────────────────────
 
 function parseAiResponse(text: string, requestId: string): DiagnosisResponse | null {
   let parsed: unknown;
   try {
+    // response_format: json_object means the model should not wrap in fences,
+    // but strip them defensively just in case.
     const cleaned = text
       .replace(/^```(?:json)?\s*/i, "")
       .replace(/\s*```\s*$/i, "")
@@ -288,111 +257,141 @@ function parseAiResponse(text: string, requestId: string): DiagnosisResponse | n
 
   if (!primary_issue || !explanation) return null;
 
-  // Normalize confidence: accept any casing from the model, return title case.
-  const rawConf =
-    typeof obj["confidence"] === "string" ? obj["confidence"].trim().toLowerCase() : "";
-  const confidence: "High" | "Medium" | "Low" =
-    rawConf === "high" ? "High" : rawConf === "medium" ? "Medium" : "Low";
+  const rawConf = typeof obj["confidence"] === "string" ? obj["confidence"].trim().toLowerCase() : "";
+  const confidence: "low" | "medium" | "high" =
+    rawConf === "high" ? "high" : rawConf === "medium" ? "medium" : "low";
 
   const evidence   = coerceStringArray(obj["evidence"],   5);
   const next_steps = coerceStringArray(obj["next_steps"], 4);
   const warnings   = coerceStringArray(obj["warnings"],   5);
 
-  // Both fields must have at least one item to be considered a valid response.
   if (!evidence.length || !next_steps.length) return null;
 
   return { requestId, primary_issue, confidence, explanation, next_steps, warnings, evidence };
 }
 
-// ── Handler ───────────────────────────────────────────────────────────────────
+// ── OpenRouter call ───────────────────────────────────────────────────────────
 
-export const aiDiagnose = onRequest({ cors: true }, async (request, response) => {
-  const requestId = randomUUID();
-
-  if (request.method !== "POST") {
-    response.status(405).send({ error: "Method not allowed", requestId });
-    return;
-  }
-
-  // Guard against oversized payloads before touching any content.
-  const rawBody = JSON.stringify(request.body ?? {});
-  if (Buffer.byteLength(rawBody, "utf8") > MAX_PAYLOAD_BYTES) {
-    logger.warn("Payload too large", { requestId });
-    response.status(413).send({ error: "Payload too large", requestId });
-    return;
-  }
-
-  // Guard against JSON null or a non-object body before touching any fields.
-  if (!isNonNullObject(request.body)) {
-    response.status(400).send({
-      error: "Request body must be a JSON object",
-      requestId,
-    });
-    return;
-  }
-
-  const body = request.body as Record<string, unknown>;
-
-  // evidence: required, non-null, non-array object.
-  if (!isNonNullObject(body["evidence"])) {
-    response.status(400).send({
-      error: "evidence is required and must be a non-null object",
-      requestId,
-    });
-    return;
-  }
-
-  const evidence = coerceEvidence(body["evidence"] as Record<string, unknown>);
-  const context  = coerceContext(body["context"]);
-
-  logger.info("ai-diagnose request received", {
-    requestId,
-    dtcCount: evidence.dtcs.length,
-    severityLevel: evidence.severityLevel,
-    isPartial: evidence.isPartial,
-    source: context.source ?? "unknown",
-  });
-
-  const apiKey = process.env["ANTHROPIC_API_KEY"];
-  if (!apiKey) {
-    logger.error("ANTHROPIC_API_KEY is not configured", { requestId });
-    response.status(200).send(buildFallback(requestId, ["AI service not configured"]));
-    return;
-  }
-
-  const userMessage = buildUserMessage(evidence, context);
+async function callOpenRouter(
+  apiKey: string,
+  systemPrompt: string,
+  userMessage: string
+): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
   try {
-    const client = new Anthropic({ apiKey });
-
-    const message = await client.messages.create({
-      model: MODEL,
-      max_tokens: 512,
-      system: SYSTEM_PROMPT,
-      messages: [{ role: "user", content: userMessage }],
+    const res = await fetch(OPENROUTER_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user",   content: userMessage  },
+        ],
+      }),
+      signal: controller.signal,
     });
 
-    const textBlock = message.content.find(b => b.type === "text");
-    if (!textBlock || textBlock.type !== "text") {
-      logger.warn("No text block in Anthropic response", { requestId });
-      response.status(200).send(buildFallback(requestId, ["AI returned an empty response"]));
-      return;
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({})) as Record<string, unknown>;
+      const errMsg = typeof errBody["error"] === "string"
+        ? errBody["error"]
+        : `HTTP ${res.status}`;
+      throw new Error(errMsg);
     }
 
-    const result = parseAiResponse(textBlock.text, requestId);
-    if (!result) {
-      logger.warn("AI response failed schema validation", { requestId });
-      response
-        .status(200)
-        .send(buildFallback(requestId, ["AI response did not match the required format"]));
-      return;
-    }
-
-    logger.info("ai-diagnose completed", { requestId, confidence: result.confidence });
-    response.status(200).send(result);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : "Unknown error";
-    logger.error("Anthropic API call failed", { requestId, message: msg });
-    response.status(200).send(buildFallback(requestId, [`AI service error: ${msg}`]));
+    const data = await res.json() as {
+      choices?: { message?: { content?: string } }[];
+    };
+    const content = data.choices?.[0]?.message?.content ?? "";
+    if (!content.trim()) throw new Error("Empty content from OpenRouter");
+    return content;
+  } finally {
+    clearTimeout(timer);
   }
-});
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+export const aiDiagnose = onRequest(
+  { cors: true, secrets: [openRouterKey] },
+  async (request, response) => {
+    const requestId = randomUUID();
+
+    if (request.method !== "POST") {
+      response.status(405).send({ error: "Method not allowed", requestId });
+      return;
+    }
+
+    // Reject oversized payloads before touching content.
+    if (Buffer.byteLength(JSON.stringify(request.body ?? {}), "utf8") > MAX_PAYLOAD_BYTES) {
+      logger.warn("Payload too large", { requestId });
+      response.status(413).send({ error: "Payload too large", requestId });
+      return;
+    }
+
+    // Body must be a non-null object (guards against JSON null).
+    if (!isNonNullObject(request.body)) {
+      response.status(400).send({ error: "Request body must be a JSON object", requestId });
+      return;
+    }
+
+    const body = request.body as Record<string, unknown>;
+
+    // evidence is required and must be a non-null, non-array object.
+    if (!isNonNullObject(body["evidence"])) {
+      response.status(400).send({
+        error: "evidence is required and must be a non-null object",
+        requestId,
+      });
+      return;
+    }
+
+    const evidence = coerceEvidence(body["evidence"] as Record<string, unknown>);
+    const context  = coerceContext(body["context"]);
+
+    logger.info("ai-diagnose: request start", {
+      requestId,
+      dtcCount: evidence.dtcs.length,
+      severityLevel: evidence.severityLevel,
+      isPartial: evidence.isPartial,
+      source: context.source ?? "unknown",
+    });
+
+    const apiKey = openRouterKey.value();
+    if (!apiKey) {
+      logger.error("ai-diagnose: OPENROUTER_API_KEY secret is empty", { requestId });
+      response.status(200).send(buildFallback(requestId, ["AI service not configured"]));
+      return;
+    }
+
+    const userMessage = buildUserMessage(evidence, context);
+
+    try {
+      const rawText = await callOpenRouter(apiKey, SYSTEM_PROMPT, userMessage);
+      const result  = parseAiResponse(rawText, requestId);
+
+      if (!result) {
+        logger.warn("ai-diagnose: response failed schema validation", { requestId });
+        response.status(200).send(
+          buildFallback(requestId, ["AI response did not match the required format"])
+        );
+        return;
+      }
+
+      logger.info("ai-diagnose: success", { requestId, confidence: result.confidence });
+      response.status(200).send(result);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      logger.error("ai-diagnose: error", { requestId, reason: msg });
+      response.status(200).send(buildFallback(requestId, [`AI service error: ${msg}`]));
+    }
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -262,7 +262,9 @@ function parseAiResponse(text: string, requestId: string): DiagnosisResponse | n
   const next_steps = coerceStringArray(obj["next_steps"], 4);
   const warnings   = coerceStringArray(obj["warnings"],   5);
 
-  if (!evidence.length || !next_steps.length) return null;
+  // next_steps must have at least one item.
+  // evidence may be empty for clean diagnoses (no fault codes / no findings to cite).
+  if (!next_steps.length) return null;
 
   return { requestId, primary_issue, confidence, explanation, next_steps, warnings, evidence };
 }
@@ -298,8 +300,10 @@ async function callOpenRouter(
 
     if (!res.ok) {
       const errBody = await res.json().catch(() => ({})) as Record<string, unknown>;
-      const errMsg = typeof errBody["error"] === "string"
-        ? errBody["error"]
+      const errObj  = errBody["error"];
+      // OpenRouter wraps errors as { error: { message, code } }; fall back to plain string.
+      const errMsg  = typeof errObj === "string" ? errObj
+        : isNonNullObject(errObj) && typeof errObj["message"] === "string" ? errObj["message"]
         : `HTTP ${res.status}`;
       throw new Error(errMsg);
     }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,5 @@
 import { onRequest } from "firebase-functions/v2/https";
 import * as logger from "firebase-functions/logger";
-import { defineSecret } from "firebase-functions/params";
 import { randomUUID } from "crypto";
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
@@ -8,8 +7,6 @@ const MODEL = "openai/gpt-4o-mini";
 const MAX_TOKENS = 512;
 const TIMEOUT_MS = 30_000;
 const MAX_PAYLOAD_BYTES = 64 * 1024;
-
-const openRouterKey = defineSecret("OPENROUTER_API_KEY");
 
 // ── System prompt ─────────────────────────────────────────────────────────────
 const SYSTEM_PROMPT = `You are a vehicle diagnostic assistant inside a professional OBD2 tool used by mechanics and workshops.
@@ -321,7 +318,7 @@ async function callOpenRouter(
 // ── Handler ───────────────────────────────────────────────────────────────────
 
 export const aiDiagnose = onRequest(
-  { cors: true, secrets: [openRouterKey] },
+  { cors: true },
   async (request, response) => {
     const requestId = randomUUID();
 
@@ -365,9 +362,9 @@ export const aiDiagnose = onRequest(
       source: context.source ?? "unknown",
     });
 
-    const apiKey = openRouterKey.value();
+    const apiKey = process.env["OPENROUTER_API_KEY"] ?? "";
     if (!apiKey) {
-      logger.error("ai-diagnose: OPENROUTER_API_KEY secret is empty", { requestId });
+      logger.error("ai-diagnose: OPENROUTER_API_KEY is not set", { requestId });
       response.status(200).send(buildFallback(requestId, ["AI service not configured"]));
       return;
     }

--- a/src/app/core/ai/ai-diagnosis.service.ts
+++ b/src/app/core/ai/ai-diagnosis.service.ts
@@ -149,7 +149,11 @@ export class AiDiagnosisService {
       evidence: string[];
     };
 
-    // Re-serialize so the existing local validator can process it unchanged.
-    return JSON.stringify(data);
+    // Firebase returns lowercase confidence ("low"|"medium"|"high").
+    // The local validator expects title case ("Low"|"Medium"|"High"); normalize here.
+    const c = (data.confidence ?? '').toLowerCase();
+    const confidence = c === 'high' ? 'High' : c === 'medium' ? 'Medium' : 'Low';
+
+    return JSON.stringify({ ...data, confidence });
   }
 }

--- a/src/app/core/ai/ai-diagnosis.service.ts
+++ b/src/app/core/ai/ai-diagnosis.service.ts
@@ -7,9 +7,7 @@ import { AiResponseValidatorService } from './ai-response-validator.service';
 import { AiFallbackService } from './ai-fallback.service';
 import { AiUsageTrackerService } from './ai-usage-tracker.service';
 
-// Update to your deployed function URL.
-// Emulator: http://127.0.0.1:5001/{project-id}/us-central1/aiDiagnose
-const FIREBASE_FUNCTION_URL = '/api/ai-diagnose';
+const FIREBASE_FUNCTION_URL = 'https://us-central1-obd2-f5a03.cloudfunctions.net/aiDiagnose';
 
 const IDLE_INSIGHT: AiInsight = { status: 'idle', response: null, generatedAt: null, isFallback: false };
 

--- a/src/app/core/ai/ai-response-validator.service.ts
+++ b/src/app/core/ai/ai-response-validator.service.ts
@@ -34,8 +34,8 @@ export class AiResponseValidatorService {
     const evidence  = this.coerceStringArray(obj['evidence'],   5);
     const nextSteps = this.coerceStringArray(obj['next_steps'], 4);
 
-    // Need at least one evidence item and one next step
-    if (!evidence.length || !nextSteps.length) return null;
+    // next_steps must be non-empty; evidence may be empty for clean diagnoses.
+    if (!nextSteps.length) return null;
 
     return {
       primary_issue: primaryIssue.slice(0, 120),

--- a/src/app/core/diagnostics/packs/index.ts
+++ b/src/app/core/diagnostics/packs/index.ts
@@ -1,0 +1,1 @@
+export { noStartPack } from './no-start.pack';

--- a/src/app/core/diagnostics/packs/no-start.pack.spec.ts
+++ b/src/app/core/diagnostics/packs/no-start.pack.spec.ts
@@ -1,0 +1,163 @@
+import { TestBed } from '@angular/core/testing';
+import { DiagnosticEngineService } from '../diagnostic-engine.service';
+import { DiagnosticState } from '../diagnostic-types';
+import { noStartPack } from './no-start.pack';
+
+/**
+ * No-Start Pack — scenario walkthroughs
+ *
+ * Each scenario simulates a mechanic answering every step and verifies:
+ *   - hypothesis score ordering matches the expected root cause
+ *   - the pack completes (currentStepId === '')
+ *   - answer history length matches steps taken
+ *
+ * Score arithmetic — initial: 0.25 each, deltas additive:
+ *   HEAVY=0.40  STRONG=0.35  MEDIUM=0.20  SLIGHT=0.15  REDUCE=-0.20
+ */
+
+function topHypothesis(state: DiagnosticState): string {
+  return Object.entries(state.hypothesisScores)
+    .sort(([, a], [, b]) => b - a)[0][0];
+}
+
+describe('noStartPack', () => {
+  let engine: DiagnosticEngineService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    engine = TestBed.inject(DiagnosticEngineService);
+  });
+
+  // ── Scenario A: Fuel starvation ──────────────────────────────────────────
+  // Mechanic hears cranking RPM, no pump prime, no fuel at rail — confirmed
+  // upstream fuel failure. Skip branches to spark_check. Spark is fine.
+  // Compression normal. Expected winner: fuel_issue.
+  it('Scenario A — fuel starvation: fuel_issue wins', () => {
+    engine.startPack(noStartPack);
+
+    // Step 1: cranking_rpm — Yes (RPM rises)
+    let step = engine.getCurrentStep()!;
+    expect(step.id).toBe('cranking_rpm');
+    engine.applyAnswer(step.options[0]); // Yes — RPM rises
+
+    // Step 2: fuel_pump_prime — No (silence)
+    step = engine.getCurrentStep()!;
+    expect(step.id).toBe('fuel_pump_prime');
+    engine.applyAnswer(step.options[1]); // No — silence  → fuel_issue +STRONG (0.35)
+
+    // Step 3: fuel_delivery — No (nothing at rail) → fuel_issue +STRONG (0.35), skip to spark_check
+    step = engine.getCurrentStep()!;
+    expect(step.id).toBe('fuel_delivery');
+    engine.applyAnswer(step.options[1]); // No — nothing at the rail
+
+    // Step 4: spark_check (skipped fuel_pressure and injector_activity)
+    step = engine.getCurrentStep()!;
+    expect(step.id).toBe('spark_check');
+    engine.applyAnswer(step.options[0]); // Yes — strong blue spark
+
+    // Step 5: compression — normal
+    step = engine.getCurrentStep()!;
+    expect(step.id).toBe('compression');
+    engine.applyAnswer(step.options[0]); // Normal  → compression_issue -REDUCE (-0.20)
+
+    // Pack complete
+    const state = engine.getState()!;
+    expect(state.currentStepId).toBe('');
+    expect(state.history.length).toBe(5);
+
+    // fuel_issue = 0.25 + 0.35 + 0.35 = 0.95 — clearly the top cause
+    expect(topHypothesis(state)).toBe('fuel_issue');
+    expect(state.hypothesisScores['fuel_issue']).toBeCloseTo(0.95, 5);
+  });
+
+  // ── Scenario B: Ignition / coil fault ───────────────────────────────────
+  // RPM visible, pump primes, fuel at rail with good pressure, injectors
+  // clicking. But NO spark. Expected winner: ignition_issue.
+  it('Scenario B — ignition fault: ignition_issue wins', () => {
+    engine.startPack(noStartPack);
+
+    // cranking_rpm — Yes
+    let step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // fuel_pump_prime — Yes (heard hum)
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // fuel_delivery — Yes (fuel present)
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // fuel_pressure — Strong (within spec)
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // injector_activity — Yes (clicking)
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // spark_check — No spark  → ignition_issue +HEAVY (0.40)
+    step = engine.getCurrentStep()!;
+    expect(step.id).toBe('spark_check');
+    engine.applyAnswer(step.options[1]);
+
+    // compression — Normal  → compression_issue -0.20
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    const state = engine.getState()!;
+    expect(state.currentStepId).toBe('');
+    expect(state.history.length).toBe(7);
+
+    // ignition_issue = 0.25 + 0.40 = 0.65
+    expect(topHypothesis(state)).toBe('ignition_issue');
+    expect(state.hypothesisScores['ignition_issue']).toBeCloseTo(0.65, 5);
+  });
+
+  // ── Scenario C: Crank sensor failure ────────────────────────────────────
+  // RPM stays at zero during crank (no crank signal). Pump primes OK, fuel
+  // at rail with good pressure. Injectors silent (ECU won't fire without
+  // crank signal). Spark absent for same reason. Expected winner: crank_sensor_issue.
+  it('Scenario C — crank sensor failure: crank_sensor_issue wins', () => {
+    engine.startPack(noStartPack);
+
+    // cranking_rpm — No (RPM stays at zero)  → crank_sensor_issue +HEAVY (0.40)
+    let step = engine.getCurrentStep()!;
+    expect(step.id).toBe('cranking_rpm');
+    engine.applyAnswer(step.options[1]);
+
+    // fuel_pump_prime — Yes (pump primes fine)
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // fuel_delivery — Yes
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // fuel_pressure — Strong
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // injector_activity — No (silent)  → fuel_issue +SLIGHT (0.15), crank_sensor_issue +MEDIUM (0.20)
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[1]);
+
+    // spark_check — No spark  → ignition_issue +HEAVY (0.40)
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[1]);
+
+    // compression — Not tested (no gauge)
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[2]);
+
+    const state = engine.getState()!;
+    expect(state.currentStepId).toBe('');
+    expect(state.history.length).toBe(7);
+
+    // crank_sensor_issue = 0.25 + 0.40 + 0.20 = 0.85
+    // ignition_issue     = 0.25 + 0.40        = 0.65
+    // fuel_issue         = 0.25 + 0.15        = 0.40
+    expect(topHypothesis(state)).toBe('crank_sensor_issue');
+    expect(state.hypothesisScores['crank_sensor_issue']).toBeCloseTo(0.85, 5);
+  });
+});

--- a/src/app/core/diagnostics/packs/no-start.pack.ts
+++ b/src/app/core/diagnostics/packs/no-start.pack.ts
@@ -1,0 +1,223 @@
+import { KnowledgePack } from '../diagnostic-types';
+
+// ── Score delta constants ─────────────────────────────────────────────────────
+// Named constants keep the effects readable and easy to recalibrate.
+// All deltas are additive on top of initialConfidence (0.25 each).
+
+const HEAVY  = 0.40;   // Strong physical evidence pointing at this cause
+const STRONG = 0.35;   // Clear symptom, very likely this cause
+const MEDIUM = 0.20;   // Supporting evidence, consistent with this cause
+const SLIGHT = 0.15;   // Weak corroborating signal
+const REDUCE = -0.20;  // Evidence against this cause
+
+// ── Pack definition ───────────────────────────────────────────────────────────
+
+export const noStartPack: KnowledgePack = {
+  id: 'no_start',
+  title: 'No-Start / Hard-Start Diagnostic',
+
+  // Four root causes that cover the vast majority of no-start conditions.
+  // Balanced starting confidence — no cause is assumed before any evidence.
+  hypotheses: [
+    { id: 'fuel_issue',         initialConfidence: 0.25 },
+    { id: 'ignition_issue',     initialConfidence: 0.25 },
+    { id: 'crank_sensor_issue', initialConfidence: 0.25 },
+    { id: 'compression_issue',  initialConfidence: 0.25 },
+  ],
+
+  steps: [
+
+    // ── STEP 1: Cranking RPM ────────────────────────────────────────────────
+    // The first and most decisive split in any no-start tree.
+    // If the ECU sees no crank signal, it cannot fire injectors or coils,
+    // making every other system irrelevant until the crank sensor is resolved.
+    {
+      id: 'cranking_rpm',
+      instruction:
+        'With the adapter connected, crank the engine for 3–5 seconds while watching the live RPM reading.',
+      question: 'Does the RPM gauge show activity above ~200 RPM during cranking?',
+      options: [
+        {
+          label: 'Yes — RPM rises when cranking',
+          effect: {},
+          // No next specified — advances automatically to fuel_pump_prime
+        },
+        {
+          label: 'No — RPM stays at zero or barely moves',
+          // Zero RPM during cranking = no crank signal reaching the ECU.
+          // Could be a failed crank sensor, sheared reluctor ring, or ECU input fault.
+          // Still continue the rest of the workflow — fuel/ignition may also be absent,
+          // and the mechanic can use remaining steps to build a fuller picture.
+          effect: { crank_sensor_issue: HEAVY },
+        },
+      ],
+    },
+
+    // ── STEP 2: Fuel Pump Prime ─────────────────────────────────────────────
+    // The fuel pump runs for ~2 seconds on key-ON to pressurise the rail.
+    // Audible prime is a quick field test for pump relay and pump health.
+    {
+      id: 'fuel_pump_prime',
+      instruction:
+        'Turn the ignition to ON (do not crank). Listen near the rear of the car — the fuel pump should hum briefly for 1–2 seconds.',
+      question: 'Can you hear the fuel pump priming?',
+      options: [
+        {
+          label: 'Yes — heard a brief hum or whir',
+          effect: {},
+        },
+        {
+          label: 'No — silence after key-ON',
+          // No prime sound: pump relay, fuel pump fuse, or pump motor failure.
+          effect: { fuel_issue: STRONG },
+        },
+        {
+          label: 'Not sure — too noisy to tell',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 3: Fuel Delivery ───────────────────────────────────────────────
+    // Confirms whether fuel is physically reaching the engine side of the system.
+    // A "No" here is definitive for an upstream fuel problem — skip pressure
+    // and injector steps since they are downstream of the confirmed fault.
+    {
+      id: 'fuel_delivery',
+      instruction:
+        'Check for fuel at the fuel rail (Schrader valve) or filter outlet with ignition ON. Use a rag to catch any spray — fire risk.',
+      question: 'Is fuel reaching the engine?',
+      options: [
+        {
+          label: 'Yes — fuel present at the rail',
+          effect: {},
+          // Advance to pressure test
+        },
+        {
+          label: 'No — nothing at the rail',
+          // Confirmed upstream failure (pump, filter, relay, or blocked line).
+          // Skip fuel pressure and injector steps — they cannot add information
+          // when we already know fuel is not reaching the engine.
+          effect: { fuel_issue: STRONG },
+          next: 'spark_check',
+        },
+        {
+          label: 'Not tested',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 4: Fuel Pressure ───────────────────────────────────────────────
+    // Weak pressure is typically a failing pump, clogged filter, or leaking
+    // pressure regulator. Zero pressure with audible prime suggests a regulator
+    // or return-line fault (pump is running but not holding pressure).
+    {
+      id: 'fuel_pressure',
+      instruction:
+        'Fit a fuel pressure gauge to the Schrader valve on the fuel rail. Observe pressure during cranking. Typical petrol spec: 35–65 psi.',
+      question: 'What is the fuel pressure during cranking?',
+      options: [
+        {
+          label: 'Strong — within manufacturer spec',
+          effect: {},
+        },
+        {
+          label: 'Weak — below spec or dropping during crank',
+          effect: { fuel_issue: MEDIUM },
+        },
+        {
+          label: 'No pressure — gauge reads zero throughout',
+          effect: { fuel_issue: HEAVY },
+        },
+        {
+          label: 'Not tested — no gauge available',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 5: Injector Activity ───────────────────────────────────────────
+    // Injectors receive their open/close signal from the ECU.
+    // No pulse with fuel present means the ECU is not commanding injection —
+    // commonly caused by a missing crank signal or ECU fault.
+    {
+      id: 'injector_activity',
+      instruction:
+        'Use a mechanic\'s stethoscope (or a long screwdriver handle to your ear) against each injector body while cranking. Alternatively, use a noid light on the injector harness connector.',
+      question: 'Are the injectors clicking or pulsing during cranking?',
+      options: [
+        {
+          label: 'Yes — clicking or noid light flashing',
+          effect: {},
+        },
+        {
+          label: 'No — silence or noid light dead',
+          // ECU is not triggering the injectors. With fuel present this strongly
+          // suggests the ECU lacks a valid crank signal to reference injection timing.
+          effect: { fuel_issue: SLIGHT, crank_sensor_issue: MEDIUM },
+        },
+        {
+          label: 'Not tested',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 6: Spark Check ─────────────────────────────────────────────────
+    // Spark is independent of fuel delivery — a no-spark result isolates
+    // the ignition system regardless of what the fuel steps showed.
+    // Keep clear of the fuel system during this test.
+    {
+      id: 'spark_check',
+      instruction:
+        'Remove one spark plug and reconnect its HT lead. Hold the plug threads against the engine block (good earth). Crank for 3 seconds and observe. Keep the plug away from the fuel rail.',
+      question: 'Is spark present at the plug during cranking?',
+      options: [
+        {
+          label: 'Yes — strong blue spark visible',
+          effect: {},
+        },
+        {
+          label: 'No — no spark or a faint orange glow only',
+          // No spark: coil failure, ignition module, crank sensor (no timing reference),
+          // or wiring fault. Heavy increase since absence of spark is a direct finding.
+          effect: { ignition_issue: HEAVY },
+        },
+        {
+          label: 'Not tested — access or safety concern',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 7: Compression ─────────────────────────────────────────────────
+    // Last check — mechanical integrity. A car with good fuel, good spark,
+    // and good crank signal that still will not start almost always has a
+    // compression or timing issue. Low or uneven compression closes the loop.
+    {
+      id: 'compression',
+      instruction:
+        'Remove all spark plugs. Fit a compression gauge to each cylinder and crank 4–6 times. Note all readings. Typical petrol spec: 150–200 psi. Readings should be within 10% of each other.',
+      question: 'What do the compression readings show?',
+      options: [
+        {
+          label: 'Normal — all cylinders within spec and within 10% of each other',
+          // Good compression rules out mechanical cause.
+          effect: { compression_issue: REDUCE },
+        },
+        {
+          label: 'Low or uneven — one or more cylinders below spec',
+          // Worn rings, burnt valve, blown head gasket, or jumped timing chain.
+          effect: { compression_issue: HEAVY },
+        },
+        {
+          label: 'Not tested — no gauge available',
+          effect: {},
+          // No next → pack complete (last step in array)
+        },
+      ],
+    },
+
+  ],
+};


### PR DESCRIPTION
## Audit findings and fixes

Two bugs found during integration audit. No features added.

---

### Bug 1 — Clean diagnosis always returned fallback (logic bug)

**Root cause:** `parseAiResponse()` in the Firebase function and `validate()` in `AiResponseValidatorService` both required `evidence.length > 0`. For a clean scan (no DTCs, no findings) the AI correctly returns `evidence: []` — there is literally nothing to cite — so both validators rejected the response as malformed. Every clean diagnosis silently fell through to the deterministic local fallback, and quota was never incremented.

**Fix:** Remove the `evidence.length` guard in both places. `next_steps.length > 0` is the meaningful invariant — there is always at least one recommended action.

**Verification:** Live probe after deploy:
```json
{
  "requestId": "d5563855-...",
  "primary_issue": "No fault detected",
  "confidence": "low",
  "explanation": "Your vehicle is operating normally...",
  "next_steps": ["No immediate action required — monitor and schedule routine service"],
  "warnings": [],
  "evidence": []
}
```

---

### Bug 2 — OpenRouter error message always swallowed (error parsing)

**Root cause:** `callOpenRouter()` checked `typeof errBody["error"] === "string"`, but OpenRouter's error format is `{ "error": { "message": "...", "code": N } }` — an object, not a string. The branch was never taken; logs always showed `HTTP 4xx` instead of the real message.

**Fix:** Check if `errObj` is an object and extract `errObj.message`.

---

## Audit results (all checks)

| Check | Result |
|---|---|
| Frontend calls no AI provider directly | ✅ |
| No API keys / provider headers in Angular | ✅ |
| Firebase builds prompts internally | ✅ |
| `requestId` in all responses including fallback | ✅ |
| Fallback for missing key | ✅ |
| Fallback for invalid input (400/413) | ✅ |
| Fallback for API error | ✅ |
| Fallback for malformed AI response | ✅ fixed |
| Fallback for clean diagnosis | ✅ fixed |
| Quota increments only on valid AI success | ✅ |
| Angular build passes | ✅ |
| Functions build passes | ✅ |