### PR TITLE
chore: milestone 2 extended diagnostic pack code quality review

### DIFF
--- a/src/app/core/ai/ai-response-validator.service.ts
+++ b/src/app/core/ai/ai-response-validator.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { AiConfidenceLevel, AiDiagnosisResponse } from './ai-diagnosis.models';
+import type { AiConfidenceLevel, AiDiagnosisResponse } from './ai-diagnosis.models';
 
 @Injectable({ providedIn: 'root' })
 export class AiResponseValidatorService {

--- a/src/app/core/diagnostics/packs/no-start.pack.spec.ts
+++ b/src/app/core/diagnostics/packs/no-start.pack.spec.ts
@@ -6,12 +6,7 @@ import { noStartPack } from './no-start.pack';
 /**
  * No-Start Pack — scenario walkthroughs
  *
- * Each scenario simulates a mechanic answering every step and verifies:
- *   - hypothesis score ordering matches the expected root cause
- *   - the pack completes (currentStepId === '')
- *   - answer history length matches steps taken
- *
- * Score arithmetic — initial: 0.25 each, deltas additive:
+ * Score constants (initial: 0.25 each, additive):
  *   HEAVY=0.40  STRONG=0.35  MEDIUM=0.20  SLIGHT=0.15  REDUCE=-0.20
  */
 


### PR DESCRIPTION
## Summary

Milestone 2 review of the extended diagnostic pack library (10 packs) and surrounding platform code. The codebase was in substantially better shape than prior milestones — the bulk of consistency work (shared `pack-scoring.ts`, `import type`, `allDiagnosticPacks` array, spec comment alignment) was already applied by the linter/pre-commit tooling. This PR captures the two remaining items that required manual attention.

## Areas reviewed

| Area | Outcome |
|------|---------|
| All 9 packs (`packs/*.pack.ts`) | ✅ All use `import type`, `pack-scoring` constants, correct `initialConfidence` per hypothesis count |
| `packs/index.ts` | ✅ All packs exported; `allDiagnosticPacks` typed array present |
| `pack-scoring.ts` | ✅ Shared delta constants and per-count initial confidence constants |
| All 4 pack specs | ✅ `import type DiagnosticState`, score comments match actual initial values |
| `core/ai/*.ts` | ✅ Imports clean; `AiInsightStatus` union covers all emitted statuses; confidence normalisation correct |
| `functions/src/index.ts` | ✅ `firebase-admin`/`db` actively used for DTC lookup — not dead code |
| Routing (`app.routes.ts`) | ✅ All routes resolve to existing components; legacy routes preserved |
| `diagnostic-engine.service.ts` | ✅ `applyAnswer` next-step bounds check correct; no unused methods |

## Changes made

### `src/app/core/ai/ai-response-validator.service.ts`
- Changed `import { AiConfidenceLevel, AiDiagnosisResponse }` → `import type { ... }`. Both are used only as type annotations; aligns with `import type` convention used across the entire `core/ai/` layer.

### `src/app/core/diagnostics/packs/no-start.pack.spec.ts`
- Aligned the file's doc-comment format to match the three other pack specs (condensed to a single "Score constants" line; removed verbose bullet-point block that was inconsistent with the rest).

## Dead code removed

None found. The `firebase-admin` import and `db` constant in `functions/src/index.ts` are actively used by the `lookupDtc` Cloud Function's Firestore read/write path.

## Build results

- `npm run build` (Angular): ✅ Bundle generation complete
- `cd functions && npm run build`: ✅ TypeScript compiled cleanly
- `npx tsc -p tsconfig.app.json --noEmit`: ✅ Zero errors

## Follow-up recommendations

1. **Bundle budget**: Initial bundle is ~4.7 kB over the 550 kB budget (pre-existing on main). Consider lazy-loading the `allDiagnosticPacks` array only where needed, or raising the budget in `angular.json` if the current size is acceptable.
2. **`SIX_HYPOTHESIS_INITIAL_CONFIDENCE` precision**: The constant is `0.17` (truncated from `1/6 ≈ 0.1667`). Not a bug, but documenting the rounding decision in `pack-scoring.ts` would prevent future confusion.
3. **Spec coverage gaps**: `misfire`, `rough-idle`, `lack-of-power`, `high-fuel-consumption`, and `overheating` packs have no spec files. Adding scenario walkthroughs would bring them to parity with the newer packs.