### PR TITLE
feat(diagnostics): Diesel DPF / EGR diagnostic knowledge pack

### DIFF
--- a/src/app/core/diagnostics/packs/dpf-egr.pack.spec.ts
+++ b/src/app/core/diagnostics/packs/dpf-egr.pack.spec.ts
@@ -1,0 +1,165 @@
+import { TestBed } from '@angular/core/testing';
+import { DiagnosticEngineService } from '../diagnostic-engine.service';
+import { DiagnosticState } from '../diagnostic-types';
+import { dpfEgrPack } from './dpf-egr.pack';
+
+/**
+ * DPF / EGR Pack — scenario walkthroughs
+ *
+ * Score constants (initial: 0.25 each, additive):
+ *   HEAVY=0.40  STRONG=0.35  MEDIUM=0.20  SLIGHT=0.15  REDUCE=-0.20
+ */
+
+function topHypothesis(state: DiagnosticState): string {
+  return Object.entries(state.hypothesisScores)
+    .sort(([, a], [, b]) => b - a)[0][0];
+}
+
+describe('dpfEgrPack', () => {
+  let engine: DiagnosticEngineService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    engine = TestBed.inject(DiagnosticEngineService);
+  });
+
+  // ── Scenario A: DPF soot overload + regeneration failure ────────────────
+  // DPF warning light / limp mode, P2002 code, soot load > 75 %,
+  // high differential pressure, EGR and temp sensors fine,
+  // forced regen refused by scan tool. Expected winner: dpf_soot_overload_issue.
+  it('Scenario A — DPF soot overload: dpf_soot_overload_issue wins', () => {
+    engine.startPack(dpfEgrPack);
+
+    // symptom_confirm — DPF warning / limp mode  → dpf_soot +STRONG, regen_fail +MEDIUM
+    let step = engine.getCurrentStep()!;
+    expect(step.id).toBe('symptom_confirm');
+    engine.applyAnswer(step.options[0]);
+
+    // dtc_check — P2002 / P2003  → dpf_soot +HEAVY
+    step = engine.getCurrentStep()!;
+    expect(step.id).toBe('dtc_check');
+    engine.applyAnswer(step.options[0]);
+
+    // soot_load_regen_history — soot > 75 %  → dpf_soot +HEAVY, regen_fail +STRONG
+    step = engine.getCurrentStep()!;
+    expect(step.id).toBe('soot_load_regen_history');
+    engine.applyAnswer(step.options[2]);
+
+    // differential_pressure — elevated, rises with RPM  → dpf_soot +STRONG, turbo +MEDIUM
+    step = engine.getCurrentStep()!;
+    expect(step.id).toBe('differential_pressure');
+    engine.applyAnswer(step.options[1]);
+
+    // egr_valve_operation — tracks correctly  → egr -REDUCE
+    step = engine.getCurrentStep()!;
+    expect(step.id).toBe('egr_valve_operation');
+    engine.applyAnswer(step.options[0]);
+
+    // exhaust_temp_sensor — plausible  → temp_sensor -REDUCE
+    step = engine.getCurrentStep()!;
+    expect(step.id).toBe('exhaust_temp_sensor');
+    engine.applyAnswer(step.options[0]);
+
+    // forced_regen_assessment — scan tool refused (soot too high)  → dpf_soot +HEAVY, regen_fail +STRONG
+    step = engine.getCurrentStep()!;
+    expect(step.id).toBe('forced_regen_assessment');
+    engine.applyAnswer(step.options[2]);
+
+    const state = engine.getState()!;
+    expect(state.currentStepId).toBe('');
+    expect(state.history.length).toBe(7);
+
+    // dpf_soot = 0.25 + 0.35 + 0.40 + 0.40 + 0.35 + 0.40 = 2.15
+    expect(topHypothesis(state)).toBe('dpf_soot_overload_issue');
+    expect(state.hypothesisScores['dpf_soot_overload_issue']).toBeCloseTo(2.15, 5);
+  });
+
+  // ── Scenario B: Differential pressure sensor fault ───────────────────────
+  // DPF light on, P2453 code, soot load reads low (sensor can't be trusted),
+  // zero differential pressure at all RPM, EGR fine, temp sensors fine,
+  // forced regen aborts (ECU thinks DPF is full because sensor is faulty).
+  // Expected winner: differential_pressure_sensor_issue.
+  it('Scenario B — differential pressure sensor fault: sensor issue wins', () => {
+    engine.startPack(dpfEgrPack);
+
+    // symptom_confirm — frequent regen cycles  → regen_fail +STRONG, dpf_soot +SLIGHT
+    let step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[1]);
+
+    // dtc_check — P2452/P2453/P2454  → diff_pressure_sensor +HEAVY, dpf_soot +SLIGHT
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[1]);
+
+    // soot_load_regen_history — data not available
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[3]);
+
+    // differential_pressure — zero/flat at all RPM  → diff_sensor +HEAVY, dpf_soot +SLIGHT
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[2]);
+
+    // egr_valve_operation — tracks correctly  → egr -REDUCE
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // exhaust_temp_sensor — plausible  → temp_sensor -REDUCE
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // forced_regen_assessment — aborted before completion  → regen_fail +HEAVY, temp_sensor +MEDIUM
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[1]);
+
+    const state = engine.getState()!;
+    expect(state.currentStepId).toBe('');
+
+    // diff_pressure_sensor = 0.25 + 0.40 + 0.40 = 1.05
+    expect(topHypothesis(state)).toBe('differential_pressure_sensor_issue');
+    expect(state.hypothesisScores['differential_pressure_sensor_issue']).toBeCloseTo(1.05, 5);
+  });
+
+  // ── Scenario C: EGR valve stuck open ────────────────────────────────────
+  // Black smoke, rough idle. P0401 code. Soot load moderate.
+  // Pressure normal. EGR actual position stuck high at idle.
+  // Temp sensors plausible. Forced regen completes (DPF itself is fine).
+  // Expected winner: egr_valve_issue.
+  it('Scenario C — EGR valve stuck open: egr_valve_issue wins', () => {
+    engine.startPack(dpfEgrPack);
+
+    // symptom_confirm — black smoke / rough idle  → egr +STRONG, dpf_soot +SLIGHT
+    let step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[3]);
+
+    // dtc_check — P0400/P0401 EGR codes  → egr +HEAVY
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[2]);
+
+    // soot_load_regen_history — moderate 40–75 %  → regen_fail +MEDIUM, dpf_soot +SLIGHT
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[1]);
+
+    // differential_pressure — within normal spec  → dpf_soot -REDUCE, diff_sensor -REDUCE
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // egr_valve_operation — stuck open  → egr +HEAVY
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[1]);
+
+    // exhaust_temp_sensor — plausible  → temp_sensor -REDUCE
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    // forced_regen_assessment — completed successfully  → dpf_soot -REDUCE, regen_fail -REDUCE
+    step = engine.getCurrentStep()!;
+    engine.applyAnswer(step.options[0]);
+
+    const state = engine.getState()!;
+    expect(state.currentStepId).toBe('');
+    expect(state.history.length).toBe(7);
+
+    // egr_valve = 0.25 + 0.35 + 0.40 + 0.40 = 1.40 — clear winner
+    expect(topHypothesis(state)).toBe('egr_valve_issue');
+    expect(state.hypothesisScores['egr_valve_issue']).toBeCloseTo(1.40, 5);
+  });
+});

--- a/src/app/core/diagnostics/packs/dpf-egr.pack.ts
+++ b/src/app/core/diagnostics/packs/dpf-egr.pack.ts
@@ -1,0 +1,311 @@
+import { KnowledgePack } from '../diagnostic-types';
+
+// ── Score delta constants ─────────────────────────────────────────────────────
+const HEAVY  = 0.40;   // Strong physical measurement pointing at this cause
+const STRONG = 0.35;   // Clear symptom, very likely this cause
+const MEDIUM = 0.20;   // Supporting evidence, consistent with this cause
+const SLIGHT = 0.15;   // Weak corroborating signal
+const REDUCE = -0.20;  // Evidence against this cause
+
+// ── Pack definition ───────────────────────────────────────────────────────────
+
+export const dpfEgrPack: KnowledgePack = {
+  id: 'dpf_egr',
+  title: 'Diesel DPF / EGR Diagnostic',
+
+  // Six root causes covering diesel particulate filter, EGR, and associated
+  // sensors. Balanced starting confidence — no cause assumed before evidence.
+  hypotheses: [
+    { id: 'dpf_soot_overload_issue',              initialConfidence: 0.25 },
+    { id: 'regeneration_failure_issue',           initialConfidence: 0.25 },
+    { id: 'egr_valve_issue',                      initialConfidence: 0.25 },
+    { id: 'differential_pressure_sensor_issue',   initialConfidence: 0.25 },
+    { id: 'exhaust_temperature_sensor_issue',     initialConfidence: 0.25 },
+    { id: 'soot_related_turbo_restriction_issue', initialConfidence: 0.25 },
+  ],
+
+  steps: [
+
+    // ── STEP 1: Symptom confirmation ────────────────────────────────────────
+    // First triage to steer scoring before any live data or tools are used.
+    // Limp mode or DPF warning is a strong early indicator; frequent short
+    // trips (preventing passive regen) points directly at soot accumulation.
+    {
+      id: 'symptom_confirm',
+      instruction:
+        'Ask the driver about recent symptoms before connecting any diagnostic tool.',
+      question: 'What is the primary complaint?',
+      options: [
+        {
+          label: 'DPF warning light on — limp mode active',
+          // Hard DPF fault or blocked filter forcing safe mode.
+          effect: { dpf_soot_overload_issue: STRONG, regeneration_failure_issue: MEDIUM },
+        },
+        {
+          label: 'Frequent regeneration cycles noticed (smell, heat, idle for long periods)',
+          // Passive regen not completing — short trips or faulty temp/pressure sensor.
+          effect: { regeneration_failure_issue: STRONG, dpf_soot_overload_issue: SLIGHT },
+        },
+        {
+          label: 'Poor acceleration / lack of power, no warning light',
+          // Possible partial restriction: heavy soot load or EGR stuck open
+          // recirculating excessive exhaust gas, diluting intake charge.
+          effect: { soot_related_turbo_restriction_issue: MEDIUM, egr_valve_issue: MEDIUM },
+        },
+        {
+          label: 'Black or grey smoke, rough idle, high fuel consumption',
+          // EGR stuck open deposits or DPF regeneration issues causing combustion problems.
+          effect: { egr_valve_issue: STRONG, dpf_soot_overload_issue: SLIGHT },
+        },
+      ],
+    },
+
+    // ── STEP 2: DPF / EGR-related DTCs ─────────────────────────────────────
+    // Fault codes are the most direct evidence. DPF pressure codes (P244x)
+    // point at the filter or differential pressure sensor. EGR codes (P040x,
+    // P040x) point at valve or actuator. Temperature codes (P040x, P242x)
+    // isolate sensor faults before condemning the filter.
+    {
+      id: 'dtc_check',
+      instruction:
+        'Connect the OBD2 adapter and read all stored and pending fault codes. Note any P244x (DPF pressure), P040x (EGR), P242x/P243x (DPF temperature), or P2002/P2003 (DPF efficiency) codes.',
+      question: 'What fault codes are present?',
+      options: [
+        {
+          label: 'P2002 / P2003 — DPF efficiency below threshold',
+          // Direct evidence of excessive soot load or failed filter substrate.
+          effect: { dpf_soot_overload_issue: HEAVY },
+        },
+        {
+          label: 'P2452 / P2453 / P2454 — DPF differential pressure sensor fault',
+          // Pressure sensor circuit or plausibility error — may falsely indicate
+          // soot overload or mask a real restriction.
+          effect: {
+            differential_pressure_sensor_issue: HEAVY,
+            dpf_soot_overload_issue: SLIGHT,
+          },
+        },
+        {
+          label: 'P0400 / P0401 / P0402 / P0404 — EGR flow or valve fault',
+          effect: { egr_valve_issue: HEAVY },
+        },
+        {
+          label: 'P242x / P243x — exhaust temperature sensor fault',
+          // Faulty temp sensor prevents ECU from knowing whether exhaust is hot
+          // enough for active regen — will cause repeated regen failures.
+          effect: {
+            exhaust_temperature_sensor_issue: HEAVY,
+            regeneration_failure_issue: MEDIUM,
+          },
+        },
+        {
+          label: 'Multiple codes from several categories above',
+          effect: {
+            dpf_soot_overload_issue: MEDIUM,
+            regeneration_failure_issue: MEDIUM,
+            egr_valve_issue: MEDIUM,
+          },
+        },
+        {
+          label: 'No DPF / EGR codes — other or no codes',
+          effect: {
+            differential_pressure_sensor_issue: SLIGHT,
+            exhaust_temperature_sensor_issue: SLIGHT,
+          },
+        },
+      ],
+    },
+
+    // ── STEP 3: Soot load and regeneration history ──────────────────────────
+    // Many scan tools can read DPF soot load (%) and distance/time since last
+    // successful regeneration via manufacturer-specific PIDs or live data.
+    // High soot load with no recent successful regen = regen failure.
+    {
+      id: 'soot_load_regen_history',
+      instruction:
+        'Using live data or manufacturer-specific diagnostics, read the DPF soot load percentage and the distance or time since the last successful regeneration (if supported by the scan tool).',
+      question: 'What does the soot load / regeneration data show?',
+      options: [
+        {
+          label: 'Soot load low (< 40 %) — recent successful regen confirmed',
+          effect: { dpf_soot_overload_issue: REDUCE, regeneration_failure_issue: REDUCE },
+        },
+        {
+          label: 'Soot load moderate (40–75 %) — regen overdue or incomplete',
+          effect: { regeneration_failure_issue: MEDIUM, dpf_soot_overload_issue: SLIGHT },
+        },
+        {
+          label: 'Soot load high (> 75 %) or regen counter not resetting',
+          // Filter critically loaded — active regen required or filter may be damaged.
+          effect: { dpf_soot_overload_issue: HEAVY, regeneration_failure_issue: STRONG },
+        },
+        {
+          label: 'Data not available on this scan tool',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 4: Differential pressure readings ──────────────────────────────
+    // The differential pressure sensor measures the pressure drop across the
+    // DPF. High pressure drop = high soot load or blocked filter. Low/zero
+    // pressure drop with DPF codes = sensor fault (blocked pipe or failed sensor).
+    {
+      id: 'differential_pressure',
+      instruction:
+        'Read the DPF differential pressure sensor live data at idle and at 2000 RPM. Typical clean filter: < 5 kPa at idle, < 15 kPa at 2000 RPM. Consult the manufacturer spec for the specific vehicle.',
+      question: 'What are the differential pressure readings?',
+      options: [
+        {
+          label: 'Within normal spec at idle and 2000 RPM',
+          effect: {
+            dpf_soot_overload_issue: REDUCE,
+            differential_pressure_sensor_issue: REDUCE,
+          },
+        },
+        {
+          label: 'Elevated — above spec, rises sharply with RPM',
+          // High restriction across the filter — soot overload or melted substrate.
+          effect: { dpf_soot_overload_issue: STRONG, soot_related_turbo_restriction_issue: MEDIUM },
+        },
+        {
+          label: 'Zero or flat across all RPM — no pressure differential',
+          // Sensor reading zero when filter must be loaded = sensor or pipe fault
+          // (blocked sample pipe, failed sensor, or wiring open circuit).
+          effect: {
+            differential_pressure_sensor_issue: HEAVY,
+            dpf_soot_overload_issue: SLIGHT,
+          },
+        },
+        {
+          label: 'Erratic or implausible — spikes / dropouts',
+          effect: { differential_pressure_sensor_issue: STRONG },
+        },
+        {
+          label: 'Not tested — live data not available',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 5: EGR valve operation ─────────────────────────────────────────
+    // Observe commanded vs actual EGR valve position in live data. On vehicles
+    // with vacuum-operated EGR, listen for the valve clicking open/closed.
+    // Black carbon around the EGR ports is normal — sticky/seized valve is not.
+    {
+      id: 'egr_valve_operation',
+      instruction:
+        'In live data, compare EGR commanded position vs actual position while blipping the throttle from idle to ~2000 RPM. Alternatively, physically inspect the valve for sticking or excessive carbon build-up.',
+      question: 'How is the EGR valve behaving?',
+      options: [
+        {
+          label: 'Tracks commanded position correctly — no lag',
+          effect: { egr_valve_issue: REDUCE },
+        },
+        {
+          label: 'Stuck open — actual position remains high at idle',
+          // EGR stuck open at idle = excessive exhaust gas recirculation,
+          // rough idle, black smoke, loss of power.
+          effect: { egr_valve_issue: HEAVY },
+        },
+        {
+          label: 'Stuck closed — actual position near zero regardless of command',
+          // EGR stuck closed = no recirculation, possible NOx DTC, but less
+          // likely to cause driveability symptoms than stuck open.
+          effect: { egr_valve_issue: STRONG },
+        },
+        {
+          label: 'Slow or sticky — lags command by more than 10–15 %',
+          effect: { egr_valve_issue: MEDIUM },
+        },
+        {
+          label: 'Not tested — EGR live data not available',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 6: Exhaust temperature sensor plausibility ─────────────────────
+    // The ECU uses exhaust temperature sensors (pre- and post-DPF) to manage
+    // active regeneration. If a sensor reads implausibly low (< 100 °C on a
+    // warm engine) or implausibly high when it should be cooling, the ECU may
+    // abort regen prematurely or never initiate it.
+    {
+      id: 'exhaust_temp_sensor',
+      instruction:
+        'Read exhaust temperature sensor live data (pre-DPF and post-DPF if available) with the engine at normal operating temperature. Compare values against ambient and coolant temperature for plausibility.',
+      question: 'What do the exhaust temperature sensor readings show?',
+      options: [
+        {
+          label: 'Plausible — pre-DPF > post-DPF, values rise with load',
+          effect: { exhaust_temperature_sensor_issue: REDUCE },
+        },
+        {
+          label: 'One sensor reads implausibly cold (near ambient when engine warm)',
+          // Open circuit or failed sensor — ECU may refuse regen if it cannot
+          // confirm safe exhaust temperature.
+          effect: {
+            exhaust_temperature_sensor_issue: HEAVY,
+            regeneration_failure_issue: MEDIUM,
+          },
+        },
+        {
+          label: 'Pre- and post-DPF sensors read the same value',
+          // Identical readings = one sensor likely shorted or cross-wired;
+          // no temperature drop visible across the filter.
+          effect: { exhaust_temperature_sensor_issue: STRONG },
+        },
+        {
+          label: 'Readings erratic or fluctuating at steady throttle',
+          effect: { exhaust_temperature_sensor_issue: MEDIUM },
+        },
+        {
+          label: 'Not tested — temperature PID not supported',
+          effect: {},
+        },
+      ],
+    },
+
+    // ── STEP 7: Forced regeneration / cleaning assessment ───────────────────
+    // The final step determines the most likely next action based on all
+    // accumulated evidence. This is not a pass/fail — it focuses the outcome
+    // on what is actionable: forced regen, sensor replacement, or valve cleaning.
+    {
+      id: 'forced_regen_assessment',
+      instruction:
+        'Attempt a forced / stationary regeneration via the scan tool (if supported and soot load permits — most tools will refuse if soot > 95 % due to fire risk). Observe whether regen initiates, completes, and whether exhaust temperatures reach 550–600 °C post-DPF.',
+      question: 'What happened during the forced regeneration attempt?',
+      options: [
+        {
+          label: 'Regen initiated and completed — post-DPF temp reached 550 °C+',
+          // Successful forced regen: filter was loaded but mechanically intact.
+          effect: {
+            dpf_soot_overload_issue: REDUCE,
+            regeneration_failure_issue: REDUCE,
+          },
+        },
+        {
+          label: 'Regen initiated but aborted before completion',
+          // ECU aborted regen: most likely a temperature sensor fault preventing
+          // confirmation of adequate exhaust temp, or soot load too high.
+          effect: {
+            regeneration_failure_issue: HEAVY,
+            exhaust_temperature_sensor_issue: MEDIUM,
+          },
+        },
+        {
+          label: 'Scan tool refused to start regen — soot load too high',
+          // Filter beyond safe regen threshold: physical removal and cleaning
+          // or replacement required.
+          effect: { dpf_soot_overload_issue: HEAVY, regeneration_failure_issue: STRONG },
+        },
+        {
+          label: 'Forced regen not supported on this vehicle / scan tool',
+          // Cannot confirm via forced regen — rely on earlier step scores.
+          effect: {},
+        },
+      ],
+    },
+
+  ],
+};

--- a/src/app/core/diagnostics/packs/index.ts
+++ b/src/app/core/diagnostics/packs/index.ts
@@ -5,3 +5,4 @@ export { lackOfPowerPack }         from './lack-of-power.pack';
 export { highFuelConsumptionPack } from './high-fuel-consumption.pack';
 export { overheatingPack }         from './overheating.pack';
 export { batteryChargingPack }     from './battery-charging.pack';
+export { dpfEgrPack }              from './dpf-egr.pack';


### PR DESCRIPTION
## Summary

- Adds `src/app/core/diagnostics/packs/dpf-egr.pack.ts` — 6-hypothesis, 7-step `KnowledgePack` for diesel DPF and EGR system diagnosis
- Exports via `packs/index.ts` barrel
- Adds `dpf-egr.pack.spec.ts` — three Jasmine scenario walkthroughs verified against `DiagnosticEngineService`

## Hypotheses

| ID | Root cause |
|----|-----------|
| `dpf_soot_overload_issue` | Filter critically loaded beyond passive/active regen capacity |
| `regeneration_failure_issue` | Regen cycle failing to initiate or complete |
| `egr_valve_issue` | EGR valve stuck open or closed, or sluggish response |
| `differential_pressure_sensor_issue` | Sensor/pipe fault giving false pressure readings |
| `exhaust_temperature_sensor_issue` | Pre/post-DPF temp sensor open circuit or implausible |
| `soot_related_turbo_restriction_issue` | Turbo intake restriction from accumulated soot |

## Workflow (7 steps)

| # | Step ID | Key evidence |
|---|---------|-------------|
| 1 | `symptom_confirm` | Triage presenting complaint |
| 2 | `dtc_check` | P2002/P2003 (DPF efficiency), P244x (pressure sensor), P040x (EGR), P242x (temp) |
| 3 | `soot_load_regen_history` | Soot load % and regen counter via live data |
| 4 | `differential_pressure` | Pre/post-DPF pressure delta at idle and 2000 RPM |
| 5 | `egr_valve_operation` | Commanded vs actual EGR position in live data |
| 6 | `exhaust_temp_sensor` | Pre/post-DPF temperature plausibility check |
| 7 | `forced_regen_assessment` | Stationary forced regen attempt and outcome |

## Example state progressions (from spec)

**Scenario A — DPF soot overload**
Limp mode → P2002 → soot > 75% → elevated pressure → regen refused by tool
`dpf_soot_overload_issue`: 0.25 + 0.35 + 0.40 + 0.40 + 0.35 + 0.40 = **2.15** ← winner

**Scenario B — Differential pressure sensor fault**
Frequent regens → P2453 → zero pressure reading → regen aborts
`differential_pressure_sensor_issue`: 0.25 + 0.40 + 0.40 = **1.05** ← winner

**Scenario C — EGR valve stuck open**
Black smoke → P0401 → normal DPF pressure → EGR stuck open → regen completes
`egr_valve_issue`: 0.25 + 0.35 + 0.40 + 0.40 = **1.40** ← winner

## Verification

`npm run build` — bundle generation complete, no errors.