### PR TITLE
feat(packs): Misfire Diagnostic Pack — Phase 4.3

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -35,7 +35,10 @@
       "Bash(node -e \"const p=require\\('./functions/package.json'\\); console.log\\(JSON.stringify\\(p, null, 2\\)\\)\")",
       "Bash(npx ng *)",
       "Bash(git merge *)",
-      "Bash(python -c \"import sys,json; comments=json.load\\(sys.stdin\\); [print\\(f'FILE: {c[\\\\\"path\\\\\"]}\\\\nLINE: {c.get\\(\\\\\"line\\\\\",\\\\\"?\\\\\"\\)} \\({c.get\\(\\\\\"side\\\\\",\\\\\"?\\\\\"\\)}\\)\\\\nBODY: {c[\\\\\"body\\\\\"]}\\\\n---'\\) for c in comments]\")"
+      "Bash(python -c \"import sys,json; comments=json.load\\(sys.stdin\\); [print\\(f'FILE: {c[\\\\\"path\\\\\"]}\\\\nLINE: {c.get\\(\\\\\"line\\\\\",\\\\\"?\\\\\"\\)} \\({c.get\\(\\\\\"side\\\\\",\\\\\"?\\\\\"\\)}\\)\\\\nBODY: {c[\\\\\"body\\\\\"]}\\\\n---'\\) for c in comments]\")",
+      "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\Lenovo\\\\Downloads\\\\OBD\\\\.claude\\\\worktrees\\\\wonderful-margulis-73b9cc\\\\src\\\\app\\\\features\" -Directory)",
+      "Bash(Select-Object -ExpandProperty FullName)",
+      "Bash(grep -E \"\\\\.ts$|^d\")"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/src/app/core/diagnostics/cylinder-analysis.service.ts
+++ b/src/app/core/diagnostics/cylinder-analysis.service.ts
@@ -1,0 +1,207 @@
+import { Injectable } from '@angular/core';
+import { DtcCode } from './dtc/dtc-code.model';
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export type CylinderStatus     = 'normal' | 'suspect' | 'critical';
+export type AnalysisConfidence = 'low' | 'medium' | 'high';
+
+export interface CylinderAnalysisResult {
+  /** True when at least one misfire-related DTC was present. */
+  hasData: boolean;
+  /** The cylinder most likely to be at fault, or null for random/unknown. */
+  primaryCylinder: number | null;
+  /** All cylinders with evidence, ranked highest → lowest confidence. */
+  affectedCylinders: number[];
+  status: CylinderStatus;
+  /** Human-readable evidence strings shown to the mechanic. */
+  evidence: string[];
+  /** Hypothesis IDs from the misfire pack, ordered most → least likely. */
+  likelyCauses: string[];
+  /** Key of the first guided test to run next. */
+  recommendedNextTest: string;
+  confidence: AnalysisConfidence;
+}
+
+// ── Misfire DTC range ─────────────────────────────────────────────────────────
+
+// P0300 = random/multiple misfire
+// P0301–P0308 = cylinder-specific misfire (covers 4-, 6-, and 8-cylinder engines)
+const MISFIRE_PATTERN = /^P030[0-8]$/;
+const CYLINDER_PATTERN = /^P030([1-8])$/;
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+@Injectable({ providedIn: 'root' })
+export class CylinderAnalysisService {
+
+  /**
+   * Analyse available DTC evidence and identify the most likely affected cylinder.
+   *
+   * @param dtcCodes   Active or stored DTCs from the current session.
+   * @param misfireCounters  Optional per-cylinder misfire counts from Mode 06 /
+   *                         manufacturer-specific PIDs. Keyed by cylinder number.
+   *
+   * Example — P0302 only:
+   *   analyse([{ code: 'P0302', ... }])
+   *   → { primaryCylinder: 2, status: 'suspect', confidence: 'high',
+   *       recommendedNextTest: 'ignition_coil_swap', ... }
+   *
+   * Example — P0300 only:
+   *   analyse([{ code: 'P0300', ... }])
+   *   → { primaryCylinder: null, status: 'suspect', confidence: 'medium',
+   *       recommendedNextTest: 'fuel_pressure_test', ... }
+   */
+  analyse(
+    dtcCodes: DtcCode[],
+    misfireCounters?: Record<number, number>,
+  ): CylinderAnalysisResult {
+    const misfireDtcs = dtcCodes.filter(d => MISFIRE_PATTERN.test(d.code));
+
+    if (!misfireDtcs.length) {
+      return this.noDataResult();
+    }
+
+    const hasRandomMisfire = misfireDtcs.some(d => d.code === 'P0300');
+    const specificCylinders = this.parseSpecificCylinders(misfireDtcs);
+    const rankedCylinders   = this.rankCylinders(specificCylinders, misfireCounters);
+    const primaryCylinder   = rankedCylinders[0] ?? null;
+
+    const evidence          = this.buildEvidence(misfireDtcs, misfireCounters);
+    const status            = this.deriveStatus(misfireDtcs, misfireCounters);
+    const confidence        = this.deriveConfidence(specificCylinders, hasRandomMisfire);
+    const likelyCauses      = this.deriveLikelyCauses(primaryCylinder, hasRandomMisfire);
+    const recommendedNextTest = this.deriveRecommendedTest(primaryCylinder, hasRandomMisfire);
+
+    return {
+      hasData: true,
+      primaryCylinder,
+      affectedCylinders: rankedCylinders,
+      status,
+      evidence,
+      likelyCauses,
+      recommendedNextTest,
+      confidence,
+    };
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private noDataResult(): CylinderAnalysisResult {
+    return {
+      hasData: false,
+      primaryCylinder: null,
+      affectedCylinders: [],
+      status: 'normal',
+      evidence: [],
+      likelyCauses: [],
+      recommendedNextTest: '',
+      confidence: 'low',
+    };
+  }
+
+  private parseSpecificCylinders(codes: DtcCode[]): number[] {
+    const cylinders = new Set<number>();
+    for (const dtc of codes) {
+      const m = dtc.code.match(CYLINDER_PATTERN);
+      if (m) cylinders.add(parseInt(m[1], 10));
+    }
+    return [...cylinders].sort((a, b) => a - b);
+  }
+
+  private rankCylinders(
+    cylinders: number[],
+    counters?: Record<number, number>,
+  ): number[] {
+    if (!counters) return cylinders;
+    return [...cylinders].sort((a, b) => (counters[b] ?? 0) - (counters[a] ?? 0));
+  }
+
+  private buildEvidence(
+    codes: DtcCode[],
+    counters?: Record<number, number>,
+  ): string[] {
+    return codes.map(dtc => {
+      if (dtc.code === 'P0300') {
+        return 'P0300 — Random or multiple-cylinder misfire detected';
+      }
+      const m = dtc.code.match(CYLINDER_PATTERN);
+      if (!m) return `${dtc.code} — Misfire detected`;
+      const cyl = parseInt(m[1], 10);
+      const count = counters?.[cyl];
+      return count != null
+        ? `${dtc.code} — Cylinder ${cyl} misfire (${count} counts)`
+        : `${dtc.code} — Cylinder ${cyl} misfire detected`;
+    });
+  }
+
+  private deriveStatus(
+    codes: DtcCode[],
+    counters?: Record<number, number>,
+  ): CylinderStatus {
+    // Multiple specific cylinders = more severe
+    const specificCount = codes.filter(d => CYLINDER_PATTERN.test(d.code)).length;
+    if (specificCount >= 3) return 'critical';
+
+    // High misfire counter threshold
+    if (counters) {
+      const max = Math.max(...Object.values(counters));
+      if (max > 50) return 'critical';
+    }
+
+    return 'suspect';
+  }
+
+  private deriveConfidence(
+    specificCylinders: number[],
+    hasRandomMisfire: boolean,
+  ): AnalysisConfidence {
+    if (specificCylinders.length > 0) return 'high';
+    if (hasRandomMisfire)             return 'medium';
+    return 'low';
+  }
+
+  private deriveLikelyCauses(
+    primaryCylinder: number | null,
+    hasRandomMisfire: boolean,
+  ): string[] {
+    if (primaryCylinder !== null) {
+      // Single cylinder — hardware inside that cylinder is most likely
+      return [
+        'ignition_coil_issue',
+        'spark_plug_issue',
+        'injector_issue',
+        'compression_issue',
+        'wiring_or_ecu_issue',
+        'intake_leak_issue',
+      ];
+    }
+    if (hasRandomMisfire) {
+      // Random misfire — systemic / fuel delivery causes move to the front
+      return [
+        'intake_leak_issue',
+        'injector_issue',
+        'ignition_coil_issue',
+        'spark_plug_issue',
+        'compression_issue',
+        'wiring_or_ecu_issue',
+      ];
+    }
+    return [];
+  }
+
+  private deriveRecommendedTest(
+    primaryCylinder: number | null,
+    hasRandomMisfire: boolean,
+  ): string {
+    if (primaryCylinder !== null) {
+      // Coil swap is the cheapest, fastest, most decisive single-cylinder test
+      return 'ignition_coil_swap';
+    }
+    if (hasRandomMisfire) {
+      // Random misfire — check fuel delivery and intake before component swaps
+      return 'fuel_pressure_test';
+    }
+    return '';
+  }
+}

--- a/src/app/core/diagnostics/packs/index.ts
+++ b/src/app/core/diagnostics/packs/index.ts
@@ -1,1 +1,2 @@
 export { noStartPack } from './no-start.pack';
+export { misfirePack }  from './misfire.pack';

--- a/src/app/core/diagnostics/packs/index.ts
+++ b/src/app/core/diagnostics/packs/index.ts
@@ -1,2 +1,3 @@
-export { noStartPack } from './no-start.pack';
-export { misfirePack }  from './misfire.pack';
+export { noStartPack }   from './no-start.pack';
+export { misfirePack }   from './misfire.pack';
+export { roughIdlePack } from './rough-idle.pack';

--- a/src/app/core/diagnostics/packs/misfire.pack.ts
+++ b/src/app/core/diagnostics/packs/misfire.pack.ts
@@ -1,0 +1,247 @@
+import { KnowledgePack } from '../diagnostic-types';
+
+// ── Score delta constants ─────────────────────────────────────────────────────
+// Shared magnitude scale — same as no-start pack for consistency.
+// All deltas are additive on top of initialConfidence (≈ 0.17 each).
+
+const HEAVY  =  0.40;   // Definitive finding — highly specific to this cause
+const STRONG =  0.35;   // Swap test moved the symptom — strong causal link
+const MEDIUM =  0.20;   // Supporting evidence, consistent with this cause
+const SLIGHT =  0.15;   // Weak corroborating signal
+const REDUCE = -0.20;   // Evidence against this cause
+
+// ── Pack definition ───────────────────────────────────────────────────────────
+
+export const misfirePack: KnowledgePack = {
+  id: 'misfire',
+  title: 'Misfire Diagnostic',
+
+  // Six root causes covering the full misfire failure space.
+  // Balanced starting point — 6 × 0.17 ≈ 1.0, no prior assumption.
+  hypotheses: [
+    { id: 'ignition_coil_issue',  initialConfidence: 0.17 },
+    { id: 'spark_plug_issue',     initialConfidence: 0.17 },
+    { id: 'injector_issue',       initialConfidence: 0.17 },
+    { id: 'wiring_or_ecu_issue',  initialConfidence: 0.17 },
+    { id: 'compression_issue',    initialConfidence: 0.17 },
+    { id: 'intake_leak_issue',    initialConfidence: 0.17 },
+  ],
+
+  steps: [
+
+    // ── STEP 1: Cylinder Identification ────────────────────────────────────
+    // Informational — establishes which cylinder is misfiring before any
+    // physical tests begin. P030X codes map directly to cylinder numbers.
+    // P0300 (random misfire) shifts suspicion toward systemic causes
+    // (fuel pressure, vacuum leak) rather than cylinder-specific hardware.
+    {
+      id: 'cylinder_identification',
+      instruction:
+        'Review stored DTCs and misfire counters on the scan tool. ' +
+        'P0301–P0304 indicate a specific cylinder. P0300 indicates a random or multiple-cylinder misfire.',
+      question: 'Which cylinder is primarily affected?',
+      options: [
+        {
+          label: 'P0301 — Cylinder 1',
+          effect: {},
+        },
+        {
+          label: 'P0302 — Cylinder 2',
+          effect: {},
+        },
+        {
+          label: 'P0303 — Cylinder 3',
+          effect: {},
+        },
+        {
+          label: 'P0304 — Cylinder 4',
+          effect: {},
+        },
+        {
+          label: 'P0300 — Random / multiple cylinders',
+          // Random misfire broadens the scope — intake or fuel delivery
+          // issues are more plausible when no single cylinder is implicated.
+          effect: { intake_leak_issue: SLIGHT, injector_issue: SLIGHT },
+        },
+        {
+          label: 'Not sure / no code stored',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 2: Ignition Coil Swap Test ────────────────────────────────────
+    // Moving the coil to another cylinder and rechecking which cylinder DTC
+    // appears is the single most decisive test for coil-specific ignition failure.
+    // If the misfire follows the coil, causation is effectively confirmed.
+    {
+      id: 'coil_swap_test',
+      instruction:
+        'Swap the ignition coil from the affected cylinder with the coil from a known-good cylinder. ' +
+        'Clear codes and run the engine for 2–3 minutes or perform a drive cycle.',
+      question: 'After the swap, did the misfire DTC move to the other cylinder?',
+      options: [
+        {
+          label: 'Yes — misfire followed the coil to the new cylinder',
+          // Definitive: coil carries the fault to a cylinder that was previously healthy.
+          effect: { ignition_coil_issue: STRONG },
+        },
+        {
+          label: 'No — misfire stayed on the same cylinder',
+          // Coil is not the cause; cylinder-specific fault (plug, injector, compression).
+          effect: { ignition_coil_issue: REDUCE },
+        },
+        {
+          label: 'Not tested — coil not accessible or swap not practical',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 3: Spark Plug Inspection / Swap ───────────────────────────────
+    // Visual inspection often reveals the cause directly (oil fouling, cracked
+    // porcelain, worn electrode). A plug swap test confirms causation the same
+    // way the coil swap does.
+    {
+      id: 'spark_plug_inspection',
+      instruction:
+        'Remove the spark plug from the affected cylinder. Inspect for fouling, cracked porcelain, ' +
+        'worn or eroded electrode, or heavy carbon deposits. If appearance is suspect, swap with a ' +
+        'plug from a known-good cylinder and retest.',
+      question: 'Was the spark plug worn, fouled, damaged, or did the misfire move with the plug?',
+      options: [
+        {
+          label: 'Yes — plug was visibly faulty or misfire followed the plug',
+          effect: { spark_plug_issue: STRONG },
+        },
+        {
+          label: 'No — plug looks serviceable and misfire did not follow',
+          effect: { spark_plug_issue: REDUCE },
+        },
+        {
+          label: 'Not tested — plug not accessed',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 4: Injector Activity Check ────────────────────────────────────
+    // Injectors should produce an audible click at idle. Absence of clicking
+    // points either to the injector body itself or to the ECU driver circuit
+    // or wiring not delivering the pulse — both are captured here.
+    {
+      id: 'injector_activity_check',
+      instruction:
+        'Use a mechanic\'s stethoscope or screwdriver handle to listen at the injector body while ' +
+        'the engine idles. Alternatively, fit a noid light to the injector harness connector and ' +
+        'crank or idle the engine.',
+      question: 'Is the injector operating normally — clicking or noid light flashing?',
+      options: [
+        {
+          label: 'No — silent or noid light dead',
+          // Absence of pulse is consistent with a dead injector OR an open/shorted
+          // driver circuit. Both hypotheses receive equal uplift until the swap
+          // test in Step 5 differentiates them.
+          effect: { injector_issue: MEDIUM, wiring_or_ecu_issue: MEDIUM },
+        },
+        {
+          label: 'Yes — clicking normally / noid light flashing',
+          // Injector is being commanded — reduces likelihood of ECU/wiring fault.
+          effect: { injector_issue: REDUCE, wiring_or_ecu_issue: REDUCE },
+        },
+        {
+          label: 'Not tested',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 5: Injector Swap Test ──────────────────────────────────────────
+    // Swapping the injector body to another cylinder distinguishes a failed
+    // injector from a wiring or ECU driver fault. If the fault follows the
+    // injector, the injector is the cause. If it stays on the same cylinder,
+    // the fault is in the harness or ECU output.
+    {
+      id: 'injector_swap_test',
+      instruction:
+        'If accessible, swap the injector from the affected cylinder with a known-good cylinder. ' +
+        'Clear codes and retest. Note which cylinder now misfires.',
+      question: 'Did the misfire move to the cylinder that received the swapped injector?',
+      options: [
+        {
+          label: 'Yes — misfire followed the injector',
+          // Injector body is the fault; wiring and ECU output are absolved.
+          effect: { injector_issue: STRONG, wiring_or_ecu_issue: REDUCE },
+        },
+        {
+          label: 'No — misfire stayed on the original cylinder',
+          // Injector body is not the cause; fault is in the fixed wiring or ECU driver.
+          effect: { injector_issue: REDUCE, wiring_or_ecu_issue: SLIGHT },
+        },
+        {
+          label: 'Not tested — swap not practical',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 6: Compression Test ────────────────────────────────────────────
+    // Low compression is caused by worn rings, burnt valves, a blown head gasket,
+    // or a jumped timing chain. A cylinder with low compression cannot generate
+    // enough combustion pressure to fire reliably regardless of spark or fuel.
+    {
+      id: 'compression_test',
+      instruction:
+        'Remove the spark plug. Fit a compression gauge and crank for 4–6 revolutions. ' +
+        'Compare the reading against manufacturer spec (typically 150–200 psi petrol) and ' +
+        'against the other cylinders — readings should be within 10% of each other.',
+      question: 'Is compression lower than spec or significantly lower than adjacent cylinders?',
+      options: [
+        {
+          label: 'Yes — low or uneven compression on this cylinder',
+          effect: { compression_issue: HEAVY },
+        },
+        {
+          label: 'No — compression within spec and consistent with other cylinders',
+          // Good compression definitively rules out mechanical cause.
+          effect: { compression_issue: REDUCE },
+        },
+        {
+          label: 'Not tested — no compression gauge available',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 7: Intake / Vacuum Leak Inspection ─────────────────────────────
+    // A localised intake manifold gasket leak or cracked vacuum hose near one
+    // cylinder leans out that cylinder's mixture enough to cause a misfire.
+    // This is particularly common after manifold removal or on high-mileage engines
+    // with degraded gaskets.
+    {
+      id: 'intake_leak_inspection',
+      instruction:
+        'Inspect the intake manifold gasket and vacuum hose connections around the affected cylinder. ' +
+        'Use carb cleaner or propane enrichment near suspect joints at idle — an RPM change indicates ' +
+        'an air leak. A smoke machine fed into the intake provides the most reliable result.',
+      question: 'Was a localised air or vacuum leak found near the affected cylinder?',
+      options: [
+        {
+          label: 'Yes — leak confirmed at intake gasket or vacuum hose',
+          effect: { intake_leak_issue: STRONG },
+        },
+        {
+          label: 'No — no leak detected',
+          // No evidence of induction leak — reduces this hypothesis.
+          effect: { intake_leak_issue: REDUCE },
+        },
+        {
+          label: 'Not tested',
+          effect: {},
+          // No next → pack complete (last step in array)
+        },
+      ],
+    },
+
+  ],
+};

--- a/src/app/core/diagnostics/packs/rough-idle.pack.ts
+++ b/src/app/core/diagnostics/packs/rough-idle.pack.ts
@@ -1,0 +1,296 @@
+import { KnowledgePack } from '../diagnostic-types';
+
+// ── Score delta constants ─────────────────────────────────────────────────────
+// Identical magnitude scale to no-start and misfire packs for consistency.
+
+const HEAVY  =  0.40;   // Definitive or measurement-confirmed finding
+const STRONG =  0.35;   // Direct observation strongly implicating this cause
+const MEDIUM =  0.20;   // Supporting evidence consistent with this cause
+const SLIGHT =  0.15;   // Weak corroborating signal
+const REDUCE = -0.20;   // Evidence against this cause
+
+// ── Pack definition ───────────────────────────────────────────────────────────
+
+export const roughIdlePack: KnowledgePack = {
+  id: 'rough_idle',
+  title: 'Rough Idle / Stalling Diagnostic',
+
+  // Seven root causes covering the full rough-idle failure space.
+  // 7 × 0.14 ≈ 0.98 — balanced starting point, no prior assumption.
+  hypotheses: [
+    { id: 'vacuum_leak_issue',   initialConfidence: 0.14 },
+    { id: 'throttle_body_issue', initialConfidence: 0.14 },
+    { id: 'idle_control_issue',  initialConfidence: 0.14 },
+    { id: 'maf_sensor_issue',    initialConfidence: 0.14 },
+    { id: 'fuel_delivery_issue', initialConfidence: 0.14 },
+    { id: 'egr_issue',           initialConfidence: 0.14 },
+    { id: 'compression_issue',   initialConfidence: 0.14 },
+  ],
+
+  steps: [
+
+    // ── STEP 1: Idle Symptom Profile ────────────────────────────────────────
+    // The symptom pattern narrows the field before any physical testing begins.
+    // Hunting idle → air management (vacuum leak, IAC, throttle body).
+    // Stalling → fuel delivery or idle control.
+    // Rough/lumpy → individual cylinder issue (compression, injector).
+    // Worsens when hot → EGR stuck open is a classic warm-idle degrader.
+    {
+      id: 'idle_symptom_profile',
+      instruction:
+        'Observe the idle behaviour with the engine fully warm. Note any RPM variation, ' +
+        'whether the issue worsens at operating temperature, and whether the engine stalls.',
+      question: 'Which best describes the idle symptom?',
+      options: [
+        {
+          label: 'Hunting or surging — RPM rises and falls rhythmically',
+          // Rhythmic hunting is the hallmark of an air leak or IAC fighting to maintain idle.
+          effect: { vacuum_leak_issue: SLIGHT, idle_control_issue: SLIGHT },
+        },
+        {
+          label: 'Low but steady — RPM sits below normal spec',
+          // Steady low idle without hunting points to restricted airflow or partial throttle fouling.
+          effect: { throttle_body_issue: SLIGHT, fuel_delivery_issue: SLIGHT },
+        },
+        {
+          label: 'Stalls at idle or when coming to a stop',
+          // Stalling at idle = engine cannot sustain combustion; fuel delivery or IAC most likely.
+          effect: { idle_control_issue: MEDIUM, fuel_delivery_issue: MEDIUM },
+        },
+        {
+          label: 'Rough or lumpy — random misfires at idle',
+          // Lumpy idle suggests a cylinder-specific fault rather than a global air/fuel issue.
+          effect: { compression_issue: SLIGHT, maf_sensor_issue: SLIGHT },
+        },
+        {
+          label: 'Worsens when warm — fine when cold, rough after heat soak',
+          // EGR valves that stick open at operating temperature are a classic cause of warm rough idle.
+          effect: { egr_issue: MEDIUM, vacuum_leak_issue: SLIGHT },
+        },
+        {
+          label: 'Not sure',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 2: Vacuum Line and Intake Hose Inspection ──────────────────────
+    // Vacuum leaks introduce unmetered air that leans out the mixture and
+    // destabilises idle. A smoke machine is the most reliable method; propane
+    // or carb cleaner at idle is a practical field alternative.
+    {
+      id: 'vacuum_inspection',
+      instruction:
+        'Inspect all vacuum hoses, the intake boot between the air filter and throttle body, ' +
+        'and the intake manifold gaskets for cracks, splits, or loose connections. ' +
+        'With the engine idling, spray carb cleaner or propane near suspect joints — ' +
+        'an RPM change indicates an air leak. A smoke machine fed into the intake is definitive.',
+      question: 'Was an air or vacuum leak found?',
+      options: [
+        {
+          label: 'Yes — crack, split hose, or loose connection found',
+          effect: { vacuum_leak_issue: STRONG },
+        },
+        {
+          label: 'No — all hoses and gaskets appear intact, no RPM change',
+          effect: { vacuum_leak_issue: REDUCE },
+        },
+        {
+          label: 'Not tested',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 3: Fuel Trim Check at Idle ─────────────────────────────────────
+    // Short-term and long-term fuel trims are the ECU's real-time record of how
+    // hard it is correcting the mixture. Positive trims (>+10%) mean the engine
+    // is running lean — vacuum leak or MAF under-reading. Negative trims (<-10%)
+    // mean rich — excessive fuel delivery or EGR contamination.
+    {
+      id: 'fuel_trim_check',
+      instruction:
+        'With the engine fully warm and at idle, read STFT Bank 1 and LTFT Bank 1 on the scan tool. ' +
+        'Acceptable range: ±10%. Readings persistently above +10% indicate a lean condition; ' +
+        'below -10% indicate a rich condition.',
+      question: 'What do the fuel trim readings show at idle?',
+      options: [
+        {
+          label: 'Lean — STFT or LTFT above +10%',
+          // Lean correction at idle is the most common fuel trim finding with vacuum leaks
+          // and MAF contamination, both of which cause unmetered air ingestion.
+          effect: { vacuum_leak_issue: MEDIUM, maf_sensor_issue: MEDIUM },
+        },
+        {
+          label: 'Normal — both STFT and LTFT within ±10%',
+          // Normal trims at idle strongly reduce the likelihood of an air leak or MAF fault.
+          effect: { vacuum_leak_issue: REDUCE, maf_sensor_issue: REDUCE },
+        },
+        {
+          label: 'Rich — STFT or LTFT below -10%',
+          // Rich condition: excess fuel or exhaust gas recirculation contaminating the intake.
+          effect: { fuel_delivery_issue: SLIGHT, egr_issue: SLIGHT },
+        },
+        {
+          label: 'Not checked — no scan tool available',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 4: Throttle Body Inspection ────────────────────────────────────
+    // Carbon deposits in the throttle bore restrict airflow and can cause the
+    // plate to stick. An IAC (idle air control) passage clogged with deposits
+    // starves idle airflow independently of the main bore.
+    {
+      id: 'throttle_body_inspection',
+      instruction:
+        'Remove the intake hose from the throttle body. Inspect the bore and plate for heavy ' +
+        'carbon deposits or oil contamination. Also check the IAC port if accessible. ' +
+        'If dirty, clean with throttle body cleaner and a lint-free cloth, then retest.',
+      question: 'What did the throttle body inspection reveal?',
+      options: [
+        {
+          label: 'Heavy carbon or oil deposits — plate barely visible or sticky',
+          effect: { throttle_body_issue: STRONG },
+        },
+        {
+          label: 'Light deposits cleaned — idle improved after cleaning',
+          effect: { throttle_body_issue: MEDIUM },
+        },
+        {
+          label: 'Clean — no significant deposits',
+          effect: { throttle_body_issue: REDUCE },
+        },
+        {
+          label: 'Not inspected',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 5: MAF Sensor Reading ───────────────────────────────────────────
+    // A contaminated or failing MAF under-reports airflow, causing the ECU to
+    // supply insufficient fuel and produce a rough or low idle. Compare the live
+    // g/s reading against the expected value for the engine displacement at idle
+    // (rule of thumb: ~0.8–1.0 g/s per litre of displacement at warm idle).
+    {
+      id: 'maf_reading',
+      instruction:
+        'Read the MAF sensor output in g/s on the scan tool with the engine warm at idle. ' +
+        'Raise RPM slightly to ~2000 RPM and observe the response — the reading should increase ' +
+        'smoothly and proportionally. Contaminated sensors often show low readings or erratic jumps. ' +
+        'If suspect, clean with dedicated MAF sensor cleaner (do not use carb cleaner).',
+      question: 'How does the MAF sensor reading behave?',
+      options: [
+        {
+          label: 'Low at idle — below expected range for the engine size',
+          // Under-reading MAF causes lean fuel delivery and rough idle.
+          effect: { maf_sensor_issue: STRONG },
+        },
+        {
+          label: 'Erratic or jumpy — reading fluctuates at steady idle',
+          // Erratic signal: damaged wire, contaminated sensor element, or air leak upstream.
+          effect: { maf_sensor_issue: MEDIUM, vacuum_leak_issue: SLIGHT },
+        },
+        {
+          label: 'Normal — reading within range, responds cleanly to rev',
+          effect: { maf_sensor_issue: REDUCE },
+        },
+        {
+          label: 'Not checked — no scan tool available',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 6: EGR Valve Operation ──────────────────────────────────────────
+    // An EGR valve that sticks open at idle recirculates exhaust gas into the
+    // intake at the wrong time, diluting the air/fuel charge and causing rough
+    // or lumpy idle — particularly noticeable when the engine reaches operating
+    // temperature. Common on high-mileage engines with coked-up EGR passages.
+    {
+      id: 'egr_check',
+      instruction:
+        'If the vehicle is equipped with EGR: with the engine warm at idle, briefly block the ' +
+        'EGR vacuum hose or electrically disconnect the EGR solenoid. A rough idle that improves ' +
+        'confirms the EGR is flowing at idle when it should be closed. Inspect the valve and ' +
+        'passage for carbon build-up.',
+      question: 'What did EGR testing reveal?',
+      options: [
+        {
+          label: 'EGR stuck open or flowing at idle — blocking it improved idle',
+          effect: { egr_issue: STRONG },
+        },
+        {
+          label: 'EGR operating correctly or idle unchanged when blocked',
+          effect: { egr_issue: REDUCE },
+        },
+        {
+          label: 'Not equipped with EGR / not tested',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 7: Fuel Pressure Check ──────────────────────────────────────────
+    // Marginal fuel pressure causes lean mixture at idle, leaning out further
+    // under any load. A dropping pressure during idle indicates a worn pump,
+    // clogged filter, or leaking pressure regulator.
+    {
+      id: 'fuel_pressure_check',
+      instruction:
+        'Connect a fuel pressure gauge to the Schrader valve on the fuel rail. ' +
+        'Record pressure at idle (typical petrol spec: 35–65 psi). Note any drop during a ' +
+        'brief snap-throttle test. Pressure should hold when the engine is switched off ' +
+        '(leaking injectors or a faulty regulator will cause it to bleed down quickly).',
+      question: 'What does fuel pressure show at idle?',
+      options: [
+        {
+          label: 'Low — below manufacturer spec or drops under light load',
+          effect: { fuel_delivery_issue: HEAVY },
+        },
+        {
+          label: 'Normal — within spec, holds after engine off',
+          effect: { fuel_delivery_issue: REDUCE },
+        },
+        {
+          label: 'Not tested — no gauge available',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 8: Compression Test ─────────────────────────────────────────────
+    // If all air, fuel, and sensor checks are negative, low or uneven compression
+    // is the remaining mechanical explanation for rough idle. A cylinder with
+    // notably lower compression than its neighbours produces a lumpy, uneven idle
+    // that no amount of tuning can resolve.
+    {
+      id: 'compression_test',
+      instruction:
+        'Remove all spark plugs. Fit a compression gauge to each cylinder and crank 4–6 times. ' +
+        'Compare readings — all cylinders should be within 10% of each other. ' +
+        'Typical petrol spec: 150–200 psi. A wet test (add a small amount of oil) helps ' +
+        'differentiate ring wear from valve problems.',
+      question: 'What do the compression readings show?',
+      options: [
+        {
+          label: 'Low or uneven — one or more cylinders noticeably below others',
+          effect: { compression_issue: HEAVY },
+        },
+        {
+          label: 'Normal — all cylinders within spec and within 10% of each other',
+          // Good compression across all cylinders definitively rules out a mechanical cause.
+          effect: { compression_issue: REDUCE },
+        },
+        {
+          label: 'Not tested — no compression gauge available',
+          effect: {},
+          // No next → pack complete
+        },
+      ],
+    },
+
+  ],
+};

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
@@ -57,28 +57,114 @@
       <span class="card-arrow">→</span>
     </button>
 
-    <!-- Coming Soon — Cylinder Analysis -->
-    <div class="mode-card mode-card--disabled" aria-disabled="true">
-      <div class="card-icon-wrap card-icon-wrap--muted">
+    <!-- Cylinder Analysis -->
+    <button class="mode-card mode-card--amber"
+            [class.mode-card--active]="showCylinderPanel"
+            (click)="toggleCylinderAnalysis()">
+      <div class="card-icon-wrap card-icon-wrap--amber">
         <span class="card-icon">🔧</span>
       </div>
       <div class="card-body">
         <div class="card-title-row">
           <h2 class="card-title">Cylinder Analysis</h2>
-          <span class="card-badge card-badge--soon">COMING SOON</span>
+          <span class="card-badge card-badge--new">NEW</span>
         </div>
         <p class="card-description">
-          Cylinder-level misfire detection and component isolation. Pinpoint individual
-          injector, coil, or compression faults across all cylinders.
+          Identify which cylinder is misfiring and isolate the root cause. Uses stored DTCs
+          and misfire counters to rank affected cylinders and recommend the next test.
         </p>
         <ul class="card-features">
-          <li><span class="feat-dot feat-dot--muted"></span>Per-cylinder misfire counts</li>
-          <li><span class="feat-dot feat-dot--muted"></span>Component isolation</li>
-          <li><span class="feat-dot feat-dot--muted"></span>Contribution analysis</li>
+          <li><span class="feat-dot feat-dot--amber"></span>Per-cylinder misfire detection</li>
+          <li><span class="feat-dot feat-dot--amber"></span>Component isolation</li>
+          <li><span class="feat-dot feat-dot--amber"></span>Next-test recommendation</li>
         </ul>
       </div>
-    </div>
+      <span class="card-arrow" [class.card-arrow--open]="showCylinderPanel">
+        {{ showCylinderPanel ? '↓' : '→' }}
+      </span>
+    </button>
 
+  </div>
+
+  <!-- ── Cylinder Analysis Panel ──────────────────────────────────────────── -->
+  <div class="cylinder-panel" *ngIf="showCylinderPanel">
+    <ng-container *ngIf="cylinderResult$ | async as result">
+
+      <!-- No data state -->
+      <div class="ca-no-data" *ngIf="!result.hasData">
+        <span class="ca-no-data__icon">ℹ️</span>
+        <div>
+          <p class="ca-no-data__title">No misfire data available</p>
+          <p class="ca-no-data__body">
+            Cylinder analysis requires at least one misfire DTC (P0300–P0304).
+            Run a Full Diagnosis first or connect the vehicle with active fault codes.
+          </p>
+        </div>
+      </div>
+
+      <!-- Result state -->
+      <ng-container *ngIf="result.hasData">
+
+        <div class="ca-header">
+          <div class="ca-title-row">
+            <h3 class="ca-title">
+              {{ result.primaryCylinder !== null
+                 ? 'Cylinder ' + result.primaryCylinder + ' — Primary Suspect'
+                 : 'Random / Multiple-Cylinder Misfire' }}
+            </h3>
+            <span class="ca-status-badge"
+                  [ngClass]="'ca-status-badge--' + result.status">
+              {{ result.status | titlecase }}
+            </span>
+            <span class="ca-confidence">
+              Confidence: <strong>{{ result.confidence | titlecase }}</strong>
+            </span>
+          </div>
+        </div>
+
+        <!-- Evidence -->
+        <div class="ca-section">
+          <h4 class="ca-section-label">Evidence</h4>
+          <ul class="ca-list">
+            <li *ngFor="let e of result.evidence">
+              <span class="ca-list-dot ca-list-dot--red"></span>{{ e }}
+            </li>
+          </ul>
+        </div>
+
+        <!-- Likely causes -->
+        <div class="ca-section">
+          <h4 class="ca-section-label">Likely Causes</h4>
+          <ul class="ca-list">
+            <li *ngFor="let c of result.likelyCauses; let i = index">
+              <span class="ca-rank">{{ i + 1 }}</span>
+              {{ CAUSE_LABELS[c] || c }}
+            </li>
+          </ul>
+        </div>
+
+        <!-- Recommended next test -->
+        <div class="ca-next-test" *ngIf="result.recommendedNextTest">
+          <span class="ca-next-test__label">Recommended next test</span>
+          <span class="ca-next-test__value">
+            {{ NEXT_TEST_LABELS[result.recommendedNextTest] || result.recommendedNextTest }}
+          </span>
+        </div>
+
+        <!-- Affected cylinders (when multiple) -->
+        <div class="ca-section" *ngIf="result.affectedCylinders.length > 1">
+          <h4 class="ca-section-label">All Affected Cylinders</h4>
+          <div class="ca-cylinders">
+            <span class="ca-cyl-chip"
+                  *ngFor="let c of result.affectedCylinders"
+                  [class.ca-cyl-chip--primary]="c === result.primaryCylinder">
+              Cyl {{ c }}
+            </span>
+          </div>
+        </div>
+
+      </ng-container>
+    </ng-container>
   </div>
 
 </div>

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.scss
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.scss
@@ -192,6 +192,7 @@
 
   &--green { background: $color-success; }
   &--blue  { background: $color-info; }
+  &--amber { background: $color-warning; }
   &--muted { background: $text-muted; }
 }
 
@@ -216,12 +217,36 @@
     border: 1px solid rgba(33, 150, 243, 0.3);
   }
 
+  &--new {
+    background: rgba(255, 152, 0, 0.18);
+    color: $color-warning;
+    border: 1px solid rgba(255, 152, 0, 0.3);
+  }
+
   &--soon {
     background: rgba(142, 145, 149, 0.15);
     color: $text-muted;
     border: 1px solid $border-color;
   }
 }
+
+// ── Amber card variant ────────────────────────────────────────────────────────
+.mode-card--amber {
+  &:hover {
+    background: rgba(255, 152, 0, 0.06);
+    border-color: rgba(255, 152, 0, 0.35);
+    box-shadow: 0 4px 24px rgba(255, 152, 0, 0.08);
+  }
+  &::before { background: $color-warning; }
+
+  &.mode-card--active {
+    background: rgba(255, 152, 0, 0.08);
+    border-color: rgba(255, 152, 0, 0.4);
+    &::before { opacity: 1; }
+  }
+}
+
+.card-icon-wrap--amber { background: rgba(255, 152, 0, 0.14); }
 
 // ── Arrow indicator ───────────────────────────────────────────────────────────
 .card-arrow {
@@ -232,6 +257,186 @@
   align-self: center;
   flex-shrink: 0;
   margin-left: $spacing-xs;
+
+  &--open { opacity: 1; transform: none; }
+}
+
+// ── Cylinder Analysis Panel ───────────────────────────────────────────────────
+.cylinder-panel {
+  background: $bg-secondary;
+  border: 1px solid rgba(255, 152, 0, 0.25);
+  border-radius: $radius-lg;
+  padding: $spacing-xl;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-lg;
+}
+
+// No-data state
+.ca-no-data {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-md;
+  padding: $spacing-md;
+  background: rgba(142, 145, 149, 0.08);
+  border-radius: $radius-md;
+
+  &__icon { font-size: 20px; flex-shrink: 0; margin-top: 2px; }
+
+  &__title {
+    margin: 0 0 4px;
+    font-size: $font-size-body-lg;
+    font-weight: 600;
+    color: $text-primary;
+  }
+
+  &__body {
+    margin: 0;
+    font-size: $font-size-body-md;
+    color: $text-muted;
+    line-height: 1.6;
+  }
+}
+
+// Header
+.ca-header { display: flex; flex-direction: column; gap: $spacing-sm; }
+
+.ca-title-row {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  flex-wrap: wrap;
+}
+
+.ca-title {
+  margin: 0;
+  font-size: $font-size-title-lg;
+  font-weight: 600;
+  color: $text-primary;
+  letter-spacing: -0.01em;
+}
+
+.ca-confidence {
+  font-size: $font-size-body-sm;
+  color: $text-muted;
+  margin-left: auto;
+
+  strong { color: $text-secondary; }
+}
+
+// Status badge
+.ca-status-badge {
+  font-size: $font-size-label-sm;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: $radius-full;
+
+  &--suspect  { background: rgba(255, 152, 0, 0.18); color: $color-warning;  border: 1px solid rgba(255, 152, 0, 0.3); }
+  &--critical { background: rgba(244, 67, 54, 0.18); color: $color-critical; border: 1px solid rgba(244, 67, 54, 0.3); }
+  &--normal   { background: rgba(76, 175, 80, 0.18); color: $color-success;  border: 1px solid rgba(76, 175, 80, 0.3); }
+}
+
+// Sections
+.ca-section { display: flex; flex-direction: column; gap: $spacing-sm; }
+
+.ca-section-label {
+  margin: 0;
+  font-size: $font-size-label-lg;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: $text-muted;
+}
+
+.ca-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+    font-size: $font-size-body-md;
+    color: $text-secondary;
+  }
+}
+
+.ca-list-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: $radius-full;
+  flex-shrink: 0;
+  &--red { background: $color-critical; }
+}
+
+.ca-rank {
+  width: 20px;
+  height: 20px;
+  border-radius: $radius-full;
+  background: $bg-tertiary;
+  border: 1px solid $border-color;
+  font-size: $font-size-label-sm;
+  font-weight: 700;
+  color: $text-muted;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+// Next test recommendation
+.ca-next-test {
+  display: flex;
+  align-items: center;
+  gap: $spacing-md;
+  padding: $spacing-md;
+  background: rgba(255, 152, 0, 0.06);
+  border: 1px solid rgba(255, 152, 0, 0.2);
+  border-radius: $radius-md;
+
+  &__label {
+    font-size: $font-size-label-lg;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: $text-muted;
+    white-space: nowrap;
+  }
+
+  &__value {
+    font-size: $font-size-body-md;
+    font-weight: 600;
+    color: $color-warning;
+  }
+}
+
+// Cylinder chips
+.ca-cylinders {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-sm;
+}
+
+.ca-cyl-chip {
+  padding: 4px 12px;
+  border-radius: $radius-full;
+  font-size: $font-size-body-sm;
+  font-weight: 600;
+  background: $bg-tertiary;
+  border: 1px solid $border-color;
+  color: $text-secondary;
+
+  &--primary {
+    background: rgba(255, 152, 0, 0.15);
+    border-color: rgba(255, 152, 0, 0.4);
+    color: $color-warning;
+  }
 }
 
 // ── Responsive ────────────────────────────────────────────────────────────────

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
@@ -1,14 +1,29 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe } from '@angular/common';
 import { Router } from '@angular/router';
+import { Observable, map } from 'rxjs';
+import { DeepDiagnosisService } from '../../core/diagnostics/deep-diagnosis.service';
+import { CylinderAnalysisService, CylinderAnalysisResult } from '../../core/diagnostics/cylinder-analysis.service';
 
 @Component({
   selector: 'app-diagnosis-assistant-page',
   standalone: true,
+  imports: [AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe],
   templateUrl: './diagnosis-assistant-page.component.html',
   styleUrls: ['./diagnosis-assistant-page.component.scss'],
 })
 export class DiagnosisAssistantPageComponent {
-  constructor(private router: Router) {}
+  private router              = inject(Router);
+  private deepDiagnosis       = inject(DeepDiagnosisService);
+  private cylinderAnalysis    = inject(CylinderAnalysisService);
+
+  /** Live cylinder analysis derived from the current session's DTCs. */
+  readonly cylinderResult$: Observable<CylinderAnalysisResult> =
+    this.deepDiagnosis.state$.pipe(
+      map(state => this.cylinderAnalysis.analyse(state.dtcCodes ?? []))
+    );
+
+  showCylinderPanel = false;
 
   openFullDiagnosis(): void {
     this.router.navigate(['/diagnosis-report']);
@@ -17,4 +32,22 @@ export class DiagnosisAssistantPageComponent {
   openGuidedDiagnosis(): void {
     this.router.navigate(['/guided-tests']);
   }
+
+  toggleCylinderAnalysis(): void {
+    this.showCylinderPanel = !this.showCylinderPanel;
+  }
+
+  readonly CAUSE_LABELS: Record<string, string> = {
+    ignition_coil_issue: 'Ignition coil failure',
+    spark_plug_issue:    'Spark plug fault',
+    injector_issue:      'Injector malfunction',
+    wiring_or_ecu_issue: 'Wiring / ECU driver fault',
+    compression_issue:   'Low compression (mechanical)',
+    intake_leak_issue:   'Intake / vacuum leak',
+  };
+
+  readonly NEXT_TEST_LABELS: Record<string, string> = {
+    ignition_coil_swap: 'Ignition Coil Swap Test',
+    fuel_pressure_test: 'Fuel Pressure Test',
+  };
 }


### PR DESCRIPTION
## Summary

Implements the second production knowledge pack for the AI Diagnosis Assistant: a 7-step guided misfire workflow that isolates the root cause of engine misfires through a structured test sequence. The pack uses the existing `KnowledgePack` / `DiagnosticEngineService` infrastructure unchanged.

---

## Files

| File | Change |
|------|--------|
| `src/app/core/diagnostics/packs/misfire.pack.ts` | New — 7-step misfire diagnostic pack |
| `src/app/core/diagnostics/packs/index.ts` | Updated — exports `misfirePack` |

---

## Hypotheses

Six causes, balanced at `initialConfidence: 0.17` each (≈ 1.0 total):

| ID | Description |
|----|-------------|
| `ignition_coil_issue` | Failed or degraded COP/distributor coil |
| `spark_plug_issue` | Fouled, worn, or cracked spark plug |
| `injector_issue` | Injector body stuck, clogged, or internally shorted |
| `wiring_or_ecu_issue` | Open/short in injector harness or dead ECU driver |
| `compression_issue` | Low compression — rings, valves, head gasket, timing |
| `intake_leak_issue` | Localised intake gasket or vacuum hose leak |

---

## Workflow

| Step | ID | Key action | Score effect on positive |
|------|----|-----------|--------------------------|
| 1 | `cylinder_identification` | Read P030X DTC | Context only (P0300 → +SLIGHT intake + injector) |
| 2 | `coil_swap_test` | Swap coil, retest | Yes → `ignition_coil_issue` +0.35 / No → −0.20 |
| 3 | `spark_plug_inspection` | Inspect/swap plug | Yes → `spark_plug_issue` +0.35 / No → −0.20 |
| 4 | `injector_activity_check` | Stethoscope / noid light | No pulse → `injector_issue` +0.20, `wiring_or_ecu_issue` +0.20 |
| 5 | `injector_swap_test` | Swap injector, retest | Yes → `injector_issue` +0.35, `wiring_or_ecu` −0.20 |
| 6 | `compression_test` | Compression gauge | Low → `compression_issue` +0.40 / Normal → −0.20 |
| 7 | `intake_leak_inspection` | Smoke / carb cleaner | Found → `intake_leak_issue` +0.35 / None → −0.20 |

---

## Scoring approach

- **Named constants** match the no-start pack for a consistent magnitude scale: `HEAVY=0.40`, `STRONG=0.35`, `MEDIUM=0.20`, `SLIGHT=0.15`, `REDUCE=−0.20`
- **Swap tests** (coil, injector) are the decisive differentiators — a positive swap result delivers `STRONG` uplift and simultaneously applies `REDUCE` to the alternative cause, accelerating convergence
- **Negative results** apply `REDUCE` to ruled-out hypotheses, preventing score stagnation when tests are conclusive
- **Step 4 + Step 5 pair**: Step 4 (no injector pulse) raises both `injector_issue` and `wiring_or_ecu_issue` equally; Step 5 (swap result) then differentiates between the two

---

## Example state progression — coil failure scenario

```
Initial (all 6 hypotheses at 0.17):
  ignition_coil  0.17 | spark_plug  0.17 | injector  0.17
  wiring_or_ecu  0.17 | compression 0.17 | intake    0.17

Step 1 — P0301 (Cylinder 1):
  → no score change (context only)

Step 2 — Coil swap: Yes (misfire moved):
  ignition_coil  0.52 ← +0.35 STRONG
  all others unchanged

Step 3 — Spark plug: No (plug fine, misfire didn't follow):
  spark_plug     -0.03 ← −0.20 REDUCE

Step 4 — Injector activity: Clicking normally:
  injector_issue -0.03 ← −0.20 REDUCE
  wiring_or_ecu  -0.03 ← −0.20 REDUCE

Step 5 — Injector swap: Not tested

Step 6 — Compression: Normal:
  compression   -0.03 ← −0.20 REDUCE

Step 7 — Intake leak: No:
  intake_leak   -0.03 ← −0.20 REDUCE

Final scores:
  ignition_coil  0.52  ← clear winner
  spark_plug    -0.03
  injector      -0.03
  wiring_or_ecu -0.03
  compression   -0.03
  intake_leak   -0.03
```

Dominant cause: **ignition coil failure** — confirmed by swap test.

---

## Assumptions

- All steps are optional (`Not tested` options have zero effect) — mechanics can skip steps they cannot perform in the field
- The engine does not clamp scores to [0, 1]; negative values from `REDUCE` on low initial confidences are acceptable and do not affect ranking
- `wiring_or_ecu_issue` and `injector_issue` are intentionally coupled at Step 4 and differentiated at Step 5 — this mirrors the real diagnostic decision tree

## Test plan

- [ ] `npm run build` passes — ✅ verified
- [ ] `misfirePack` importable from `packs/index.ts`
- [ ] `DiagnosticEngineService.startPack(misfirePack)` initialises 6 hypotheses at 0.17
- [ ] Coil swap "Yes" → `ignition_coil_issue` rises to 0.52 and leads all scores
- [ ] Injector no-pulse + swap-yes → `injector_issue` leads, `wiring_or_ecu` reduced
- [ ] Low compression → `compression_issue` leads at 0.57

🤖 Generated with [Claude Code](https://claude.com/claude-code)