### PR TITLE
fix(ui): surface all 9 guided diagnostic packs in the diagnosis assistant

### DIFF
--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
@@ -35,7 +35,9 @@
     </button>
 
     <!-- Guided Diagnosis -->
-    <button class="mode-card mode-card--secondary" (click)="openGuidedDiagnosis()">
+    <button class="mode-card mode-card--secondary"
+            [class.mode-card--active]="showGuidedPacksPanel"
+            (click)="toggleGuidedPacks()">
       <div class="card-icon-wrap card-icon-wrap--blue">
         <span class="card-icon">▶</span>
       </div>
@@ -46,15 +48,17 @@
         </div>
         <p class="card-description">
           Follow a step-by-step troubleshooting workflow and answer questions as you perform
-          physical checks. Ideal for no-start, hard-start, and intermittent faults.
+          physical checks. 9 diagnostic packs covering the most common fault categories.
         </p>
         <ul class="card-features">
-          <li><span class="feat-dot feat-dot--blue"></span>Hypothesis scoring</li>
-          <li><span class="feat-dot feat-dot--blue"></span>No-start pack</li>
-          <li><span class="feat-dot feat-dot--blue"></span>Mechanic-guided questions</li>
+          <li><span class="feat-dot feat-dot--blue"></span>No-start · Misfire · Rough idle</li>
+          <li><span class="feat-dot feat-dot--blue"></span>Overheating · Battery · DPF/EGR · EV</li>
+          <li><span class="feat-dot feat-dot--blue"></span>Hypothesis scoring — mechanic questions</li>
         </ul>
       </div>
-      <span class="card-arrow">→</span>
+      <span class="card-arrow" [class.card-arrow--open]="showGuidedPacksPanel">
+        {{ showGuidedPacksPanel ? '↓' : '→' }}
+      </span>
     </button>
 
     <!-- Analyze Cylinders -->
@@ -111,6 +115,97 @@
       </span>
     </button>
 
+  </div>
+
+  <!-- ── Guided Diagnostic Packs Panel ──────────────────────────────────────── -->
+  <div class="guided-packs-panel" *ngIf="showGuidedPacksPanel">
+
+    <!-- Pack selection list (no active pack) -->
+    <ng-container *ngIf="!activePack">
+      <div class="gp-header">
+        <h3 class="gp-title">Select a Diagnostic Pack</h3>
+        <p class="gp-subtitle">
+          Answer step-by-step questions to identify the most likely root cause.
+          Scores update after each answer.
+        </p>
+      </div>
+      <div class="gp-pack-grid">
+        <button class="gp-pack-card" *ngFor="let pack of allPacks" (click)="launchPack(pack)">
+          <span class="gp-pack-title">{{ pack.title }}</span>
+          <span class="gp-pack-meta">
+            {{ pack.hypotheses.length }} hypotheses &middot; {{ pack.steps.length }} questions
+          </span>
+          <span class="gp-pack-arrow">→</span>
+        </button>
+      </div>
+    </ng-container>
+
+    <!-- Active pack Q&A -->
+    <ng-container *ngIf="activePack && (diagnosticState$ | async) as state">
+
+      <div class="gp-active-header">
+        <div>
+          <h3 class="gp-title">{{ activePack.title }}</h3>
+          <span class="gp-progress-label" *ngIf="state.history.length > 0">
+            {{ state.history.length }} / {{ activePack.steps.length }} answered
+          </span>
+        </div>
+        <button class="gp-back-btn" (click)="resetPack()">← Change Pack</button>
+      </div>
+
+      <!-- Current step (pack in progress) -->
+      <ng-container *ngIf="state.currentStepId">
+        <ng-container *ngIf="currentStep(state) as step">
+          <div class="gp-step-card">
+            <p class="gp-step-instruction">{{ step.instruction }}</p>
+            <p class="gp-step-question">{{ step.question }}</p>
+            <div class="gp-options">
+              <button class="gp-option-btn"
+                      *ngFor="let opt of step.options"
+                      (click)="applyAnswer(opt)">
+                {{ opt.label }}
+              </button>
+            </div>
+          </div>
+        </ng-container>
+
+        <!-- Live hypothesis scores (show after first answer) -->
+        <div class="gp-live-scores" *ngIf="state.history.length > 0">
+          <h4 class="gp-scores-label">Hypothesis Scores</h4>
+          <div class="gp-hyp-list">
+            <div class="gp-hyp-row" *ngFor="let h of topHypotheses(state); let i = index"
+                 [class.gp-hyp-row--top]="i === 0">
+              <span class="gp-hyp-label">{{ h.label }}</span>
+              <div class="gp-hyp-bar-wrap">
+                <div class="gp-hyp-bar" [style.width.%]="h.barPct"></div>
+              </div>
+              <span class="gp-hyp-score">{{ h.score | number:'1.2-2' }}</span>
+            </div>
+          </div>
+        </div>
+      </ng-container>
+
+      <!-- Pack complete -->
+      <ng-container *ngIf="!state.currentStepId">
+        <div class="gp-results">
+          <h4 class="gp-results-title">Diagnosis Complete</h4>
+          <p class="gp-results-subtitle">Ranked by accumulated evidence score:</p>
+          <div class="gp-hyp-list">
+            <div class="gp-hyp-row" *ngFor="let h of topHypotheses(state); let i = index"
+                 [class.gp-hyp-row--top]="i === 0">
+              <span class="gp-hyp-rank">{{ i + 1 }}</span>
+              <span class="gp-hyp-label">{{ h.label }}</span>
+              <div class="gp-hyp-bar-wrap">
+                <div class="gp-hyp-bar" [style.width.%]="h.barPct"></div>
+              </div>
+              <span class="gp-hyp-score">{{ h.score | number:'1.2-2' }}</span>
+            </div>
+          </div>
+          <button class="gp-restart-btn" (click)="resetPack()">Test Another Symptom</button>
+        </div>
+      </ng-container>
+
+    </ng-container>
   </div>
 
   <!-- ── Catalytic Converter Panel ───────────────────────────────────────── -->

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.scss
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.scss
@@ -634,6 +634,262 @@ $color-purple: #9c27b0;
   }
 }
 
+// ── Guided Packs Panel ────────────────────────────────────────────────────────
+
+.guided-packs-panel {
+  background: $bg-secondary;
+  border: 1px solid rgba(33, 150, 243, 0.25);
+  border-radius: $radius-lg;
+  padding: $spacing-xl;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-lg;
+}
+
+.gp-header { display: flex; flex-direction: column; gap: $spacing-xs; }
+
+.gp-title {
+  margin: 0;
+  font-size: $font-size-title-lg;
+  font-weight: 600;
+  color: $text-primary;
+  letter-spacing: -0.01em;
+}
+
+.gp-subtitle {
+  margin: 0;
+  font-size: $font-size-body-md;
+  color: $text-muted;
+  line-height: 1.55;
+}
+
+// Pack selection grid
+.gp-pack-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: $spacing-sm;
+}
+
+.gp-pack-card {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  padding: $spacing-md;
+  background: $bg-tertiary;
+  border: 1px solid $border-color;
+  border-radius: $radius-md;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s ease, background 0.15s ease;
+  font-family: $font-family;
+
+  &:hover {
+    border-color: rgba(33, 150, 243, 0.45);
+    background: rgba(33, 150, 243, 0.06);
+  }
+}
+
+.gp-pack-title {
+  flex: 1;
+  font-size: $font-size-body-md;
+  font-weight: 600;
+  color: $text-primary;
+  line-height: 1.35;
+}
+
+.gp-pack-meta {
+  font-size: $font-size-body-sm;
+  color: $text-muted;
+  white-space: nowrap;
+}
+
+.gp-pack-arrow {
+  font-size: $font-size-body-md;
+  color: $text-muted;
+  flex-shrink: 0;
+}
+
+// Active pack header
+.gp-active-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: $spacing-md;
+  flex-wrap: wrap;
+}
+
+.gp-progress-label {
+  font-size: $font-size-body-sm;
+  color: $text-muted;
+  margin-top: 4px;
+}
+
+.gp-back-btn {
+  padding: 5px $spacing-md;
+  border: 1px solid $border-color;
+  border-radius: $radius-full;
+  background: $bg-tertiary;
+  color: $text-muted;
+  font-size: $font-size-body-sm;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: $font-family;
+  white-space: nowrap;
+  transition: border-color 0.15s ease, color 0.15s ease;
+
+  &:hover { border-color: $border-light; color: $text-secondary; }
+}
+
+// Step card
+.gp-step-card {
+  background: $bg-tertiary;
+  border: 1px solid $border-color;
+  border-radius: $radius-md;
+  padding: $spacing-lg;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-md;
+}
+
+.gp-step-instruction {
+  margin: 0;
+  font-size: $font-size-body-sm;
+  color: $text-muted;
+  line-height: 1.6;
+}
+
+.gp-step-question {
+  margin: 0;
+  font-size: $font-size-body-lg;
+  font-weight: 600;
+  color: $text-primary;
+  line-height: 1.45;
+}
+
+.gp-options {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-sm;
+}
+
+.gp-option-btn {
+  padding: $spacing-sm $spacing-md;
+  border: 1px solid rgba(33, 150, 243, 0.3);
+  border-radius: $radius-md;
+  background: rgba(33, 150, 243, 0.06);
+  color: $color-info;
+  font-size: $font-size-body-md;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  font-family: $font-family;
+  transition: background 0.12s ease, border-color 0.12s ease;
+
+  &:hover {
+    background: rgba(33, 150, 243, 0.14);
+    border-color: rgba(33, 150, 243, 0.55);
+  }
+}
+
+// Hypothesis scores
+.gp-live-scores,
+.gp-results {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-md;
+}
+
+.gp-scores-label,
+.gp-results-title {
+  margin: 0;
+  font-size: $font-size-label-lg;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: $text-muted;
+}
+
+.gp-results-subtitle {
+  margin: 0;
+  font-size: $font-size-body-sm;
+  color: $text-muted;
+}
+
+.gp-hyp-list {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-sm;
+}
+
+.gp-hyp-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) 1fr auto;
+  align-items: center;
+  gap: $spacing-sm;
+
+  &--top .gp-hyp-label { color: $color-info; font-weight: 700; }
+  &--top .gp-hyp-bar   { background: $color-info; }
+}
+
+.gp-hyp-rank {
+  min-width: 20px;
+  height: 20px;
+  border-radius: $radius-full;
+  background: $bg-tertiary;
+  border: 1px solid $border-color;
+  font-size: $font-size-label-sm;
+  font-weight: 700;
+  color: $text-muted;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.gp-hyp-label {
+  font-size: $font-size-body-sm;
+  font-weight: 600;
+  color: $text-secondary;
+}
+
+.gp-hyp-bar-wrap {
+  height: 6px;
+  background: $bg-tertiary;
+  border-radius: $radius-full;
+  overflow: hidden;
+}
+
+.gp-hyp-bar {
+  height: 100%;
+  background: rgba(33, 150, 243, 0.6);
+  border-radius: $radius-full;
+  transition: width 0.3s ease;
+}
+
+.gp-hyp-score {
+  font-size: $font-size-label-sm;
+  color: $text-muted;
+  font-variant-numeric: tabular-nums;
+  min-width: 36px;
+  text-align: right;
+}
+
+.gp-restart-btn {
+  align-self: flex-start;
+  padding: $spacing-sm $spacing-lg;
+  border: 1px solid rgba(33, 150, 243, 0.35);
+  border-radius: $radius-md;
+  background: rgba(33, 150, 243, 0.08);
+  color: $color-info;
+  font-size: $font-size-body-md;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: $font-family;
+  transition: background 0.12s ease;
+
+  &:hover { background: rgba(33, 150, 243, 0.16); }
+}
+
 // ── Responsive ────────────────────────────────────────────────────────────────
 @media (max-width: 700px) {
   .assistant-page {

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe } from '@angular/common';
+import { AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe, DecimalPipe } from '@angular/common';
 import { Router } from '@angular/router';
 import { Observable, combineLatest } from 'rxjs';
 import { map, throttleTime } from 'rxjs/operators';
@@ -10,11 +10,21 @@ import { CatalyticConverterAnalysisService } from '../../core/diagnostics/cataly
 import type { CatalyticConverterResult } from '../../core/diagnostics/catalytic-converter-analysis.service';
 import { O2SensorBufferService } from '../../core/diagnostics/o2-sensor-buffer.service';
 import { O2SensorGraphComponent } from '../../shared/components/o2-sensor-graph/o2-sensor-graph.component';
+import { DiagnosticEngineService } from '../../core/diagnostics/diagnostic-engine.service';
+import { allDiagnosticPacks } from '../../core/diagnostics/packs';
+import type { KnowledgePack, DiagnosticState, Step, StepOption } from '../../core/diagnostics/diagnostic-types';
+
+export interface HypothesisView {
+  id: string;
+  label: string;
+  score: number;
+  barPct: number;
+}
 
 @Component({
   selector: 'app-diagnosis-assistant-page',
   standalone: true,
-  imports: [AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe, O2SensorGraphComponent],
+  imports: [AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe, DecimalPipe, O2SensorGraphComponent],
   templateUrl: './diagnosis-assistant-page.component.html',
   styleUrls: ['./diagnosis-assistant-page.component.scss'],
 })
@@ -24,18 +34,28 @@ export class DiagnosisAssistantPageComponent {
   private cylinderAnalysis    = inject(CylinderAnalysisService);
   private catalyticAnalysis   = inject(CatalyticConverterAnalysisService);
   private o2Buffer            = inject(O2SensorBufferService);
+  private diagnosticEngine    = inject(DiagnosticEngineService);
 
-  /** Live cylinder analysis derived from the current session's DTCs. */
+  // ── All knowledge packs ──────────────────────────────────────────────────────
+  readonly allPacks: readonly KnowledgePack[] = allDiagnosticPacks;
+  readonly diagnosticState$: Observable<DiagnosticState | null> =
+    this.diagnosticEngine.diagnosticState$;
+
+  // ── Panel visibility ─────────────────────────────────────────────────────────
+  showGuidedPacksPanel = false;
+  showCylinderPanel    = false;
+  showCatalyticPanel   = false;
+
+  /** The pack that is currently selected (pre-start or mid-run). */
+  activePack: KnowledgePack | null = null;
+
+  // ── Observables ──────────────────────────────────────────────────────────────
+
   readonly cylinderResult$: Observable<CylinderAnalysisResult> =
     this.deepDiagnosis.state$.pipe(
       map(state => this.cylinderAnalysis.analyse(state.dtcCodes ?? []))
     );
 
-  /**
-   * Catalytic converter analysis combining DTC codes with live O2 sensor data
-   * from the rolling 60-second buffer (Bank 1). Throttled to 500 ms to avoid
-   * excessive re-renders at 5 Hz frame rate.
-   */
   readonly catalyticResult$: Observable<CatalyticConverterResult> = combineLatest([
     this.deepDiagnosis.state$,
     this.o2Buffer.state$,
@@ -47,15 +67,19 @@ export class DiagnosisAssistantPageComponent {
     })),
   );
 
-  showCylinderPanel  = false;
-  showCatalyticPanel = false;
+  // ── Navigation ───────────────────────────────────────────────────────────────
 
   openFullDiagnosis(): void {
     this.router.navigate(['/diagnosis-report']);
   }
 
-  openGuidedDiagnosis(): void {
-    this.router.navigate(['/guided-tests']);
+  // ── Panel toggles ────────────────────────────────────────────────────────────
+
+  toggleGuidedPacks(): void {
+    this.showGuidedPacksPanel = !this.showGuidedPacksPanel;
+    if (!this.showGuidedPacksPanel) {
+      this.activePack = null;
+    }
   }
 
   toggleCylinderAnalysis(): void {
@@ -65,6 +89,46 @@ export class DiagnosisAssistantPageComponent {
   toggleCatalyticAnalysis(): void {
     this.showCatalyticPanel = !this.showCatalyticPanel;
   }
+
+  // ── Pack engine ──────────────────────────────────────────────────────────────
+
+  launchPack(pack: KnowledgePack): void {
+    this.activePack = pack;
+    this.diagnosticEngine.startPack(pack);
+  }
+
+  applyAnswer(option: StepOption): void {
+    this.diagnosticEngine.applyAnswer(option);
+  }
+
+  resetPack(): void {
+    this.activePack = null;
+  }
+
+  currentStep(state: DiagnosticState): Step | null {
+    return this.diagnosticEngine.getCurrentStep();
+  }
+
+  topHypotheses(state: DiagnosticState): HypothesisView[] {
+    const entries = Object.entries(state.hypothesisScores)
+      .map(([id, score]) => ({
+        id,
+        score,
+        label: id
+          .replace(/_issue$/, '')
+          .replace(/_/g, ' ')
+          .replace(/\b\w/g, c => c.toUpperCase()),
+      }))
+      .sort((a, b) => b.score - a.score);
+
+    const maxScore = Math.max(...entries.map(e => e.score), 0.01);
+    return entries.map(e => ({
+      ...e,
+      barPct: Math.max(0, (e.score / maxScore) * 100),
+    }));
+  }
+
+  // ── Catalytic helpers ────────────────────────────────────────────────────────
 
   catalyticStatusClass(status: string): string {
     if (status === 'normal')              return 'cat-status-badge--normal';


### PR DESCRIPTION
## Root Causes Found

### 1 — All 9 knowledge packs were invisible (primary bug)
`allDiagnosticPacks` is a fully implemented array of 9 `KnowledgePack` objects exported from `packs/index.ts`. However, **no feature component ever imported it, called `DiagnosticEngineService.startPack()`, or rendered any pack card**. Every pack was dead code from the UI's point of view.

### 2 — "Guided Diagnosis" card opened the wrong page
The card navigated to `/guided-tests` (the legacy `GuidedTestsPageComponent`). That page runs automated sensor tests (`GuidedTestService`) and the deep diagnosis scan (`DeepDiagnosisService`). It has **zero integration with the knowledge-pack engine** — selecting it appeared to open an unrelated page rather than launching a guided pack.

---

## UI Integration Fixes

| File | Change |
|---|---|
| `diagnosis-assistant-page.component.ts` | Injected `DiagnosticEngineService`; added `allPacks`, `diagnosticState$`, `launchPack()`, `applyAnswer()`, `resetPack()`, `currentStep()`, `topHypotheses()` |
| `diagnosis-assistant-page.component.html` | Rewired Guided Diagnosis card to `toggleGuidedPacks()`; added inline guided packs panel with pack grid, step Q&A, live hypothesis scores, and completion results view |
| `diagnosis-assistant-page.component.scss` | Added all `.gp-*` styles (pack grid, step card, option buttons, hypothesis bars) |

---

## Features Now Visible and Clickable

All 9 packs accessible inline from the AI Diagnosis Assistant:

- **No-Start / Hard-Start** — 4 hypotheses, 6 questions
- **Misfire** — hypothesis scoring for coil/plug/injector/compression/wiring
- **Rough Idle / Stalling**
- **Lack of Power / Hesitation**
- **High Fuel Consumption**
- **Engine Overheating**
- **Battery / Charging System**
- **Diesel DPF / EGR**
- **EV Reduced Power / Charging Fault**

Pack flow: select pack → step-by-step Q&A → live hypothesis scores update after each answer → ranked results on completion → "Test Another Symptom" resets.

---

## Routing Fixes

- Guided Diagnosis card no longer navigates away to `/guided-tests`
- Panel opens inline (consistent with Analyze Cylinders and Catalytic Converter Test patterns)
- `/guided-tests` legacy route is preserved for direct links

---

## Build

`npm run build` — passes. Only pre-existing bundle size warning (5.28 kB over 550 kB budget from Chart.js).