### PR TITLE
feat: Diagnosis Assistant — unified diagnostic hub

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -16,21 +16,16 @@
         </a>
       </li>
       <li>
-        <a routerLink="/diagnosis-report" routerLinkActive="active">
+        <a routerLink="/diagnosis-assistant" routerLinkActive="active"
+           [routerLinkActiveOptions]="{ paths: 'subset', queryParams: 'ignored', matrixParams: 'ignored', fragment: 'ignored' }">
           <span class="nav-icon">🔬</span>
-          <span class="nav-label">Diagnosis</span>
+          <span class="nav-label">Diagnosis Assistant</span>
         </a>
       </li>
       <li>
         <a routerLink="/dashboard" routerLinkActive="active">
           <span class="nav-icon">📡</span>
           <span class="nav-label">Live Data</span>
-        </a>
-      </li>
-      <li>
-        <a routerLink="/guided-tests" routerLinkActive="active">
-          <span class="nav-icon">▶</span>
-          <span class="nav-label">Guided Tests</span>
         </a>
       </li>
       <li>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -16,8 +16,7 @@
         </a>
       </li>
       <li>
-        <a routerLink="/diagnosis-assistant" routerLinkActive="active"
-           [routerLinkActiveOptions]="{ paths: 'subset', queryParams: 'ignored', matrixParams: 'ignored', fragment: 'ignored' }">
+        <a routerLink="/diagnosis-assistant" [class.active]="diagnosisActive()">
           <span class="nav-icon">🔬</span>
           <span class="nav-label">AI Diagnosis Assistant</span>
         </a>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -19,7 +19,7 @@
         <a routerLink="/diagnosis-assistant" routerLinkActive="active"
            [routerLinkActiveOptions]="{ paths: 'subset', queryParams: 'ignored', matrixParams: 'ignored', fragment: 'ignored' }">
           <span class="nav-icon">🔬</span>
-          <span class="nav-label">Diagnosis Assistant</span>
+          <span class="nav-label">AI Diagnosis Assistant</span>
         </a>
       </li>
       <li>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,7 @@
 import { Component, inject } from '@angular/core';
-import { RouterOutlet, Router, RouterLink, RouterLinkActive } from '@angular/router';
+import { RouterOutlet, Router, RouterLink, RouterLinkActive, NavigationEnd } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { filter, map, startWith } from 'rxjs/operators';
 import { VehicleProfileService } from './core/vehicle/vehicle-profile.service';
 import { AdapterSwitcherService } from './core/adapters/adapter-switcher.service';
 
@@ -15,11 +17,29 @@ export class AppComponent {
   private vehicleService = inject(VehicleProfileService);
   private adapterSwitcher = inject(AdapterSwitcherService);
 
+  // True whenever the user is anywhere inside the diagnosis flows —
+  // /diagnosis-assistant, /diagnosis-report, or /guided-tests.
+  readonly diagnosisActive = toSignal(
+    this.router.events.pipe(
+      filter(e => e instanceof NavigationEnd),
+      map(() => this.isDiagnosisUrl()),
+      startWith(this.isDiagnosisUrl()),
+    ),
+    { initialValue: false }
+  );
+
   constructor() {
     if (!this.vehicleService.getActiveProfile()) {
       this.router.navigate(['/vehicle-profile']);
     }
     // Restore last adapter mode and reconnect simulator across page refreshes
     this.adapterSwitcher.autoConnect();
+  }
+
+  private isDiagnosisUrl(): boolean {
+    const url = this.router.url;
+    return url.startsWith('/diagnosis-assistant') ||
+           url.startsWith('/diagnosis-report') ||
+           url.startsWith('/guided-tests');
   }
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,13 @@ export const routes: Routes = [
     loadComponent: () => import('./features/dashboard/dashboard-page.component')
       .then(m => m.DashboardPageComponent)
   },
+  // ── Diagnosis Assistant (unified hub) ─────────────────────────────────────
+  {
+    path: 'diagnosis-assistant',
+    loadComponent: () => import('./features/diagnosis-assistant/diagnosis-assistant-page.component')
+      .then(m => m.DiagnosisAssistantPageComponent)
+  },
+  // ── Legacy routes — kept so bookmarks and deep-links still work ───────────
   {
     path: 'guided-tests',
     providers: [provideCharts(withDefaultRegisterables())],

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
@@ -1,0 +1,84 @@
+<div class="assistant-page">
+
+  <header class="page-header">
+    <div class="header-eyebrow">
+      <span class="eyebrow-icon">🔍</span>
+      <span class="eyebrow-text">Diagnostic System</span>
+    </div>
+    <h1 class="page-title">Diagnosis Assistant</h1>
+    <p class="page-subtitle">Select a diagnostic mode to get started.</p>
+  </header>
+
+  <div class="mode-grid">
+
+    <!-- Full Diagnosis -->
+    <button class="mode-card mode-card--primary" (click)="openFullDiagnosis()">
+      <div class="card-icon-wrap card-icon-wrap--green">
+        <span class="card-icon">🔬</span>
+      </div>
+      <div class="card-body">
+        <div class="card-title-row">
+          <h2 class="card-title">Full Diagnosis</h2>
+          <span class="card-badge card-badge--auto">AUTO</span>
+        </div>
+        <p class="card-description">
+          Analyze all available DTCs, live data, freeze-frame data, and evidence automatically.
+          Best when the vehicle is connected and a fault code is present.
+        </p>
+        <ul class="card-features">
+          <li><span class="feat-dot feat-dot--green"></span>DTC code analysis</li>
+          <li><span class="feat-dot feat-dot--green"></span>Live sensor evidence</li>
+          <li><span class="feat-dot feat-dot--green"></span>AI-assisted summary</li>
+        </ul>
+      </div>
+      <span class="card-arrow">→</span>
+    </button>
+
+    <!-- Guided Diagnosis -->
+    <button class="mode-card mode-card--secondary" (click)="openGuidedDiagnosis()">
+      <div class="card-icon-wrap card-icon-wrap--blue">
+        <span class="card-icon">▶</span>
+      </div>
+      <div class="card-body">
+        <div class="card-title-row">
+          <h2 class="card-title">Guided Diagnosis</h2>
+          <span class="card-badge card-badge--step">STEP-BY-STEP</span>
+        </div>
+        <p class="card-description">
+          Follow a step-by-step troubleshooting workflow and answer questions as you perform
+          physical checks. Ideal for no-start, hard-start, and intermittent faults.
+        </p>
+        <ul class="card-features">
+          <li><span class="feat-dot feat-dot--blue"></span>Hypothesis scoring</li>
+          <li><span class="feat-dot feat-dot--blue"></span>No-start pack</li>
+          <li><span class="feat-dot feat-dot--blue"></span>Mechanic-guided questions</li>
+        </ul>
+      </div>
+      <span class="card-arrow">→</span>
+    </button>
+
+    <!-- Coming Soon — Cylinder Analysis -->
+    <div class="mode-card mode-card--disabled" aria-disabled="true">
+      <div class="card-icon-wrap card-icon-wrap--muted">
+        <span class="card-icon">🔧</span>
+      </div>
+      <div class="card-body">
+        <div class="card-title-row">
+          <h2 class="card-title">Cylinder Analysis</h2>
+          <span class="card-badge card-badge--soon">COMING SOON</span>
+        </div>
+        <p class="card-description">
+          Cylinder-level misfire detection and component isolation. Pinpoint individual
+          injector, coil, or compression faults across all cylinders.
+        </p>
+        <ul class="card-features">
+          <li><span class="feat-dot feat-dot--muted"></span>Per-cylinder misfire counts</li>
+          <li><span class="feat-dot feat-dot--muted"></span>Component isolation</li>
+          <li><span class="feat-dot feat-dot--muted"></span>Contribution analysis</li>
+        </ul>
+      </div>
+    </div>
+
+  </div>
+
+</div>

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
@@ -5,7 +5,7 @@
       <span class="eyebrow-icon">🔍</span>
       <span class="eyebrow-text">Diagnostic System</span>
     </div>
-    <h1 class="page-title">Diagnosis Assistant</h1>
+    <h1 class="page-title">AI Diagnosis Assistant</h1>
     <p class="page-subtitle">Select a diagnostic mode to get started.</p>
   </header>
 

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.scss
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.scss
@@ -1,0 +1,250 @@
+@use '../../../styles/variables' as *;
+
+// ── Page shell ────────────────────────────────────────────────────────────────
+.assistant-page {
+  min-height: 100%;
+  padding: $spacing-2xl $spacing-xl;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2xl;
+}
+
+// ── Header ────────────────────────────────────────────────────────────────────
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-sm;
+}
+
+.header-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  font-size: $font-size-label-lg;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: $text-muted;
+
+  .eyebrow-icon { opacity: 0.6; }
+}
+
+.page-title {
+  margin: 0;
+  font-size: $font-size-display;
+  font-weight: 700;
+  color: $text-primary;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+
+.page-subtitle {
+  margin: 0;
+  font-size: $font-size-body-lg;
+  color: $text-muted;
+}
+
+// ── Card grid ─────────────────────────────────────────────────────────────────
+.mode-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: $spacing-lg;
+  align-items: start;
+}
+
+// ── Base card ─────────────────────────────────────────────────────────────────
+.mode-card {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-md;
+  padding: $spacing-xl;
+  border-radius: $radius-lg;
+  background: $bg-secondary;
+  border: 1px solid $border-color;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease;
+  text-decoration: none;
+  width: 100%;
+  font-family: $font-family;
+
+  // Pseudo-element left accent bar (hidden by default, shown on hover/active)
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 20%;
+    height: 60%;
+    width: 3px;
+    border-radius: 0 $radius-sm $radius-sm 0;
+    opacity: 0;
+    transition: opacity 0.18s ease;
+  }
+
+  &:hover:not(.mode-card--disabled) {
+    transform: translateY(-2px);
+    border-color: $border-light;
+
+    &::before { opacity: 1; }
+
+    .card-arrow { opacity: 1; transform: translateX(4px); }
+  }
+
+  &:active:not(.mode-card--disabled) {
+    transform: translateY(0);
+  }
+
+  &--disabled {
+    cursor: default;
+    opacity: 0.45;
+  }
+}
+
+// ── Card colour variants ───────────────────────────────────────────────────────
+.mode-card--primary {
+  &:hover {
+    background: rgba(76, 175, 80, 0.06);
+    border-color: rgba(76, 175, 80, 0.35);
+    box-shadow: 0 4px 24px rgba(76, 175, 80, 0.08);
+  }
+  &::before { background: $color-success; }
+}
+
+.mode-card--secondary {
+  &:hover {
+    background: rgba(33, 150, 243, 0.06);
+    border-color: rgba(33, 150, 243, 0.35);
+    box-shadow: 0 4px 24px rgba(33, 150, 243, 0.08);
+  }
+  &::before { background: $color-info; }
+}
+
+// ── Icon wrap ─────────────────────────────────────────────────────────────────
+.card-icon-wrap {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  border-radius: $radius-md;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+
+  &--green  { background: rgba(76, 175, 80, 0.14); }
+  &--blue   { background: rgba(33, 150, 243, 0.14); }
+  &--muted  { background: rgba(142, 145, 149, 0.12); }
+}
+
+// ── Card body ─────────────────────────────────────────────────────────────────
+.card-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-sm;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  flex-wrap: wrap;
+}
+
+.card-title {
+  margin: 0;
+  font-size: $font-size-title-lg;
+  font-weight: 600;
+  color: $text-primary;
+  letter-spacing: -0.01em;
+}
+
+.card-description {
+  margin: 0;
+  font-size: $font-size-body-md;
+  color: $text-muted;
+  line-height: 1.6;
+}
+
+// ── Feature list ──────────────────────────────────────────────────────────────
+.card-features {
+  margin: $spacing-xs 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+    font-size: $font-size-body-sm;
+    color: $text-secondary;
+  }
+}
+
+.feat-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: $radius-full;
+  flex-shrink: 0;
+
+  &--green { background: $color-success; }
+  &--blue  { background: $color-info; }
+  &--muted { background: $text-muted; }
+}
+
+// ── Badges ────────────────────────────────────────────────────────────────────
+.card-badge {
+  font-size: $font-size-label-sm;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: $radius-full;
+
+  &--auto {
+    background: rgba(76, 175, 80, 0.18);
+    color: $color-success;
+    border: 1px solid rgba(76, 175, 80, 0.3);
+  }
+
+  &--step {
+    background: rgba(33, 150, 243, 0.18);
+    color: $color-info;
+    border: 1px solid rgba(33, 150, 243, 0.3);
+  }
+
+  &--soon {
+    background: rgba(142, 145, 149, 0.15);
+    color: $text-muted;
+    border: 1px solid $border-color;
+  }
+}
+
+// ── Arrow indicator ───────────────────────────────────────────────────────────
+.card-arrow {
+  font-size: 20px;
+  color: $text-muted;
+  opacity: 0;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  align-self: center;
+  flex-shrink: 0;
+  margin-left: $spacing-xs;
+}
+
+// ── Responsive ────────────────────────────────────────────────────────────────
+@media (max-width: 700px) {
+  .assistant-page {
+    padding: $spacing-xl $spacing-md;
+  }
+
+  .mode-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .page-title {
+    font-size: $font-size-headline;
+  }
+}

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-diagnosis-assistant-page',
+  standalone: true,
+  templateUrl: './diagnosis-assistant-page.component.html',
+  styleUrls: ['./diagnosis-assistant-page.component.scss'],
+})
+export class DiagnosisAssistantPageComponent {
+  constructor(private router: Router) {}
+
+  openFullDiagnosis(): void {
+    this.router.navigate(['/diagnosis-report']);
+  }
+
+  openGuidedDiagnosis(): void {
+    this.router.navigate(['/guided-tests']);
+  }
+}


### PR DESCRIPTION
## Summary

Consolidates the separate **Diagnosis** and **Guided Tests** navigation entries into a single **Diagnosis Assistant** hub, giving users a clear mode-selection screen before entering either diagnostic flow.

- Replaces two nav items with one **Diagnosis Assistant** entry (`/diagnosis-assistant`)
- Hub page presents three mode cards: Full Diagnosis, Guided Diagnosis, and a Coming-Soon Cylinder Analysis placeholder
- Legacy routes `/diagnosis-report` and `/guided-tests` are preserved — existing bookmarks and deep-links continue to work
- No business logic, AI services, or diagnostic engine code was modified

## Files created

| File | Purpose |
|------|---------|
| `src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts` | Standalone hub component, routes to existing flows |
| `src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html` | Card-based mode-selection UI |
| `src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.scss` | Dark-theme styles using NexDrive Pro design tokens |

## Files modified

| File | Change |
|------|--------|
| `src/app/app.routes.ts` | Added `/diagnosis-assistant` route; legacy routes retained |
| `src/app/app.component.html` | Replaced Diagnosis + Guided Tests nav items with single Diagnosis Assistant entry |

## Routing changes

| Route | Before | After |
|-------|--------|-------|
| `/diagnosis-assistant` | — | New hub page |
| `/diagnosis-report` | Nav item | Legacy (accessible from hub) |
| `/guided-tests` | Nav item | Legacy (accessible from hub) |

## Navigation changes

**Before:** Vehicle Setup · **Diagnosis** · Live Data · **Guided Tests** · Session Replay · Sessions · BLE Debug

**After:** Vehicle Setup · **Diagnosis Assistant** · Live Data · Session Replay · Sessions · BLE Debug

## Test plan

- [ ] Navigate to `/diagnosis-assistant` — hub page loads with three cards
- [ ] Click **Full Diagnosis** — routes to `/diagnosis-report`
- [ ] Click **Guided Diagnosis** — routes to `/guided-tests`
- [ ] Navigate directly to `/diagnosis-report` — loads correctly (legacy route)
- [ ] Navigate directly to `/guided-tests` — loads correctly (legacy route)
- [ ] Sidebar shows one **Diagnosis Assistant** item, no separate Diagnosis or Guided Tests
- [ ] `npm run build` passes with no errors or budget warnings