### PR TITLE
feat(vehicle): Phase 2 — manual vehicle setup UI

### DIFF
--- a/src/app/core/models/vehicle-profile.model.ts
+++ b/src/app/core/models/vehicle-profile.model.ts
@@ -11,8 +11,11 @@ export interface VehicleProfile {
   fuelType: 'petrol' | 'diesel' | 'hybrid' | 'electric' | 'unknown';
   transmission: 'manual' | 'automatic' | 'cvt' | 'unknown';
   vin?: string;
+  vinPattern?: string;
   detectedProtocol?: string;
   notes?: string;
+  source?: 'user_confirmed' | 'vin_lookup' | 'vin_pattern';
+  reviewStatus?: 'verified' | 'pending' | 'unreviewed';
   createdAt: number;
   updatedAt: number;
 }

--- a/src/app/core/vehicle/vehicle-profile.service.ts
+++ b/src/app/core/vehicle/vehicle-profile.service.ts
@@ -41,4 +41,25 @@ export class VehicleProfileService {
   getActiveProfile(): VehicleProfile | null {
     return this.activeProfileSubject.value;
   }
+
+  saveConfirmedProfile(
+    profile: Omit<VehicleProfile, 'id' | 'source' | 'reviewStatus' | 'createdAt' | 'updatedAt'>,
+    vin?: string,
+    vinPattern?: string,
+  ): void {
+    const existing = this.activeProfileSubject.value;
+    const now = Date.now();
+    const confirmed: VehicleProfile = {
+      ...profile,
+      id: existing?.id || 'veh_' + now,
+      source: 'user_confirmed',
+      reviewStatus: 'verified',
+      vin: vin ?? profile.vin ?? existing?.vin,
+      vinPattern: vinPattern ?? profile.vinPattern ?? existing?.vinPattern,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    localStorage.setItem('obd_active_vehicle', JSON.stringify(confirmed));
+    this.activeProfileSubject.next(confirmed);
+  }
 }

--- a/src/app/features/vehicle-profile/manual-vehicle-setup.component.html
+++ b/src/app/features/vehicle-profile/manual-vehicle-setup.component.html
@@ -1,0 +1,135 @@
+<div class="mvs-panel">
+
+  <!-- ── Not-found banner ─────────────────────────────────────────────────── -->
+  <div class="mvs-banner">
+    <span class="banner-icon">⚠</span>
+    <span class="banner-text">
+      Vehicle not found. Select details manually and we'll remember it for future diagnosis.
+    </span>
+  </div>
+
+  <!-- ── Success state ────────────────────────────────────────────────────── -->
+  <ng-container *ngIf="saveState === 'success'">
+    <div class="mvs-success">
+      <span class="success-icon">✓</span>
+      <div>
+        <p class="success-title">Profile Saved</p>
+        <p class="success-body">
+          Vehicle profile saved. We'll remember this vehicle for future diagnosis.
+        </p>
+      </div>
+    </div>
+    <button class="btn-secondary" (click)="reset()">Edit Details</button>
+  </ng-container>
+
+  <!-- ── Form ─────────────────────────────────────────────────────────────── -->
+  <ng-container *ngIf="saveState !== 'success'">
+    <h2 class="mvs-title">Vehicle Details</h2>
+
+    <!-- Make — required -->
+    <div class="field-group">
+      <label class="field-label" for="mvs-make">
+        Make <span class="required-mark">*</span>
+      </label>
+      <div class="select-wrap">
+        <select
+          id="mvs-make"
+          [(ngModel)]="selectedMake"
+          (ngModelChange)="onMakeChange()"
+          class="select-field">
+          <option value="" disabled>Select make…</option>
+          <option *ngFor="let m of makes" [value]="m">{{ m }}</option>
+        </select>
+        <span class="select-arrow">▾</span>
+      </div>
+    </div>
+
+    <!-- Model — required -->
+    <div class="field-group" [class.field--disabled]="!selectedMake">
+      <label class="field-label" for="mvs-model">
+        Model <span class="required-mark">*</span>
+      </label>
+      <div class="select-wrap">
+        <select
+          id="mvs-model"
+          [(ngModel)]="selectedModel"
+          [disabled]="!selectedMake"
+          class="select-field">
+          <option value="" disabled>Select model…</option>
+          <option *ngFor="let m of models" [value]="m">{{ m }}</option>
+        </select>
+        <span class="select-arrow">▾</span>
+      </div>
+    </div>
+
+    <!-- Year — optional -->
+    <div class="field-group">
+      <label class="field-label" for="mvs-year">Year</label>
+      <div class="select-wrap">
+        <select
+          id="mvs-year"
+          [(ngModel)]="selectedYear"
+          class="select-field">
+          <option [ngValue]="null">Unknown</option>
+          <option *ngFor="let y of years" [ngValue]="y">{{ y }}</option>
+        </select>
+        <span class="select-arrow">▾</span>
+      </div>
+    </div>
+
+    <!-- Engine — optional -->
+    <div class="field-group">
+      <label class="field-label" for="mvs-engine">Engine</label>
+      <input
+        id="mvs-engine"
+        type="text"
+        [(ngModel)]="selectedEngine"
+        placeholder="e.g. 2.0L Turbo"
+        class="text-field" />
+    </div>
+
+    <!-- Fuel Type — required -->
+    <div class="field-group">
+      <label class="field-label" for="mvs-fuel">
+        Fuel Type <span class="required-mark">*</span>
+      </label>
+      <div class="select-wrap">
+        <select
+          id="mvs-fuel"
+          [(ngModel)]="selectedFuelType"
+          class="select-field">
+          <option *ngFor="let f of fuelOptions" [value]="f.value">{{ f.label }}</option>
+        </select>
+        <span class="select-arrow">▾</span>
+      </div>
+    </div>
+
+    <!-- Protocol — optional -->
+    <div class="field-group">
+      <label class="field-label" for="mvs-protocol">OBD Protocol</label>
+      <input
+        id="mvs-protocol"
+        type="text"
+        [(ngModel)]="selectedProtocol"
+        placeholder="e.g. ISO 15765-4 (CAN)"
+        class="text-field" />
+    </div>
+
+    <!-- Error message -->
+    <div class="mvs-error" *ngIf="saveState === 'error'">
+      <span class="error-icon">✕</span>
+      {{ errorMessage }}
+    </div>
+
+    <!-- Save CTA -->
+    <button
+      class="btn-save"
+      [disabled]="!canSave"
+      (click)="save()">
+      Save Vehicle Profile
+    </button>
+
+    <p class="hint" *ngIf="!canSave">Make, model, and fuel type are required.</p>
+  </ng-container>
+
+</div>

--- a/src/app/features/vehicle-profile/manual-vehicle-setup.component.scss
+++ b/src/app/features/vehicle-profile/manual-vehicle-setup.component.scss
@@ -1,0 +1,245 @@
+@use '../../../styles/variables' as *;
+
+.mvs-panel {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-md;
+  background: $bg-secondary;
+  border: 1px solid $border-color;
+  border-radius: $radius-lg;
+  padding: $spacing-xl;
+}
+
+// ── Banner ────────────────────────────────────────────────────────────────────
+.mvs-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-sm;
+  padding: $spacing-md;
+  background: rgba($color-warning, 0.08);
+  border: 1px solid rgba($color-warning, 0.3);
+  border-left: 3px solid $color-warning;
+  border-radius: $radius-sm;
+
+  .banner-icon {
+    font-size: 14px;
+    color: $color-warning;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  .banner-text {
+    font-size: $font-size-body-md;
+    color: $text-secondary;
+    line-height: 1.5;
+  }
+}
+
+// ── Title ─────────────────────────────────────────────────────────────────────
+.mvs-title {
+  margin: 0 0 $spacing-sm;
+  font-size: $font-size-title-md;
+  font-weight: 600;
+  color: $text-primary;
+  padding-bottom: $spacing-md;
+  border-bottom: 1px solid $border-color;
+}
+
+// ── Fields ────────────────────────────────────────────────────────────────────
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  &.field--disabled {
+    opacity: 0.4;
+    pointer-events: none;
+  }
+}
+
+.field-label {
+  font-size: $font-size-label-lg;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: $text-muted;
+}
+
+.required-mark {
+  color: $color-critical;
+  margin-left: 2px;
+}
+
+.select-wrap {
+  position: relative;
+
+  .select-arrow {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: $text-secondary;
+    pointer-events: none;
+    font-size: 12px;
+  }
+}
+
+.select-field {
+  width: 100%;
+  padding: 10px 36px 10px 12px;
+  background: $surface-container;
+  border: 0;
+  border-bottom: 2px solid $border-color;
+  border-radius: $radius-sm $radius-sm 0 0;
+  color: $text-primary;
+  font-size: $font-size-body-md;
+  font-family: $font-family;
+  appearance: none;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+
+  &:focus {
+    outline: none;
+    border-bottom-color: $color-success;
+    background: $surface-container-high;
+  }
+
+  option {
+    background: $bg-tertiary;
+    color: $text-primary;
+  }
+
+  &:disabled { cursor: not-allowed; }
+}
+
+.text-field {
+  width: 100%;
+  padding: 10px 12px;
+  background: $surface-container;
+  border: 0;
+  border-bottom: 2px solid $border-color;
+  border-radius: $radius-sm $radius-sm 0 0;
+  color: $text-primary;
+  font-size: $font-size-body-md;
+  font-family: $font-family;
+  box-sizing: border-box;
+  transition: border-color 0.15s, background 0.15s;
+
+  &::placeholder { color: $text-muted; }
+
+  &:focus {
+    outline: none;
+    border-bottom-color: $color-success;
+    background: $surface-container-high;
+  }
+}
+
+// ── Save button ───────────────────────────────────────────────────────────────
+.btn-save {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: $spacing-sm;
+  padding: 14px $spacing-lg;
+  background: linear-gradient(180deg, rgba($color-success, 0.22) 0%, rgba($color-success, 0.12) 100%);
+  border: 1px solid rgba($color-success, 0.4);
+  border-top-color: rgba($color-success, 0.55);
+  border-radius: $radius-sm;
+  color: $color-success;
+  font-size: $font-size-body-lg;
+  font-weight: 700;
+  font-family: $font-family;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: linear-gradient(180deg, rgba($color-success, 0.3) 0%, rgba($color-success, 0.18) 100%);
+    box-shadow: 0 0 14px rgba($color-success, 0.2);
+  }
+
+  &:disabled {
+    opacity: 0.32;
+    cursor: not-allowed;
+    box-shadow: none;
+  }
+}
+
+.btn-secondary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px $spacing-lg;
+  background: transparent;
+  border: 1px solid $border-color;
+  border-radius: $radius-sm;
+  color: $text-secondary;
+  font-size: $font-size-body-md;
+  font-weight: 600;
+  font-family: $font-family;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+
+  &:hover {
+    border-color: $text-secondary;
+    color: $text-primary;
+  }
+}
+
+// ── Hint ──────────────────────────────────────────────────────────────────────
+.hint {
+  margin: 0;
+  font-size: $font-size-label-lg;
+  color: $text-muted;
+  text-align: center;
+}
+
+// ── Success state ─────────────────────────────────────────────────────────────
+.mvs-success {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-md;
+  padding: $spacing-md;
+  background: rgba($color-success, 0.08);
+  border: 1px solid rgba($color-success, 0.3);
+  border-left: 3px solid $color-success;
+  border-radius: $radius-sm;
+
+  .success-icon {
+    font-size: 18px;
+    color: $color-success;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  .success-title {
+    margin: 0 0 4px;
+    font-size: $font-size-body-md;
+    font-weight: 700;
+    color: $color-success;
+  }
+
+  .success-body {
+    margin: 0;
+    font-size: $font-size-body-md;
+    color: $text-secondary;
+    line-height: 1.5;
+  }
+}
+
+// ── Error state ───────────────────────────────────────────────────────────────
+.mvs-error {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  padding: $spacing-sm $spacing-md;
+  background: rgba($color-critical, 0.08);
+  border: 1px solid rgba($color-critical, 0.3);
+  border-radius: $radius-sm;
+  font-size: $font-size-body-md;
+  color: $color-critical;
+
+  .error-icon {
+    font-size: 12px;
+    flex-shrink: 0;
+  }
+}

--- a/src/app/features/vehicle-profile/manual-vehicle-setup.component.ts
+++ b/src/app/features/vehicle-profile/manual-vehicle-setup.component.ts
@@ -1,0 +1,90 @@
+import { Component, Input, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { VehicleProfileService } from '../../core/vehicle/vehicle-profile.service';
+import { VehicleProfile } from '../../core/models/vehicle-profile.model';
+import { MAKE_NAMES, getModelsForMake, getYearRange } from '../../core/vehicle/vehicle-data';
+
+type FuelOption = { value: VehicleProfile['fuelType']; label: string };
+
+@Component({
+  selector: 'app-manual-vehicle-setup',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './manual-vehicle-setup.component.html',
+  styleUrls: ['./manual-vehicle-setup.component.scss'],
+})
+export class ManualVehicleSetupComponent {
+  @Input() vin?: string;
+  @Input() vinPattern?: string;
+
+  private vehicleService = inject(VehicleProfileService);
+
+  readonly makes = MAKE_NAMES;
+  readonly years = getYearRange();
+  readonly fuelOptions: FuelOption[] = [
+    { value: 'unknown',  label: 'Unknown' },
+    { value: 'petrol',   label: 'Petrol' },
+    { value: 'diesel',   label: 'Diesel' },
+    { value: 'hybrid',   label: 'Hybrid' },
+    { value: 'electric', label: 'Electric (EV)' },
+  ];
+
+  selectedMake     = '';
+  selectedModel    = '';
+  selectedYear: number | null = null;
+  selectedEngine   = '';
+  selectedFuelType: VehicleProfile['fuelType'] = 'unknown';
+  selectedProtocol = '';
+
+  saveState: 'idle' | 'success' | 'error' = 'idle';
+  errorMessage = '';
+
+  get models(): string[] {
+    return this.selectedMake ? getModelsForMake(this.selectedMake) : [];
+  }
+
+  get canSave(): boolean {
+    return !!(this.selectedMake && this.selectedModel && this.selectedFuelType);
+  }
+
+  onMakeChange(): void {
+    this.selectedModel = '';
+  }
+
+  save(): void {
+    if (!this.canSave) return;
+
+    try {
+      this.vehicleService.saveConfirmedProfile(
+        {
+          make: this.selectedMake,
+          model: this.selectedModel,
+          year: this.selectedYear ?? 0,
+          trimVariant: '',
+          engineSize: this.selectedEngine,
+          fuelType: this.selectedFuelType,
+          transmission: 'unknown',
+          detectedProtocol: this.selectedProtocol || undefined,
+        },
+        this.vin,
+        this.vinPattern,
+      );
+      this.saveState = 'success';
+    } catch {
+      this.saveState = 'error';
+      this.errorMessage = 'Failed to save vehicle profile. Please try again.';
+    }
+  }
+
+  reset(): void {
+    this.selectedMake     = '';
+    this.selectedModel    = '';
+    this.selectedYear     = null;
+    this.selectedEngine   = '';
+    this.selectedFuelType = 'unknown';
+    this.selectedProtocol = '';
+    this.saveState        = 'idle';
+    this.errorMessage     = '';
+  }
+}

--- a/src/app/features/vehicle-profile/vehicle-profile-page.component.html
+++ b/src/app/features/vehicle-profile/vehicle-profile-page.component.html
@@ -156,4 +156,11 @@
     </div>
   </div>
 
+  <!-- ── Manual vehicle setup (shown when VIN is not resolved) ─────────── -->
+  <app-manual-vehicle-setup
+    *ngIf="showManualSetup"
+    [vin]="pendingVin"
+    [vinPattern]="pendingVinPattern">
+  </app-manual-vehicle-setup>
+
 </div>

--- a/src/app/features/vehicle-profile/vehicle-profile-page.component.ts
+++ b/src/app/features/vehicle-profile/vehicle-profile-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -13,15 +13,16 @@ import {
   ConnectionProfile,
   deriveConnectionProfile,
 } from '../../core/vehicle/connection-profile';
+import { ManualVehicleSetupComponent } from './manual-vehicle-setup.component';
 
 @Component({
   selector: 'app-vehicle-profile-page',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, ManualVehicleSetupComponent],
   templateUrl: './vehicle-profile-page.component.html',
   styleUrls: ['./vehicle-profile-page.component.scss'],
 })
-export class VehicleProfilePageComponent {
+export class VehicleProfilePageComponent implements OnInit {
   private vehicleService = inject(VehicleProfileService);
   private router = inject(Router);
 
@@ -31,6 +32,20 @@ export class VehicleProfilePageComponent {
   selectedMake = '';
   selectedModel = '';
   selectedYear: number | null = null;
+
+  activeProfile: VehicleProfile | null = null;
+
+  get showManualSetup(): boolean {
+    return !this.activeProfile?.vin;
+  }
+
+  get pendingVin(): string | undefined {
+    return this.activeProfile?.vin;
+  }
+
+  get pendingVinPattern(): string | undefined {
+    return this.activeProfile?.vinPattern;
+  }
 
   get models(): string[] {
     return this.selectedMake ? getModelsForMake(this.selectedMake) : [];
@@ -79,6 +94,7 @@ export class VehicleProfilePageComponent {
 
   ngOnInit(): void {
     const profile = this.vehicleService.getActiveProfile();
+    this.activeProfile = profile;
     if (profile) {
       this.selectedMake = profile.make;
       this.selectedModel = profile.model;


### PR DESCRIPTION
## Summary

- Adds `ManualVehicleSetupComponent` shown on the Vehicle Setup page when no VIN is resolved
- Extends `VehicleProfile` model with `source`, `reviewStatus`, and `vinPattern` fields
- Adds `saveConfirmedProfile()` to `VehicleProfileService` so user-entered details are stored with `source: 'user_confirmed'` and `reviewStatus: 'verified'`

## UI Flow

1. User lands on `/vehicle-profile`
2. If no VIN is present on the active profile, the **Manual Vehicle Setup** panel appears below the main form with the banner: _"Vehicle not found. Select details manually and we'll remember it for future diagnosis."_
3. User fills in Make (required), Model (required), Year (optional), Engine (optional), Fuel Type (required — defaults to "Unknown"), and OBD Protocol (optional)
4. On save, `VehicleProfileService.saveConfirmedProfile()` is called; a success message appears: _"Vehicle profile saved. We'll remember this vehicle for future diagnosis."_
5. If save throws, an error banner is shown; the counter is never incremented

## Files Changed

| File | Change |
|------|--------|
| `src/app/core/models/vehicle-profile.model.ts` | Added `source`, `reviewStatus`, `vinPattern` optional fields |
| `src/app/core/vehicle/vehicle-profile.service.ts` | Added `saveConfirmedProfile()` method |
| `src/app/features/vehicle-profile/manual-vehicle-setup.component.ts` | New standalone component |
| `src/app/features/vehicle-profile/manual-vehicle-setup.component.html` | New template |
| `src/app/features/vehicle-profile/manual-vehicle-setup.component.scss` | New styles using design system tokens |
| `src/app/features/vehicle-profile/vehicle-profile-page.component.ts` | Imports and embeds `ManualVehicleSetupComponent`; tracks `activeProfile` |
| `src/app/features/vehicle-profile/vehicle-profile-page.component.html` | Adds `<app-manual-vehicle-setup>` guarded by `*ngIf="showManualSetup"` |

## How VehicleProfileService Is Used

`saveConfirmedProfile()` (new) takes the partial profile object plus optional `vin` and `vinPattern` arguments. It always sets:
- `source: 'user_confirmed'`
- `reviewStatus: 'verified'`
- Preserves existing `id` and `createdAt` if a profile already exists

VIN and VIN pattern are pulled from `@Input()` bindings on the component — so when Phase 3 adds VIN decoding, the resolved values flow in automatically.

## Validation Behaviour

- **Make** and **Model** are required (dropdowns); the Save button is disabled until both are set
- **Fuel Type** is required but pre-selected to `unknown`, so it is always valid
- **Year**, **Engine**, and **OBD Protocol** are optional
- A `required-mark` (`*`) on labels signals required fields to the user
- Error state surfaces any unexpected exception from the service as an inline banner

## Build Result

```
Application bundle generation complete. [12.928 seconds]
```

Clean build, no type errors. Budget warning is pre-existing and unrelated to these changes.