### PR TITLE
feat(cat-test): live O2 sensor voltage graph + AI DTC learning database

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -16,6 +16,7 @@ export const routes: Routes = [
   // ── Diagnosis Assistant (unified hub) ─────────────────────────────────────
   {
     path: 'diagnosis-assistant',
+    providers: [provideCharts(withDefaultRegisterables())],
     loadComponent: () => import('./features/diagnosis-assistant/diagnosis-assistant-page.component')
       .then(m => m.DiagnosisAssistantPageComponent)
   },

--- a/src/app/core/adapters/obd-pid-parser.service.ts
+++ b/src/app/core/adapters/obd-pid-parser.service.ts
@@ -31,6 +31,10 @@ export class ObdPidParserService {
       case '010F': return this.parseIntakeAirTemp(bytes);
       case '0110': return this.parseMaf(bytes);
       case '0111': return this.parseThrottlePosition(bytes);
+      case '0114':
+      case '0115':
+      case '0116':
+      case '0117': return this.parseO2Voltage(bytes);
       default:     return null;
     }
   }
@@ -134,5 +138,11 @@ export class ObdPidParserService {
     if (bytes.length < 2) return null;
     const [A, B] = bytes;
     return SignalValidator.clamp(((A * 256) + B) / 100, 0, 655);
+  }
+
+  /** 0114–0117 - Narrow-band O2 sensor voltage: A × 0.005 V (0–1.275 V) */
+  private parseO2Voltage(bytes: number[]): number | null {
+    if (bytes.length < 1) return null;
+    return SignalValidator.clamp(bytes[0] * 0.005, 0, 1.275);
   }
 }

--- a/src/app/core/adapters/simulator-obd-adapter.service.ts
+++ b/src/app/core/adapters/simulator-obd-adapter.service.ts
@@ -100,6 +100,23 @@ export class SimulatorObdAdapterService implements ObdAdapter {
                    : rand < 0.08 ? rpm + 700 + Math.random() * 300
                    : rpm;
 
+    // O2 sensors — only active once the engine is at operating temperature.
+    // Upstream (S1B1): switches at ~1 Hz between lean (~0.1 V) and rich (~0.9 V).
+    // Downstream (S2B1): stable at ~0.65 V (healthy catalyst damping upstream swings).
+    // Bank 2 is intentionally omitted to exercise the "no data" fallback path.
+    const warm = coolant >= 60;
+    const o2S1B1 = warm
+      ? parseFloat(Math.max(0, Math.min(1.275,
+          0.45 + 0.40 * Math.sin(2 * Math.PI * this.frameIndex / 5) +
+          (Math.random() * 0.04 - 0.02),
+        )).toFixed(3))
+      : undefined;
+    const o2S2B1 = warm
+      ? parseFloat(Math.max(0, Math.min(1.275,
+          0.65 + (Math.random() * 0.04 - 0.02),
+        )).toFixed(3))
+      : undefined;
+
     const frame: ObdLiveFrame = {
       timestamp:        Date.now(),
       rpm:              Math.max(0, Math.round(finalRpm)),
@@ -111,6 +128,7 @@ export class SimulatorObdAdapterService implements ObdAdapter {
       ltftB1:           parseFloat(ltft.toFixed(2)),
       maf,
       throttlePosition: Math.min(100, 8 + (finalRpm / 4000) * 55 + Math.random() * 5),
+      ...(o2S1B1 !== undefined ? { o2S1B1, o2S2B1 } : {}),
     };
 
     this.dataSubject.next(frame);

--- a/src/app/core/adapters/web-bluetooth-elm327-adapter.service.ts
+++ b/src/app/core/adapters/web-bluetooth-elm327-adapter.service.ts
@@ -77,8 +77,12 @@ const INIT_COMMANDS = ['ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH0', 'ATSP0'] as const;
  * 0111 — Throttle position  (A×100)/255 (%)
  * 010F — Intake Air Temp    A−40 (°C)
  * 0110 — MAF                ((A×256)+B)/100 (g/s)
+ * 0114 — O2 S1B1 voltage    A×0.005 (V)
+ * 0115 — O2 S2B1 voltage    A×0.005 (V)
+ * 0116 — O2 S1B2 voltage    A×0.005 (V)
+ * 0117 — O2 S2B2 voltage    A×0.005 (V)
  */
-const POLL_PIDS = ['010C', '010D', '0105', '0104', '0106', '0107', '0111', '010F', '0110'] as const;
+const POLL_PIDS = ['010C', '010D', '0105', '0104', '0106', '0107', '0111', '010F', '0110', '0114', '0115', '0116', '0117'] as const;
 
 /** Pause between poll cycles (ms). Prevents flooding the BLE link. */
 const POLL_INTERVAL_MS = 200;
@@ -392,15 +396,19 @@ export class WebBluetoothElm327AdapterService implements ObdAdapter, OnDestroy {
   /** Write a parsed value into the current frame accumulator. */
   private applyPidValue(pid: string, value: number): void {
     switch (pid) {
-      case '010C': this.currentFrame.rpm         = value; break;
-      case '010D': this.currentFrame.speed       = value; break;
-      case '0105': this.currentFrame.coolantTemp = value; break;
-      case '0104': this.currentFrame.engineLoad  = value; break;
-      case '0106': this.currentFrame.stftB1            = value; break;
-      case '0107': this.currentFrame.ltftB1            = value; break;
-      case '0111': this.currentFrame.throttlePosition  = value; break;
-      case '010F': this.currentFrame.intakeAirTemp     = value; break;
-      case '0110': this.currentFrame.maf               = value; break;
+      case '010C': this.currentFrame.rpm              = value; break;
+      case '010D': this.currentFrame.speed            = value; break;
+      case '0105': this.currentFrame.coolantTemp      = value; break;
+      case '0104': this.currentFrame.engineLoad       = value; break;
+      case '0106': this.currentFrame.stftB1           = value; break;
+      case '0107': this.currentFrame.ltftB1           = value; break;
+      case '0111': this.currentFrame.throttlePosition = value; break;
+      case '010F': this.currentFrame.intakeAirTemp    = value; break;
+      case '0110': this.currentFrame.maf              = value; break;
+      case '0114': this.currentFrame.o2S1B1           = value; break;
+      case '0115': this.currentFrame.o2S2B1           = value; break;
+      case '0116': this.currentFrame.o2S1B2           = value; break;
+      case '0117': this.currentFrame.o2S2B2           = value; break;
     }
   }
 

--- a/src/app/core/diagnostics/o2-sensor-buffer.service.ts
+++ b/src/app/core/diagnostics/o2-sensor-buffer.service.ts
@@ -1,0 +1,202 @@
+import { Injectable, OnDestroy, inject } from '@angular/core';
+import { BehaviorSubject, Subscription } from 'rxjs';
+import { AdapterSwitcherService } from '../adapters/adapter-switcher.service';
+import { ObdLiveFrame } from '../models/obd-live-frame.model';
+import type { CatalyticConverterInput } from './catalytic-converter-analysis.service';
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export interface O2Frame {
+  timestamp: number;
+  upstream: number | null;
+  downstream: number | null;
+}
+
+export interface O2BankAnalytics {
+  upstreamSwitchingHz: number;
+  downstreamSwitchingHz: number;
+  crossCorrelation: number;
+  downstreamIsStable: boolean;
+  upstreamMean: number;
+  downstreamMean: number;
+  hasData: boolean;
+}
+
+export interface O2SensorBufferState {
+  bank1Frames: O2Frame[];
+  bank2Frames: O2Frame[];
+  bank1Analytics: O2BankAnalytics;
+  bank2Analytics: O2BankAnalytics;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** 60 s at 5 Hz (200 ms/frame) */
+const BUFFER_SIZE = 300;
+
+/** Recompute analytics every N frames to avoid per-frame overhead. */
+const ANALYTICS_INTERVAL = 5;
+
+/** O2 midpoint voltage — used for switching-frequency detection. */
+const SWITCH_THRESHOLD_V = 0.45;
+
+/** Downstream is "stable" when its std dev is below this level. */
+const STABLE_STD_DEV_V = 0.08;
+
+export const NO_ANALYTICS: O2BankAnalytics = {
+  upstreamSwitchingHz: 0,
+  downstreamSwitchingHz: 0,
+  crossCorrelation: 0,
+  downstreamIsStable: false,
+  upstreamMean: 0,
+  downstreamMean: 0,
+  hasData: false,
+};
+
+// ── Pure analytics functions ──────────────────────────────────────────────────
+
+function switchingHz(voltages: number[], durationSeconds: number): number {
+  if (voltages.length < 2 || durationSeconds <= 0) return 0;
+  let crossings = 0;
+  let above = voltages[0] > SWITCH_THRESHOLD_V;
+  for (let i = 1; i < voltages.length; i++) {
+    const nowAbove = voltages[i] > SWITCH_THRESHOLD_V;
+    if (nowAbove !== above) { crossings++; above = nowAbove; }
+  }
+  return crossings / durationSeconds;
+}
+
+function pearsonCorrelation(xs: number[], ys: number[]): number {
+  const n = xs.length;
+  if (n < 2) return 0;
+  let sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0, sumY2 = 0;
+  for (let i = 0; i < n; i++) {
+    sumX += xs[i]; sumY += ys[i];
+    sumXY += xs[i] * ys[i];
+    sumX2 += xs[i] * xs[i];
+    sumY2 += ys[i] * ys[i];
+  }
+  const num = n * sumXY - sumX * sumY;
+  const den = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
+  return den === 0 ? 0 : Math.abs(num / den);
+}
+
+function stdDev(values: number[]): number {
+  if (values.length < 2) return 0;
+  const mean = values.reduce((s, v) => s + v, 0) / values.length;
+  const variance = values.reduce((s, v) => s + (v - mean) ** 2, 0) / values.length;
+  return Math.sqrt(variance);
+}
+
+function mean(values: number[]): number {
+  return values.length ? values.reduce((s, v) => s + v, 0) / values.length : 0;
+}
+
+function computeAnalytics(frames: O2Frame[]): O2BankAnalytics {
+  const upVoltages  = frames.filter(f => f.upstream   !== null).map(f => f.upstream   as number);
+  const downVoltages = frames.filter(f => f.downstream !== null).map(f => f.downstream as number);
+
+  if (upVoltages.length < 5 && downVoltages.length < 5) return NO_ANALYTICS;
+
+  const pairedFrames = frames.filter(f => f.upstream !== null && f.downstream !== null);
+  const upPaired   = pairedFrames.map(f => f.upstream   as number);
+  const downPaired = pairedFrames.map(f => f.downstream as number);
+
+  const durationSec = frames.length * 0.2;
+  const downMeanVolt = mean(downVoltages);
+  const downStd = stdDev(downVoltages);
+  const downstreamIsStable =
+    downVoltages.length >= 5 &&
+    downMeanVolt >= 0.45 && downMeanVolt <= 0.95 &&
+    downStd < STABLE_STD_DEV_V;
+
+  return {
+    upstreamSwitchingHz:   switchingHz(upVoltages,   durationSec),
+    downstreamSwitchingHz: switchingHz(downVoltages, durationSec),
+    crossCorrelation: upPaired.length >= 5 ? pearsonCorrelation(upPaired, downPaired) : 0,
+    downstreamIsStable,
+    upstreamMean:   mean(upVoltages),
+    downstreamMean: downMeanVolt,
+    hasData: true,
+  };
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+@Injectable({ providedIn: 'root' })
+export class O2SensorBufferService implements OnDestroy {
+  private readonly adapter = inject(AdapterSwitcherService);
+  private readonly sub: Subscription;
+
+  private bank1Frames: O2Frame[] = [];
+  private bank2Frames: O2Frame[] = [];
+  private framesSinceAnalytics = 0;
+
+  readonly state$ = new BehaviorSubject<O2SensorBufferState>({
+    bank1Frames: [],
+    bank2Frames: [],
+    bank1Analytics: NO_ANALYTICS,
+    bank2Analytics: NO_ANALYTICS,
+  });
+
+  constructor() {
+    this.sub = this.adapter.data$.subscribe(frame => this.onFrame(frame));
+  }
+
+  ngOnDestroy(): void {
+    this.sub.unsubscribe();
+  }
+
+  /** Build the o2Sensors input for CatalyticConverterAnalysisService from the given bank. */
+  buildCatalyticO2Input(bank: 1 | 2): CatalyticConverterInput['o2Sensors'] {
+    const state = this.state$.getValue();
+    const analytics = bank === 1 ? state.bank1Analytics : state.bank2Analytics;
+    if (!analytics.hasData) return undefined;
+    return {
+      upstream:           { switchingHz: analytics.upstreamSwitchingHz },
+      downstream:         { switchingHz: analytics.downstreamSwitchingHz },
+      crossCorrelation:   analytics.crossCorrelation,
+      downstreamIsStable: analytics.downstreamIsStable,
+    };
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────────
+
+  private onFrame(frame: ObdLiveFrame): void {
+    let changed = false;
+
+    if (frame.o2S1B1 !== undefined || frame.o2S2B1 !== undefined) {
+      this.bank1Frames.push({
+        timestamp:  frame.timestamp,
+        upstream:   frame.o2S1B1   ?? null,
+        downstream: frame.o2S2B1   ?? null,
+      });
+      if (this.bank1Frames.length > BUFFER_SIZE) this.bank1Frames.shift();
+      changed = true;
+    }
+
+    if (frame.o2S1B2 !== undefined || frame.o2S2B2 !== undefined) {
+      this.bank2Frames.push({
+        timestamp:  frame.timestamp,
+        upstream:   frame.o2S1B2   ?? null,
+        downstream: frame.o2S2B2   ?? null,
+      });
+      if (this.bank2Frames.length > BUFFER_SIZE) this.bank2Frames.shift();
+      changed = true;
+    }
+
+    if (!changed) return;
+
+    this.framesSinceAnalytics++;
+    const recompute = this.framesSinceAnalytics >= ANALYTICS_INTERVAL;
+    if (recompute) this.framesSinceAnalytics = 0;
+
+    const prev = this.state$.getValue();
+    this.state$.next({
+      bank1Frames: this.bank1Frames,
+      bank2Frames: this.bank2Frames,
+      bank1Analytics: recompute ? computeAnalytics(this.bank1Frames) : prev.bank1Analytics,
+      bank2Analytics: recompute ? computeAnalytics(this.bank2Frames) : prev.bank2Analytics,
+    });
+  }
+}

--- a/src/app/core/models/obd-live-frame.model.ts
+++ b/src/app/core/models/obd-live-frame.model.ts
@@ -40,4 +40,13 @@ export interface ObdLiveFrame {
   
   /** Signal strength or packet success rate (optional) */
   connectionQuality?: number;
+
+  /** O2 Sensor 1 Bank 1 — upstream pre-catalyst voltage in V (0–1.275) */
+  o2S1B1?: number;
+  /** O2 Sensor 2 Bank 1 — downstream post-catalyst voltage in V (0–1.275) */
+  o2S2B1?: number;
+  /** O2 Sensor 1 Bank 2 — upstream pre-catalyst voltage in V (0–1.275) */
+  o2S1B2?: number;
+  /** O2 Sensor 2 Bank 2 — downstream post-catalyst voltage in V (0–1.275) */
+  o2S2B2?: number;
 }

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
@@ -155,6 +155,12 @@
         </div>
       </div>
 
+      <!-- Live O2 Sensor Graph -->
+      <div class="cat-section">
+        <h4 class="cat-section-label">Live O2 Sensor Voltage</h4>
+        <app-o2-sensor-graph></app-o2-sensor-graph>
+      </div>
+
       <!-- Evidence -->
       <div class="cat-section" *ngIf="result.evidence.length > 0">
         <h4 class="cat-section-label">Evidence</h4>

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
@@ -1,17 +1,20 @@
 import { Component, inject } from '@angular/core';
 import { AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe } from '@angular/common';
 import { Router } from '@angular/router';
-import { Observable, map } from 'rxjs';
+import { Observable, combineLatest } from 'rxjs';
+import { map, throttleTime } from 'rxjs/operators';
 import { DeepDiagnosisService } from '../../core/diagnostics/deep-diagnosis.service';
 import { CylinderAnalysisService } from '../../core/diagnostics/cylinder-analysis.service';
 import type { CylinderAnalysisResult } from '../../core/diagnostics/cylinder-analysis.service';
 import { CatalyticConverterAnalysisService } from '../../core/diagnostics/catalytic-converter-analysis.service';
 import type { CatalyticConverterResult } from '../../core/diagnostics/catalytic-converter-analysis.service';
+import { O2SensorBufferService } from '../../core/diagnostics/o2-sensor-buffer.service';
+import { O2SensorGraphComponent } from '../../shared/components/o2-sensor-graph/o2-sensor-graph.component';
 
 @Component({
   selector: 'app-diagnosis-assistant-page',
   standalone: true,
-  imports: [AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe],
+  imports: [AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe, O2SensorGraphComponent],
   templateUrl: './diagnosis-assistant-page.component.html',
   styleUrls: ['./diagnosis-assistant-page.component.scss'],
 })
@@ -20,6 +23,7 @@ export class DiagnosisAssistantPageComponent {
   private deepDiagnosis       = inject(DeepDiagnosisService);
   private cylinderAnalysis    = inject(CylinderAnalysisService);
   private catalyticAnalysis   = inject(CatalyticConverterAnalysisService);
+  private o2Buffer            = inject(O2SensorBufferService);
 
   /** Live cylinder analysis derived from the current session's DTCs. */
   readonly cylinderResult$: Observable<CylinderAnalysisResult> =
@@ -27,11 +31,21 @@ export class DiagnosisAssistantPageComponent {
       map(state => this.cylinderAnalysis.analyse(state.dtcCodes ?? []))
     );
 
-  /** Catalytic converter analysis derived from the current session's DTCs. */
-  readonly catalyticResult$: Observable<CatalyticConverterResult> =
-    this.deepDiagnosis.state$.pipe(
-      map(state => this.catalyticAnalysis.analyse({ dtcCodes: state.dtcCodes ?? [] }))
-    );
+  /**
+   * Catalytic converter analysis combining DTC codes with live O2 sensor data
+   * from the rolling 60-second buffer (Bank 1). Throttled to 500 ms to avoid
+   * excessive re-renders at 5 Hz frame rate.
+   */
+  readonly catalyticResult$: Observable<CatalyticConverterResult> = combineLatest([
+    this.deepDiagnosis.state$,
+    this.o2Buffer.state$,
+  ]).pipe(
+    throttleTime(500, undefined, { leading: true, trailing: true }),
+    map(([diagState]) => this.catalyticAnalysis.analyse({
+      dtcCodes:  diagState.dtcCodes ?? [],
+      o2Sensors: this.o2Buffer.buildCatalyticO2Input(1),
+    })),
+  );
 
   showCylinderPanel  = false;
   showCatalyticPanel = false;

--- a/src/app/shared/components/o2-sensor-graph/o2-sensor-graph.component.html
+++ b/src/app/shared/components/o2-sensor-graph/o2-sensor-graph.component.html
@@ -1,0 +1,70 @@
+<div class="o2-graph">
+
+  <!-- Bank selector -->
+  <div class="o2-graph__bank-tabs">
+    <button class="o2-bank-tab"
+            [class.o2-bank-tab--active]="selectedBank === 1"
+            (click)="selectBank(1)">
+      Bank 1 (S1B1 / S2B1)
+    </button>
+    <button class="o2-bank-tab"
+            [class.o2-bank-tab--active]="selectedBank === 2"
+            (click)="selectBank(2)">
+      Bank 2 (S1B2 / S2B2)
+    </button>
+  </div>
+
+  <!-- Status bar -->
+  <div class="o2-graph__status-bar">
+    <span class="o2-status-badge" [ngClass]="statusClass">{{ statusLabel }}</span>
+    <div class="o2-metrics" *ngIf="hasData">
+      <span class="o2-metric">
+        <span class="o2-metric__label">Upstream</span>
+        <span class="o2-metric__value o2-metric__value--upstream">{{ upstreamHz }} Hz</span>
+      </span>
+      <span class="o2-metric">
+        <span class="o2-metric__label">Downstream</span>
+        <span class="o2-metric__value o2-metric__value--downstream">{{ downstreamHz }} Hz</span>
+      </span>
+      <span class="o2-metric">
+        <span class="o2-metric__label">Correlation</span>
+        <span class="o2-metric__value">{{ correlationPct }}%</span>
+      </span>
+      <span class="o2-metric">
+        <span class="o2-metric__label">↑ Mean V</span>
+        <span class="o2-metric__value o2-metric__value--upstream">{{ upstreamMeanV }} V</span>
+      </span>
+      <span class="o2-metric">
+        <span class="o2-metric__label">↓ Mean V</span>
+        <span class="o2-metric__value o2-metric__value--downstream">{{ downstreamMeanV }} V</span>
+      </span>
+    </div>
+  </div>
+
+  <!-- Live chart -->
+  <div class="o2-graph__chart-wrap" *ngIf="hasData; else noData">
+    <canvas baseChart #o2Chart="base-chart"
+            [data]="chartData"
+            [options]="chartOptions"
+            type="line">
+    </canvas>
+    <span class="o2-graph__time-label">← Last 30 s</span>
+  </div>
+
+  <!-- No-data fallback -->
+  <ng-template #noData>
+    <div class="o2-graph__no-data">
+      <span class="o2-graph__no-data-icon">〜</span>
+      <div>
+        <p class="o2-graph__no-data-title">
+          No O2 sensor data for Bank {{ selectedBank }}
+        </p>
+        <p class="o2-graph__no-data-body">
+          O2 voltage readings begin once the engine reaches operating temperature (~60 °C).
+          Bank 2 is only present on V-configuration or flat-six engines.
+        </p>
+      </div>
+    </div>
+  </ng-template>
+
+</div>

--- a/src/app/shared/components/o2-sensor-graph/o2-sensor-graph.component.scss
+++ b/src/app/shared/components/o2-sensor-graph/o2-sensor-graph.component.scss
@@ -1,0 +1,157 @@
+@use '../../../../styles/variables' as *;
+
+$color-upstream:   #4caf50;
+$color-downstream: #9c27b0;
+
+.o2-graph {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-md;
+}
+
+// ── Bank tabs ─────────────────────────────────────────────────────────────────
+
+.o2-graph__bank-tabs {
+  display: flex;
+  gap: $spacing-xs;
+}
+
+.o2-bank-tab {
+  padding: 5px $spacing-md;
+  border-radius: $radius-full;
+  border: 1px solid $border-color;
+  background: $bg-tertiary;
+  color: $text-muted;
+  font-family: $font-family;
+  font-size: $font-size-body-sm;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+
+  &--active {
+    background: rgba(156, 39, 176, 0.18);
+    border-color: rgba(156, 39, 176, 0.45);
+    color: $color-downstream;
+  }
+
+  &:not(.o2-bank-tab--active):hover {
+    border-color: $border-light;
+    color: $text-secondary;
+  }
+}
+
+// ── Status bar ────────────────────────────────────────────────────────────────
+
+.o2-graph__status-bar {
+  display: flex;
+  align-items: center;
+  gap: $spacing-md;
+  flex-wrap: wrap;
+}
+
+.o2-status-badge {
+  font-size: $font-size-label-sm;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  padding: 2px 9px;
+  border-radius: $radius-full;
+  white-space: nowrap;
+
+  &.o2-status--normal   { background: rgba(76, 175, 80, 0.18); color: $color-success;  border: 1px solid rgba(76, 175, 80, 0.3);  }
+  &.o2-status--warning  { background: rgba(255, 152, 0, 0.18); color: $color-warning;  border: 1px solid rgba(255, 152, 0, 0.3);  }
+  &.o2-status--critical { background: rgba(244, 67, 54, 0.18); color: $color-critical; border: 1px solid rgba(244, 67, 54, 0.3);  }
+  &.o2-status--muted    { background: rgba(142, 145, 149, 0.12); color: $text-muted;   border: 1px solid $border-color;             }
+}
+
+// ── Metrics strip ─────────────────────────────────────────────────────────────
+
+.o2-metrics {
+  display: flex;
+  gap: $spacing-lg;
+  flex-wrap: wrap;
+}
+
+.o2-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.o2-metric__label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: $text-muted;
+}
+
+.o2-metric__value {
+  font-size: $font-size-body-sm;
+  font-weight: 600;
+  color: $text-secondary;
+  font-variant-numeric: tabular-nums;
+
+  &--upstream   { color: $color-upstream;   }
+  &--downstream { color: $color-downstream; }
+}
+
+// ── Chart ─────────────────────────────────────────────────────────────────────
+
+.o2-graph__chart-wrap {
+  position: relative;
+  height: 200px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: $radius-md;
+  border: 1px solid $border-color;
+  overflow: hidden;
+  padding: $spacing-sm 0 0;
+
+  canvas {
+    width: 100% !important;
+    height: 100% !important;
+  }
+}
+
+.o2-graph__time-label {
+  position: absolute;
+  bottom: 6px;
+  right: $spacing-sm;
+  font-size: 9px;
+  color: $text-muted;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+// ── No-data state ─────────────────────────────────────────────────────────────
+
+.o2-graph__no-data {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-md;
+  padding: $spacing-md;
+  background: rgba(142, 145, 149, 0.06);
+  border: 1px dashed $border-color;
+  border-radius: $radius-md;
+}
+
+.o2-graph__no-data-icon {
+  font-size: 22px;
+  color: $text-muted;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.o2-graph__no-data-title {
+  margin: 0 0 4px;
+  font-size: $font-size-body-md;
+  font-weight: 600;
+  color: $text-secondary;
+}
+
+.o2-graph__no-data-body {
+  margin: 0;
+  font-size: $font-size-body-sm;
+  color: $text-muted;
+  line-height: 1.6;
+}

--- a/src/app/shared/components/o2-sensor-graph/o2-sensor-graph.component.ts
+++ b/src/app/shared/components/o2-sensor-graph/o2-sensor-graph.component.ts
@@ -1,0 +1,208 @@
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  ViewChild,
+  inject,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+} from '@angular/core';
+import { NgIf, NgClass } from '@angular/common';
+import { ChartData, ChartOptions } from 'chart.js';
+import { BaseChartDirective } from 'ng2-charts';
+import { Subscription, throttleTime } from 'rxjs';
+import {
+  O2SensorBufferService,
+  O2SensorBufferState,
+  O2BankAnalytics,
+  NO_ANALYTICS,
+} from '../../../core/diagnostics/o2-sensor-buffer.service';
+
+/** Number of frames shown on the chart (30 s at 5 Hz). */
+const CHART_WINDOW = 150;
+
+/** Status derived from live analytics. */
+type O2Status = 'normal' | 'mildly_degraded' | 'severely_degraded' | 'monitoring' | 'no_data';
+
+function deriveStatus(a: O2BankAnalytics): O2Status {
+  if (!a.hasData) return 'no_data';
+  if (a.crossCorrelation > 0.75) return 'severely_degraded';
+  if (a.crossCorrelation > 0.40) return 'mildly_degraded';
+  if (a.downstreamIsStable)      return 'normal';
+  return 'monitoring';
+}
+
+const STATUS_LABELS: Record<O2Status, string> = {
+  normal:            'Normal',
+  mildly_degraded:   'Mildly Degraded',
+  severely_degraded: 'Severely Degraded',
+  monitoring:        'Monitoring…',
+  no_data:           'No Data',
+};
+
+const STATUS_CSS: Record<O2Status, string> = {
+  normal:            'o2-status--normal',
+  mildly_degraded:   'o2-status--warning',
+  severely_degraded: 'o2-status--critical',
+  monitoring:        'o2-status--muted',
+  no_data:           'o2-status--muted',
+};
+
+@Component({
+  selector: 'app-o2-sensor-graph',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIf, NgClass, BaseChartDirective],
+  templateUrl: './o2-sensor-graph.component.html',
+  styleUrls: ['./o2-sensor-graph.component.scss'],
+})
+export class O2SensorGraphComponent implements OnInit, OnDestroy {
+  private readonly buffer = inject(O2SensorBufferService);
+  private readonly cdr    = inject(ChangeDetectorRef);
+  private sub?: Subscription;
+
+  @ViewChild('o2Chart', { read: BaseChartDirective }) chart?: BaseChartDirective;
+
+  selectedBank: 1 | 2 = 1;
+
+  // ── View state (updated by update()) ────────────────────────────────────────
+  hasData       = false;
+  status: O2Status = 'no_data';
+  statusLabel   = STATUS_LABELS['no_data'];
+  statusClass   = STATUS_CSS['no_data'];
+  upstreamHz    = '—';
+  downstreamHz  = '—';
+  correlationPct = '—';
+  upstreamMeanV  = '—';
+  downstreamMeanV = '—';
+
+  // ── Chart configuration ──────────────────────────────────────────────────────
+  chartData: ChartData<'line'> = {
+    labels: [],
+    datasets: [
+      {
+        label: 'Upstream (S1)',
+        data: [],
+        borderColor: '#4caf50',
+        backgroundColor: 'rgba(76,175,80,0.08)',
+        fill: false,
+        tension: 0.3,
+        pointRadius: 0,
+        borderWidth: 2,
+        yAxisID: 'yVolt',
+      },
+      {
+        label: 'Downstream (S2)',
+        data: [],
+        borderColor: '#9c27b0',
+        backgroundColor: 'rgba(156,39,176,0.08)',
+        fill: false,
+        tension: 0.3,
+        pointRadius: 0,
+        borderWidth: 2,
+        yAxisID: 'yVolt',
+      },
+    ],
+  };
+
+  chartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false,
+    interaction: { mode: 'index', intersect: false },
+    plugins: {
+      legend: {
+        display: true,
+        position: 'top',
+        labels: {
+          color: '#cccccc',
+          font: { size: 11 },
+          boxWidth: 12,
+          padding: 14,
+          usePointStyle: true,
+        },
+      },
+      tooltip: {
+        backgroundColor: 'rgba(30,30,30,0.92)',
+        titleColor: '#ffffff',
+        bodyColor: '#cccccc',
+        borderColor: '#333333',
+        borderWidth: 1,
+        callbacks: {
+          label: ctx => {
+            const v = ctx.raw as number | null;
+            return v === null
+              ? `${ctx.dataset.label}: —`
+              : `${ctx.dataset.label}: ${v.toFixed(3)} V`;
+          },
+        },
+      },
+    },
+    scales: {
+      x: { display: false },
+      yVolt: {
+        type: 'linear',
+        position: 'left',
+        min: 0,
+        max: 1.3,
+        grid: { color: 'rgba(255,255,255,0.05)' },
+        ticks: { color: '#aaaaaa', maxTicksLimit: 7, font: { size: 10 } },
+        title: { display: true, text: 'Voltage (V)', color: '#aaaaaa', font: { size: 10 } },
+      },
+    },
+  };
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────────
+
+  ngOnInit(): void {
+    this.sub = this.buffer.state$.pipe(
+      throttleTime(400, undefined, { leading: true, trailing: true }),
+    ).subscribe(state => this.update(state));
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+    this.chart?.chart?.destroy();
+  }
+
+  // ── Public ───────────────────────────────────────────────────────────────────
+
+  selectBank(bank: 1 | 2): void {
+    this.selectedBank = bank;
+    this.update(this.buffer.state$.getValue());
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────────────
+
+  private update(state: O2SensorBufferState): void {
+    const frames    = this.selectedBank === 1 ? state.bank1Frames : state.bank2Frames;
+    const analytics = this.selectedBank === 1 ? state.bank1Analytics : state.bank2Analytics;
+
+    this.status      = deriveStatus(analytics);
+    this.statusLabel = STATUS_LABELS[this.status];
+    this.statusClass = STATUS_CSS[this.status];
+    this.hasData     = analytics.hasData;
+
+    if (analytics.hasData) {
+      this.upstreamHz     = analytics.upstreamSwitchingHz.toFixed(2);
+      this.downstreamHz   = analytics.downstreamSwitchingHz.toFixed(2);
+      this.correlationPct = (analytics.crossCorrelation * 100).toFixed(0);
+      this.upstreamMeanV  = analytics.upstreamMean.toFixed(3);
+      this.downstreamMeanV = analytics.downstreamMean.toFixed(3);
+    } else {
+      this.upstreamHz = this.downstreamHz = this.correlationPct = '—';
+      this.upstreamMeanV = this.downstreamMeanV = '—';
+    }
+
+    // Rebuild chart window
+    const window = frames.slice(-CHART_WINDOW);
+    this.chartData.labels = window.map((_, i) => String(i));
+    this.chartData.datasets[0].data = window.map(f => f.upstream);
+    this.chartData.datasets[1].data = window.map(f => f.downstream);
+
+    this.chart?.chart?.update('none');
+    this.cdr.markForCheck();
+  }
+}
+
+export { NO_ANALYTICS };


### PR DESCRIPTION
## Summary

- **AI DTC learning database**: `lookupDtc` Firebase function looks up unknown DTC codes in Firestore, falls back to GPT-4o-mini, and persists AI-generated definitions for future sessions. Frontend `DtcLookupService` caches results in-session.
- **Live O2 sensor voltage graph**: Real-time upstream vs downstream voltage chart embedded in the Catalytic Converter Test panel. Bank selector (Bank 1 / Bank 2), 30 s sliding window, switching-Hz / correlation / mean-V metrics strip, and no-data fallback for cold engine or single-bank vehicles.
- **Codex P1/P2 fixes**: Awaited Firestore write in `lookupDtc`; session-cache the unknown fallback to prevent repeated slow retries.

## What changed

| Area | Change |
|---|---|
| `functions/src/index.ts` | `aiDiagnose` + `lookupDtc` Cloud Functions; Firestore write is now awaited |
| `dtc-lookup.service.ts` | Full priority chain: local → Firestore/AI; failure fallback is session-cached |
| `dtc-code.model.ts` | Added `firebase`, `ai_generated` sources; `safeToDrive`, `lookupConfidence`, `reviewStatus` fields |
| `obd-live-frame.model.ts` | Added `o2S1B1/S2B1/S1B2/S2B2` voltage fields |
| `obd-pid-parser.service.ts` | PIDs 0114–0117 parsed as `A × 0.005 V` |
| `web-bluetooth-elm327-adapter.service.ts` | O2 PIDs added to poll cycle |
| `simulator-obd-adapter.service.ts` | Upstream switches ~1 Hz; downstream stable ~0.65 V (healthy cat) |
| `o2-sensor-buffer.service.ts` | 60 s rolling buffer; switching Hz, Pearson correlation, std-dev stability |
| `o2-sensor-graph` component | Self-contained chart widget with bank tabs, metrics, no-data state |
| `diagnosis-assistant-page` | `catalyticResult$` combines DTCs + live O2 analytics; graph embedded in panel |

## Test plan

- [ ] Simulator: open Catalytic Converter Test → graph appears once coolant ≥ 60 °C
- [ ] Bank 1 tab shows upstream (green) switching + downstream (purple) stable
- [ ] Bank 2 tab shows no-data fallback message
- [ ] Metrics strip (Hz, correlation %, mean V) updates as frames accumulate
- [ ] `catalyticResult$` confidence rises from low → medium/high as O2 data arrives
- [ ] Unknown DTC lookup hits `/lookupDtc` function and caches result in session
- [ ] Second lookup for same unknown code returns from cache without network call
- [ ] `npm run build` passes