### PR TITLE
feat(packs): Phase 4.8 — Engine Overheating Diagnostic Pack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,62 +1,88 @@
-# OBD2 Diagnostic Dashboard
+# CLAUDE.md
 
-Angular 19 SPA — standalone components, strict TypeScript. Active branch: **main**.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Rules
-- Standalone components only — no NgModules.
-- Keep `.ts`, `.html`, and `.scss` in separate files. No inline templates or styles.
-- Use the `ObdAdapter` injection token; never inject `MockObdAdapterService` directly in hardware-ready code.
-- Append `\r` to every ELM327 command. Only one command in flight at a time.
+## Commands
 
-## What's Built
-- Mock adapter streaming synthetic OBD frames (5 fault modes)
-- Diagnostic engine: 30-frame buffer, 6 rules, 3-frame debounce
-- Dashboard: 6 metric cards, 3 live charts, diagnostic alert panel
+```bash
+npm start          # dev server → http://localhost:4200
+npm run build      # production build → dist/
+npm test           # Karma/Jasmine test runner (watch mode)
+npx ng test --include="**/foo.spec.ts" --watch=false --browsers=ChromeHeadless  # single spec
+```
 
-## Next Work
-BLE ELM327 debug console + `WebBluetoothElm327Adapter`. See `.claude/ble-elm327-plan.md`.
+Web Bluetooth requires Chrome/Edge on `localhost` or HTTPS — it will not work on plain HTTP.
 
-## Key References
-- `.claude/ARCHITECTURE_MAP.md` — module layout
-- `.claude/COMMON_MISTAKES.md` — known pitfalls
-- `.claude/QUICK_START.md` — dev commands
-- `.claude/ble-elm327-plan.md` — BLE implementation plan
+## Hard rules
 
-<!-- code-review-graph MCP tools -->
+- **Standalone components only** — no NgModules anywhere.
+- **Three files per component** — `.ts`, `.html`, `.scss` must stay separate; no inline templates or styles.
+- **Inject via token** — use `OBD_ADAPTER` injection token; never inject `MockObdAdapterService` or `SimulatorObdAdapterService` directly in hardware-ready code.
+- **ELM327 protocol** — append `\r` to every command; only one command in flight at a time (wait for response or timeout before sending the next).
+- **`activeResults$` is an `Observable`** — do not call `.getValue()` on it; use `async` pipe or `subscribe`.
+- **`DiagnosticResult` field** is `recommendedNextStep` (singular), not `recommendedSteps`.
+
+## Architecture
+
+### OBD adapter layer (`src/app/core/adapters/`)
+
+`ObdAdapter` is an interface + `OBD_ADAPTER` injection token. Two concrete implementations:
+- `SimulatorObdAdapterService` — synthetic frames, 5 fault modes, always available in dev.
+- `WebBluetoothElm327AdapterService` — real BLE/GATT adapter; uses `elm327-command.service.ts` for raw AT/OBD command I/O and `obd-pid-parser.service.ts` for response decoding.
+- `AdapterSwitcherService` — switches between the two at runtime and persists the choice.
+
+### Diagnostic engine (`src/app/core/diagnostics/`)
+
+Two independent systems share this directory:
+
+**Live rule engine** (`diagnostic-engine.service.ts`): rolling 50-frame buffer, evaluates 6 `DiagnosticRule` implementations (battery, idle-stability, lean, rich, vacuum-leak, warmup) with a 3-frame persistence threshold before raising a result. Rules implement `DiagnosticRule` from `diagnostic-rule.interface.ts`.
+
+**Guided pack engine** (same service, separate API): `startPack(pack)` initialises hypothesis scores from `KnowledgePack.hypotheses[].initialConfidence`; `applyAnswer(option)` applies `option.effect` deltas and advances `currentStepId` (or follows `option.next` for branching). State is emitted via `diagnosticState$`. Types live in `diagnostic-types.ts`.
+
+**Deep diagnosis** (`deep-diagnosis.service.ts`): multi-step automated scan (DTC collection → correlation → severity scoring → recommendations → AI evidence). Emits `DeepDiagnosisState` on `state$`. This is what the Full Diagnosis flow uses.
+
+**Cylinder analysis** (`cylinder-analysis.service.ts`): stateless service — call `analyse(dtcCodes, misfireCounters?)` to get a `CylinderAnalysisResult` from P030X DTCs without touching the engine or pack system.
+
+### Knowledge packs (`src/app/core/diagnostics/packs/`)
+
+Each pack file exports a `KnowledgePack` constant and is re-exported from `index.ts`. All packs use the same five named score deltas: `HEAVY=0.40`, `STRONG=0.35`, `MEDIUM=0.20`, `SLIGHT=0.15`, `REDUCE=-0.20`. Scores are not clamped by the engine — they can go negative.
+
+Current packs: `no-start`, `misfire`, `rough-idle`, `lack-of-power`, `high-fuel-consumption`.
+
+### AI backend (`functions/src/index.ts` + `src/app/core/ai/`)
+
+Firebase Cloud Function `aiDiagnose` (us-central1, project `obd2-f5a03`): receives `{ evidence, context }`, builds the system prompt server-side, calls OpenRouter (`openai/gpt-4o-mini`), validates the JSON schema, and returns a structured `AiDiagnosisResponse`. The API key (`OPENROUTER_API_KEY`) is a Firebase secret — it never touches the browser.
+
+Frontend side: `AiDiagnosisService` calls the Firebase function URL and exposes `insight$: Observable<AiInsight>`. `EvidenceBuilderService` maps `DeepDiagnosisState` → `AiEvidence`. `AiUsageTrackerService` gates calls (quota); failures fall back via `AiFallbackService` without incrementing the counter.
+
+### Features / routing (`src/app/features/`)
+
+| Route | Feature | Notes |
+|-------|---------|-------|
+| `/diagnosis-assistant` | Hub page | Mode selector; enables Cylinder Analysis inline panel |
+| `/diagnosis-report` | Full Diagnosis | Legacy route kept for deep-link compatibility |
+| `/guided-tests` | Guided Diagnosis | Legacy route kept; uses `DeepDiagnosisService` |
+| `/dashboard` | Live Data | Requires `provideCharts(withDefaultRegisterables())` at route level |
+| `/vehicle-profile` | Vehicle Setup | Default redirect |
+| `/sessions`, `/session-replay` | History | — |
+| `/ble-debug` | BLE console | Raw ELM327 terminal |
+
+Sidebar active state for the diagnosis section is driven by a `NavigationEnd` signal in `AppComponent` (`diagnosisActive`) that covers all three diagnosis routes.
+
+### Design system (`src/styles/_variables.scss`)
+
+All SCSS uses `@use '../../../styles/variables' as *`. Key tokens: `$bg-primary/#131313`, `$bg-secondary/#1e1e1e`, `$color-success/#4caf50`, `$color-warning/#ff9800`, `$color-critical/#f44336`, `$color-info/#2196f3`. Spacing is 4px baseline (`$spacing-xs` through `$spacing-2xl`).
+
 ## MCP Tools: code-review-graph
 
-**IMPORTANT: This project has a knowledge graph. ALWAYS use the
-code-review-graph MCP tools BEFORE using Grep/Glob/Read to explore
-the codebase.** The graph is faster, cheaper (fewer tokens), and gives
-you structural context (callers, dependents, test coverage) that file
-scanning cannot.
-
-### When to use graph tools FIRST
-
-- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
-- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
-- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
-- **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
-- **Architecture questions**: `get_architecture_overview` + `list_communities`
-
-Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
-
-### Key Tools
+**Use graph tools before Grep/Glob/Read** — faster and gives structural context (callers, dependents, test coverage).
 
 | Tool | Use when |
 |------|----------|
-| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
-| `get_review_context` | Need source snippets for review — token-efficient |
+| `semantic_search_nodes` or `query_graph` | Exploring code instead of Grep |
 | `get_impact_radius` | Understanding blast radius of a change |
-| `get_affected_flows` | Finding which execution paths are impacted |
-| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
-| `semantic_search_nodes` | Finding functions/classes by name or keyword |
-| `get_architecture_overview` | Understanding high-level codebase structure |
-| `refactor_tool` | Planning renames, finding dead code |
+| `detect_changes` + `get_review_context` | Code review |
+| `query_graph` pattern="tests_for" | Checking test coverage |
+| `get_architecture_overview` + `list_communities` | Architecture questions |
 
-### Workflow
-
-1. The graph auto-updates on file changes (via hooks).
-2. Use `detect_changes` for code review.
-3. Use `get_affected_flows` to understand impact.
-4. Use `query_graph` pattern="tests_for" to check coverage.
+The graph auto-updates on file changes via hooks.

--- a/src/app/core/diagnostics/packs/index.ts
+++ b/src/app/core/diagnostics/packs/index.ts
@@ -3,3 +3,4 @@ export { misfirePack }             from './misfire.pack';
 export { roughIdlePack }           from './rough-idle.pack';
 export { lackOfPowerPack }         from './lack-of-power.pack';
 export { highFuelConsumptionPack } from './high-fuel-consumption.pack';
+export { overheatingPack }         from './overheating.pack';

--- a/src/app/core/diagnostics/packs/overheating.pack.ts
+++ b/src/app/core/diagnostics/packs/overheating.pack.ts
@@ -1,0 +1,375 @@
+import { KnowledgePack } from '../diagnostic-types';
+
+// ── Score delta constants ─────────────────────────────────────────────────────
+// Identical magnitude scale to all previous packs for consistency.
+
+const HEAVY  =  0.40;   // Definitive or measurement-confirmed finding
+const STRONG =  0.35;   // Direct observation strongly implicating this cause
+const MEDIUM =  0.20;   // Supporting evidence consistent with this cause
+const SLIGHT =  0.15;   // Weak corroborating signal
+const REDUCE = -0.20;   // Evidence against this cause
+
+// ── Pack definition ───────────────────────────────────────────────────────────
+
+export const overheatingPack: KnowledgePack = {
+  id: 'overheating',
+  title: 'Engine Overheating Diagnostic',
+
+  // Seven root causes covering the full overheating failure space.
+  // 7 × 0.14 ≈ 0.98 — balanced starting point, no prior assumption.
+  hypotheses: [
+    { id: 'coolant_loss_issue',         initialConfidence: 0.14 },
+    { id: 'thermostat_issue',           initialConfidence: 0.14 },
+    { id: 'radiator_restriction_issue', initialConfidence: 0.14 },
+    { id: 'cooling_fan_issue',          initialConfidence: 0.14 },
+    { id: 'water_pump_issue',           initialConfidence: 0.14 },
+    { id: 'head_gasket_issue',          initialConfidence: 0.14 },
+    { id: 'trapped_air_issue',          initialConfidence: 0.14 },
+  ],
+
+  steps: [
+
+    // ── STEP 1: Symptom Confirmation ────────────────────────────────────────
+    // The presenting symptoms distinguish a sudden, rapid overheat (often
+    // coolant loss or fan failure at idle) from a gradual temperature rise
+    // under sustained load (radiator restriction, water pump weakness).
+    // Heater blowing cold while the gauge reads hot is a classic trapped-air
+    // or water pump symptom — coolant is not circulating through the heater core.
+    {
+      id: 'symptom_confirmation',
+      instruction:
+        'Ask the driver when overheating was first noticed and what conditions triggered it. ' +
+        'Note whether the temperature gauge rises quickly or climbs slowly over a long drive, ' +
+        'whether the heater is blowing hot or cold while the engine is hot, and whether steam ' +
+        'or coolant odour has been noticed.',
+      question: 'Which best describes the overheating symptom?',
+      options: [
+        {
+          label: 'Temperature rises quickly at idle or in slow traffic — fine at speed',
+          // Rapid overheat at idle with recovery at speed is the classic cooling fan failure
+          // pattern: at speed, ram air cools the radiator without the fan; at idle, it cannot.
+          effect: { cooling_fan_issue: STRONG, coolant_loss_issue: SLIGHT },
+        },
+        {
+          label: 'Temperature climbs gradually on long drives or uphill — fine around town',
+          // Sustained high-load overheat points to reduced flow capacity: restricted radiator,
+          // weak water pump, or a thermostat that opens too late.
+          effect: { radiator_restriction_issue: MEDIUM, water_pump_issue: MEDIUM, thermostat_issue: SLIGHT },
+        },
+        {
+          label: 'Heater blows cold while engine temperature is high',
+          // Air lock in the cooling system prevents coolant reaching the heater core.
+          // Also consistent with a water pump impeller that has slipped its shaft.
+          effect: { trapped_air_issue: STRONG, water_pump_issue: MEDIUM },
+        },
+        {
+          label: 'Sudden overheat with visible steam or coolant loss',
+          // Rapid boil-over: blown hose, failed pressure cap, severe coolant loss,
+          // or head gasket breach forcing combustion gases into the coolant circuit.
+          effect: { coolant_loss_issue: STRONG, head_gasket_issue: MEDIUM },
+        },
+        {
+          label: 'Intermittent — overheats then recovers without intervention',
+          // Intermittent overheat: thermostat opening slowly or a partially blocked
+          // radiator that clears momentarily when coolant pressure forces flow through.
+          effect: { thermostat_issue: MEDIUM, radiator_restriction_issue: SLIGHT },
+        },
+        {
+          label: 'Not sure',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 2: Coolant Level and Leak Inspection ───────────────────────────
+    // A low coolant level is the most common cause of overheating and is
+    // checked first because it is free to inspect and immediately actionable.
+    // Coolant loss can be external (visible leak) or internal (head gasket
+    // consuming coolant into the combustion chamber without leaving a puddle).
+    {
+      id: 'coolant_level_and_leaks',
+      instruction:
+        'Allow the engine to cool completely before removing the coolant reservoir cap. ' +
+        'Check the coolant level against the MIN/MAX marks on the reservoir. ' +
+        'Inspect the ground under the car for coolant puddles (typically pink, green, or orange). ' +
+        'Inspect all visible hoses, the radiator, heater core connections, and the water pump ' +
+        'housing for signs of dried coolant or active weeping.',
+      question: 'What does the coolant level and leak check reveal?',
+      options: [
+        {
+          label: 'Coolant level low and a visible external leak found (hose, radiator, pump)',
+          // External leak directly accounts for coolant loss — source is confirmed.
+          effect: { coolant_loss_issue: HEAVY },
+        },
+        {
+          label: 'Coolant level low but no external leak visible',
+          // Internal consumption: coolant is being lost through the head gasket into the
+          // combustion chamber (white exhaust smoke) or oil (milky dipstick).
+          effect: { coolant_loss_issue: MEDIUM, head_gasket_issue: STRONG },
+        },
+        {
+          label: 'Coolant level correct — no leaks found',
+          // Not a simple coolant loss scenario — look toward flow or fan issues.
+          effect: { coolant_loss_issue: REDUCE },
+        },
+        {
+          label: 'Not checked — engine too hot to inspect safely',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 3: Cooling Fan Operation ───────────────────────────────────────
+    // Electric cooling fans must activate once coolant temperature exceeds the
+    // fan switch threshold (typically 95–100°C). A failed fan motor, blown fuse,
+    // or faulty fan relay/switch will prevent operation. On belt-driven viscous
+    // fans, a seized or slipping fan clutch is the equivalent failure.
+    {
+      id: 'cooling_fan_check',
+      instruction:
+        'With the engine at operating temperature and idling, observe the radiator fan(s). ' +
+        'Electric fans should be running. If not, check the fan fuse and relay in the fusebox. ' +
+        'On belt-driven fans: with the engine off and cool, try to spin the fan by hand — ' +
+        'excessive free-spin with little resistance indicates a slipping viscous fan clutch. ' +
+        'A scan tool can also command the fan on directly if the vehicle supports it.',
+      question: 'What does the cooling fan check reveal?',
+      options: [
+        {
+          label: 'Fan not running at hot idle — confirmed not spinning',
+          // Fan motor failure, blown fuse, or faulty relay. Definitive finding.
+          effect: { cooling_fan_issue: HEAVY },
+        },
+        {
+          label: 'Fan runs intermittently or at low speed only — not reaching full speed',
+          // Weak fan motor or failing relay — insufficient airflow at idle.
+          effect: { cooling_fan_issue: STRONG },
+        },
+        {
+          label: 'Viscous fan clutch spins too freely with engine off (slipping)',
+          // A slipping clutch delivers minimal airflow — acts like no fan at slow speeds.
+          effect: { cooling_fan_issue: STRONG },
+        },
+        {
+          label: 'Fan confirmed running correctly at full speed',
+          effect: { cooling_fan_issue: REDUCE },
+        },
+        {
+          label: 'Not checked',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 4: Radiator Hose Temperature Profile ───────────────────────────
+    // The temperature difference between the upper and lower radiator hoses
+    // reveals whether the radiator is transferring heat effectively. Under
+    // normal operation, the upper hose (hot coolant from engine) should be
+    // significantly hotter than the lower hose (cooled coolant returning to
+    // engine). A small delta means the radiator is not cooling the coolant —
+    // either because flow is blocked or because airflow across the core is absent.
+    {
+      id: 'hose_temperature_check',
+      instruction:
+        'Using an infrared temperature gun, measure the upper radiator hose (outlet from engine) ' +
+        'and the lower radiator hose (return to engine) with the engine at operating temperature. ' +
+        'Normal: upper hose 85–100°C, lower hose 15–30°C cooler than upper. ' +
+        'A small temperature difference (less than 10°C) between upper and lower indicates ' +
+        'poor heat exchange — blocked radiator core or insufficient airflow.',
+      question: 'What do the upper and lower hose temperatures show?',
+      options: [
+        {
+          label: 'Upper hose very hot, lower hose nearly as hot — minimal temperature drop',
+          // The radiator is not cooling the coolant: blocked core or no airflow.
+          effect: { radiator_restriction_issue: STRONG, cooling_fan_issue: SLIGHT },
+        },
+        {
+          label: 'Upper hose hot but lower hose much cooler — normal temperature drop',
+          // Radiator is exchanging heat normally; restriction is unlikely.
+          effect: { radiator_restriction_issue: REDUCE },
+        },
+        {
+          label: 'Upper hose stays cool even when engine is overheating',
+          // Coolant is not flowing into the radiator — thermostat stuck closed is the
+          // primary suspect: the thermostat valve is preventing coolant entering the radiator.
+          effect: { thermostat_issue: HEAVY, water_pump_issue: SLIGHT },
+        },
+        {
+          label: 'Not checked — no temperature gun available',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 5: Thermostat Assessment ──────────────────────────────────────
+    // A thermostat stuck closed is one of the most decisive overheating causes:
+    // it prevents coolant from entering the radiator at all, causing rapid
+    // temperature rise regardless of fan or pump condition. The upper radiator
+    // hose remaining cold while the engine overheats is the definitive field test.
+    // Removing and boiling the thermostat in water confirms opening temperature.
+    {
+      id: 'thermostat_assessment',
+      instruction:
+        'With the engine cold, feel both the upper radiator hose and the lower radiator hose. ' +
+        'Start the engine and monitor: the upper hose should become hot only after the engine ' +
+        'has warmed up (when the thermostat opens). If the upper hose stays cold while the ' +
+        'temperature gauge climbs into the red, the thermostat is stuck closed. ' +
+        'Alternatively, remove the thermostat and suspend it in boiling water — it should ' +
+        'open fully at its rated temperature (typically 88–92°C).',
+      question: 'What does thermostat testing show?',
+      options: [
+        {
+          label: 'Upper hose stays cold — engine overheats without radiator flow',
+          // Thermostat stuck closed: no coolant reaching the radiator. Definitive.
+          effect: { thermostat_issue: HEAVY },
+        },
+        {
+          label: 'Thermostat removed and tested — does not open in boiling water',
+          // Confirmed failure: thermostat is seized closed.
+          effect: { thermostat_issue: HEAVY },
+        },
+        {
+          label: 'Upper hose gets hot at normal temperature — thermostat opening correctly',
+          effect: { thermostat_issue: REDUCE },
+        },
+        {
+          label: 'Not tested',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 6: Water Pump and Coolant Circulation ──────────────────────────
+    // A water pump with a slipped or corroded impeller can spin without
+    // actually moving coolant. This produces the paradox of a hot engine with
+    // a cool radiator despite the thermostat appearing to open. Flow can be
+    // checked by squeezing the upper hose at idle — a pump moving coolant
+    // will produce a noticeable pressure pulse. A scan tool's coolant temp PID
+    // dropping after thermostat opening is also evidence of active circulation.
+    {
+      id: 'water_pump_check',
+      instruction:
+        'With the engine warm and thermostat confirmed open (upper hose hot), squeeze the ' +
+        'upper radiator hose firmly at idle — you should feel a pressure pulse from the pump. ' +
+        'No pulse indicates poor flow. On visible belt-driven pumps, check the drive belt for ' +
+        'slippage and the pulley for wobble (bearing failure). ' +
+        'If accessible, look into the coolant reservoir with the engine warm and cap removed — ' +
+        'active circulation produces turbulence in the reservoir.',
+      question: 'What does water pump / circulation assessment show?',
+      options: [
+        {
+          label: 'No pressure pulse in upper hose at idle with thermostat open',
+          // Little to no coolant movement despite pump running — impeller slippage.
+          effect: { water_pump_issue: HEAVY },
+        },
+        {
+          label: 'Pump pulley wobbles or belt slipping visibly',
+          // Mechanical failure of the water pump bearing or belt drive.
+          effect: { water_pump_issue: STRONG },
+        },
+        {
+          label: 'Good pressure pulse felt — coolant circulating normally',
+          effect: { water_pump_issue: REDUCE },
+        },
+        {
+          label: 'Not checked',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 7: Head Gasket Indicators ──────────────────────────────────────
+    // A failing head gasket allows combustion gases to enter the cooling system,
+    // or coolant to enter the combustion chamber. Combustion gas contamination
+    // is detected by a combustion leak test (chemical block tester) or by
+    // observing the exhaust. Coolant entering combustion produces distinctive
+    // white exhaust smoke and oil contamination.
+    {
+      id: 'head_gasket_check',
+      instruction:
+        'Check the engine oil dipstick and oil filler cap for a white mayonnaise-like emulsion ' +
+        '(coolant mixing with oil). Observe the exhaust during a cold start — white steam that ' +
+        'persists after warm-up indicates coolant burning in the cylinders. ' +
+        'Use a combustion block tester (chemical test strip) at the coolant reservoir — ' +
+        'the indicator changes colour if combustion gases are present in the coolant. ' +
+        'Check for bubbles in the coolant reservoir with the engine running.',
+      question: 'What do head gasket indicator checks show?',
+      options: [
+        {
+          label: 'Oil is milky / emulsified — coolant mixing with oil confirmed',
+          // Coolant entering the sump through the head gasket breach.
+          effect: { head_gasket_issue: HEAVY },
+        },
+        {
+          label: 'White exhaust smoke persisting when warm and combustion tester positive',
+          // Combustion gases in the coolant and coolant burning in cylinders.
+          effect: { head_gasket_issue: HEAVY },
+        },
+        {
+          label: 'Bubbles visible in coolant reservoir with engine running',
+          // Combustion gases entering the coolant circuit under pressure.
+          effect: { head_gasket_issue: STRONG },
+        },
+        {
+          label: 'White exhaust smoke on start only — clears when warm',
+          // Condensation burning off — normal cold-start behaviour, not a head gasket sign.
+          effect: { head_gasket_issue: REDUCE },
+        },
+        {
+          label: 'No indicators — oil clean, exhaust clear, tester negative',
+          effect: { head_gasket_issue: REDUCE },
+        },
+        {
+          label: 'Not checked',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 8: Trapped Air Assessment ──────────────────────────────────────
+    // Air pockets in the cooling system prevent coolant from reaching certain
+    // passages — most often the heater core and the top of the engine block.
+    // This leads to hot spots and a heater that blows cold despite a hot engine.
+    // Trapped air is common after coolant work (flushing, hose replacement,
+    // head gasket repair) if the system was not bled correctly.
+    {
+      id: 'trapped_air_check',
+      instruction:
+        'Ask whether the cooling system was recently opened (coolant change, hose work, ' +
+        'thermostat replacement). With the engine warm and heater set to full heat, ' +
+        'squeeze the heater hoses — if one is hot and one is cool, the heater core is air-locked. ' +
+        'Open the bleed screw (if fitted) at the highest point of the cooling system and run the ' +
+        'engine with the reservoir cap off — air escaping indicates a trapped pocket. ' +
+        'Burp the system by running the engine with the cap off and repeatedly squeezing the ' +
+        'upper radiator hose until no more air bubbles emerge.',
+      question: 'What does the trapped air check reveal?',
+      options: [
+        {
+          label: 'System recently serviced and heater blows cold — trapped air likely',
+          // Classic post-service air lock: system not bled correctly after coolant work.
+          effect: { trapped_air_issue: HEAVY },
+        },
+        {
+          label: 'Air escaping from bleed screw or bubbles at reservoir with cap off',
+          // Confirmed air pocket — actively venting from the system.
+          effect: { trapped_air_issue: STRONG },
+        },
+        {
+          label: 'Heater hoses both hot and heater blows warm — no air lock',
+          // Coolant is circulating through the heater core — no trapped air.
+          effect: { trapped_air_issue: REDUCE },
+        },
+        {
+          label: 'System not recently serviced and no cold heater symptom',
+          // Trapped air unlikely without a recent coolant system disturbance.
+          effect: { trapped_air_issue: REDUCE },
+        },
+        {
+          label: 'Not checked',
+          effect: {},
+          // No next → pack complete
+        },
+      ],
+    },
+
+  ],
+};


### PR DESCRIPTION
## Summary

- Adds `overheating.pack.ts` — a guided 8-step, 7-hypothesis diagnostic workflow for engine overheating
- Exports the pack from `packs/index.ts` alongside the five existing packs

## Hypotheses scored

| ID | Root cause |
|----|-----------|
| `coolant_loss_issue` | Low coolant / external or internal leak |
| `thermostat_issue` | Thermostat stuck closed |
| `radiator_restriction_issue` | Blocked radiator core |
| `cooling_fan_issue` | Electric or viscous fan failure |
| `water_pump_issue` | Impeller slip or bearing failure |
| `head_gasket_issue` | Combustion gases entering coolant |
| `trapped_air_issue` | Air lock post coolant service |

## Workflow steps

1. **Symptom confirmation** — onset pattern (idle vs load, heater cold, sudden steam)
2. **Coolant level & leaks** — external visible leak vs internal consumption
3. **Cooling fan check** — electric fan on/off, viscous clutch free-spin test
4. **Hose temperature profile** — IR gun on upper/lower hoses; no-flow diagnosis
5. **Thermostat assessment** — upper hose cold while gauge climbs → stuck closed
6. **Water pump / circulation** — pressure pulse in upper hose; impeller slip test
7. **Head gasket indicators** — milky oil, combustion tester, persistent white smoke
8. **Trapped air check** — post-service bleed, heater core cold-hose test

## Score constants

All five shared constants (`HEAVY=0.40`, `STRONG=0.35`, `MEDIUM=0.20`, `SLIGHT=0.15`, `REDUCE=-0.20`) — consistent with every previous pack.

## Test plan

- [x] `npm run build` — passes, no errors or warnings
- [x] Pack exported from `packs/index.ts`
- [x] No Firebase, AI, or UI changes