### PR TITLE
fix(diagnostics): address Codex P2 comments on dpf-egr and battery-charging packs

### DIFF
--- a/src/app/core/diagnostics/packs/battery-charging.pack.ts
+++ b/src/app/core/diagnostics/packs/battery-charging.pack.ts
@@ -100,16 +100,19 @@ export const batteryChargingPack: KnowledgePack = {
       question: 'What does the voltmeter read with the engine running?',
       options: [
         {
-          label: '13.8–14.7 V — normal charging',
+          label: '13.8–14.7 V — normal charging range',
           effect: { alternator_issue: REDUCE, drive_belt_issue: REDUCE },
         },
         {
-          label: '13.5 V or below — undercharging',
+          label: 'Below 13.8 V but engine running — undercharging',
+          // Covers any reading under 13.8 V with engine on, including the
+          // 13.5–13.7 V borderline zone. Worn brushes, slipping belt, or
+          // failed diode pack.
           effect: { alternator_issue: STRONG, drive_belt_issue: MEDIUM },
         },
         {
-          label: '15.0 V or above — overcharging',
-          // High voltage = failed voltage regulator inside alternator.
+          label: 'Above 14.7 V — overcharging',
+          // Covers readings from 14.8 V upward. Failed voltage regulator.
           effect: { alternator_issue: HEAVY },
         },
         {
@@ -194,11 +197,11 @@ export const batteryChargingPack: KnowledgePack = {
       question: 'What is the lowest voltage seen during cranking?',
       options: [
         {
-          label: '10.0 V or above — acceptable drop',
+          label: 'Above 10.0 V — acceptable drop',
           effect: { battery_failure_issue: REDUCE, starter_draw_issue: REDUCE },
         },
         {
-          label: '9.6–10.0 V — borderline',
+          label: '9.6–10.0 V inclusive — borderline',
           effect: { battery_failure_issue: SLIGHT, starter_draw_issue: SLIGHT },
         },
         {

--- a/src/app/core/diagnostics/packs/dpf-egr.pack.ts
+++ b/src/app/core/diagnostics/packs/dpf-egr.pack.ts
@@ -90,9 +90,11 @@ export const dpfEgrPack: KnowledgePack = {
           effect: { egr_valve_issue: HEAVY },
         },
         {
-          label: 'P242x / P243x — exhaust temperature sensor fault',
-          // Faulty temp sensor prevents ECU from knowing whether exhaust is hot
-          // enough for active regen — will cause repeated regen failures.
+          label: 'P242x — exhaust temperature sensor fault',
+          // P242x codes (e.g. P2420, P2422) are DPF/exhaust temperature sensor
+          // faults. P243x is the secondary air injection family — do not include
+          // here. Faulty temp sensor prevents ECU from confirming safe regen temp,
+          // causing repeated regen failures.
           effect: {
             exhaust_temperature_sensor_issue: HEAVY,
             regeneration_failure_issue: MEDIUM,


### PR DESCRIPTION
## Summary

Three Codex P2 fixes across two pack files. No behaviour changes — label and boundary corrections only.

## Changes

### `dpf-egr.pack.ts` — P243x removed from exhaust temp DTC option (PR #188 comment)

`P243x` codes belong to the **secondary air injection pressure/flow sensor** family in generic OBD-II, not DPF temperature sensing. Including them in the exhaust temperature option incorrectly boosted `exhaust_temperature_sensor_issue` and `regeneration_failure_issue` whenever a vehicle reported a P243x code. Label now reads `P242x` only.

### `battery-charging.pack.ts` — charging voltage brackets made exhaustive (PR #187 comment, line 107)

Previous options used hard cut-offs of `13.5 V` and `15.0 V`, leaving readings like 13.6 V or 14.8 V in a gap between options. Replaced with open-ended labels:
- `Below 13.8 V but engine running — undercharging` (was: `13.5 V or below`)
- `Above 14.7 V — overcharging` (was: `15.0 V or above`)

Every real-world measurement now falls into exactly one option.

### `battery-charging.pack.ts` — 10.0 V overlap removed in cranking drop (PR #187 comment, line 201)

`"10.0 V or above"` and `"9.6–10.0 V"` both matched a reading of exactly 10.0 V, applying opposite score directions (`REDUCE` vs `SLIGHT`). Fixed:
- `"Above 10.0 V — acceptable drop"` (exclusive lower bound)
- `"9.6–10.0 V inclusive — borderline"` (explicit inclusive upper bound)

## Verification

`npm run build` — bundle generation complete, no errors.