### PR TITLE
fix: UI integration audit — diagnosis assistant, guided packs, session comparison

### DIFF
--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.scss
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.scss
@@ -118,6 +118,12 @@
     box-shadow: 0 4px 24px rgba(33, 150, 243, 0.08);
   }
   &::before { background: $color-info; }
+
+  &.mode-card--active {
+    background: rgba(33, 150, 243, 0.08);
+    border-color: rgba(33, 150, 243, 0.4);
+    &::before { opacity: 1; }
+  }
 }
 
 // ── Icon wrap ─────────────────────────────────────────────────────────────────

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
@@ -109,15 +109,26 @@ export class DiagnosisAssistantPageComponent {
     return this.diagnosticEngine.getCurrentStep();
   }
 
+  private static readonly ACRONYMS: Record<string, string> = {
+    Dpf: 'DPF', Egr: 'EGR', Hv: 'HV', Soc: 'SOC', Soh: 'SOH', Or: 'or',
+  };
+
+  private hypothesisLabel(id: string): string {
+    return id
+      .replace(/_issue$/, '')
+      .replace(/_/g, ' ')
+      .replace(/\b\w+/g, word => {
+        const cap = word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+        return DiagnosisAssistantPageComponent.ACRONYMS[cap] ?? cap;
+      });
+  }
+
   topHypotheses(state: DiagnosticState): HypothesisView[] {
     const entries = Object.entries(state.hypothesisScores)
       .map(([id, score]) => ({
         id,
         score,
-        label: id
-          .replace(/_issue$/, '')
-          .replace(/_/g, ' ')
-          .replace(/\b\w/g, c => c.toUpperCase()),
+        label: this.hypothesisLabel(id),
       }))
       .sort((a, b) => b.score - a.score);
 

--- a/src/app/features/sessions/session-summary.component.html
+++ b/src/app/features/sessions/session-summary.component.html
@@ -96,7 +96,7 @@
         <div class="cp-header">
           <h2 class="cp-title">Session Comparison</h2>
           <span class="cp-badge" [ngClass]="effectivenessClass(r.repairEffectiveness)">
-            {{ r.repairEffectiveness | titlecase }}
+            {{ repairEffectivenessLabel(r.repairEffectiveness) }}
           </span>
         </div>
 

--- a/src/app/features/sessions/session-summary.component.ts
+++ b/src/app/features/sessions/session-summary.component.ts
@@ -75,6 +75,9 @@ export class SessionSummaryComponent {
       this.comparisonError  = null;
     } else if (this.selectedIds.size < 2) {
       this.selectedIds.add(entry.id);
+      this.comparisonError = null;
+    } else {
+      this.comparisonError = 'Only two sessions can be compared at a time. Deselect one before choosing another.';
     }
   }
 
@@ -87,7 +90,10 @@ export class SessionSummaryComponent {
       .filter(e => this.selectedIds.has(e.id))
       .sort((a, b) => a.savedAt - b.savedAt);
 
-    if (selected.length !== 2) return;
+    if (selected.length !== 2) {
+      this.comparisonError = 'Select exactly two sessions to compare.';
+      return;
+    }
 
     const outcome = this.comparisonService.compare(selected[0], selected[1]);
     if (outcome.ok) {
@@ -104,6 +110,14 @@ export class SessionSummaryComponent {
     if (e === 'partial')    return 'warning';
     if (e === 'worsened')   return 'critical';
     return 'muted';
+  }
+
+  repairEffectivenessLabel(e: string): string {
+    if (e === 'successful') return 'Successful';
+    if (e === 'partial')    return 'Partial';
+    if (e === 'no_change')  return 'No Change';
+    if (e === 'worsened')   return 'Worsened';
+    return e;
   }
 
   private resetComparison(): void {


### PR DESCRIPTION
## Root causes identified

### AI Diagnosis Assistant
1. **`mode-card--secondary` had no active-state CSS** — the Guided Diagnosis card gave no visual "panel open" feedback when clicked. Amber and purple cards already had `&.mode-card--active` rules; the secondary card was the outlier.
2. **Lowercased acronyms in hypothesis score labels** — `topHypotheses()` used a bare word-capitaliser that produced garbled labels for acronym-heavy hypothesis IDs: `Dpf Soot Overload`, `Egr Valve`, `Hv Isolation`, `Low Soc Or Soh` (affects DPF/EGR and EV Reduced Power packs).

### Session Comparison
3. **`repairEffectiveness` badge used `| titlecase` on `'no_change'`** — Angular's `TitleCasePipe` treats underscores as part of the word (not word separators), so the badge rendered `"No_change"` instead of `"No Change"`.
4. **Third-session selection attempt was silently ignored** — `toggleSelect()` enforced the 2-session limit with no user feedback; the user could not tell why their click was absorbed.
5. **`runComparison()` returned silently** when `selected.length !== 2` instead of surfacing an error, which could leave the user staring at a blank panel.

---

## UI integration fixes

- Added `.mode-card--secondary.mode-card--active` (blue palette: `rgba(33,150,243,0.08)` background, `rgba(33,150,243,0.4)` border, left-accent bar visible) consistent with the amber and purple card patterns.
- Added `ACRONYMS` lookup map (`DPF`, `EGR`, `HV`, `SOC`, `SOH`) and `hypothesisLabel()` helper in `DiagnosisAssistantPageComponent`; replaced the inline word-capitaliser in `topHypotheses()`.
- Added `repairEffectivenessLabel()` helper with explicit string→label map; replaced `| titlecase` binding in the comparison badge template.

## Routing fixes

No routing changes required. Full audit confirmed all routes are correct:
- `/diagnosis-assistant` → unified hub with all 4 mode cards
- `/diagnosis-report` → Full Diagnosis (AI deep scan)
- Guided Diagnosis, Analyze Cylinders, Catalytic Converter Test → inline panels (no separate routes needed)

## Guided pack registration fixes

All 9 packs verified in `allDiagnosticPacks` (exported from `packs/index.ts`) and surfaced in the Guided Diagnosis panel grid. No missing registrations.

## Session comparison fixes

- `toggleSelect()` now sets `comparisonError = 'Only two sessions can be compared at a time. Deselect one before choosing another.'` when the user tries to add a third selection.
- `comparisonError` is cleared when a valid selection is added or removed, preventing stale messages from persisting.
- `runComparison()` now surfaces `'Select exactly two sessions to compare.'` instead of returning silently.
- VIN mismatch and same-session errors are surfaced by `SessionComparisonService` and rendered in the existing `comparison-error` div.

## Features verified end-to-end

| Feature | Status |
|---------|--------|
| Full Diagnosis card | ✅ Visible, routes to `/diagnosis-report` |
| Guided Diagnosis card | ✅ Visible, active-state now highlighted, toggles panel |
| Guided Diagnosis — all 9 packs | ✅ All listed: No-Start · Misfire · Rough Idle · Lack of Power · High Fuel Consumption · Overheating · Battery/Charging · DPF/EGR · EV Reduced Power |
| Analyze Cylinders card | ✅ Visible, toggles analysis panel |
| Catalytic Converter Test card | ✅ Visible, toggles catalytic panel |
| Hypothesis labels — DPF/EGR pack | ✅ Now reads DPF, EGR correctly |
| Hypothesis labels — EV pack | ✅ Now reads HV, SOC, SOH correctly |
| Sessions Compare button | ✅ Enters compare mode, 2-session gate enforced with error messages |
| Sessions — Run Comparison | ✅ Invokes `SessionComparisonService.compare()` |
| Sessions — VIN mismatch error | ✅ Displayed in error banner |
| Sessions — 3rd-selection error | ✅ Now shown instead of silent ignore |
| Sessions — comparison result panel | ✅ Shows Fixed Issues, Still Present, New Issues, Improved Metrics, Worsened Metrics, Unchanged Findings, Overall Conclusion, Repair Effectiveness |
| Sessions — effectiveness badge | ✅ Renders "No Change" correctly (was "No_change") |

## Build results

```
✔ Building...
Application bundle generation complete.
▲ [WARNING] bundle initial exceeded maximum budget by 5.28 kB
```

Zero errors. The budget warning is pre-existing and unrelated to this change.