### PR TITLE
feat: integrate VIN lookup with vehicle intelligence database

### DIFF
--- a/src/app/core/vehicle/vehicle-identification.service.ts
+++ b/src/app/core/vehicle/vehicle-identification.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, OnDestroy, inject } from '@angular/core';
+import { BehaviorSubject, Subscription } from 'rxjs';
+import { AdapterSwitcherService } from '../adapters/adapter-switcher.service';
+import { VehicleProfileService } from './vehicle-profile.service';
+import { VehicleIntelligenceService } from './vehicle-intelligence.service';
+import { VehicleProfile } from '../models/vehicle-profile.model';
+import { VehicleIntelligenceProfile } from './vehicle-intelligence.models';
+
+export type VehicleIdentificationSource = 'local' | 'vin_lookup' | 'vin_pattern';
+
+export type VehicleIdentificationState =
+  | { status: 'loading' }
+  | { status: 'found'; make: string; model: string; year?: number; fuelType?: string; source: VehicleIdentificationSource }
+  | { status: 'not_found'; vin: string; vinPattern: string }
+  | { status: 'vin_unavailable' };
+
+@Injectable({ providedIn: 'root' })
+export class VehicleIdentificationService implements OnDestroy {
+  private readonly adapter = inject(AdapterSwitcherService);
+  private readonly vehicleProfiles = inject(VehicleProfileService);
+  private readonly vehicleIntelligence = inject(VehicleIntelligenceService);
+
+  private readonly sub: Subscription;
+
+  readonly state$ = new BehaviorSubject<VehicleIdentificationState>({ status: 'loading' });
+
+  constructor() {
+    this.sub = this.adapter.vinInfo$.subscribe(vinInfo => {
+      if (vinInfo === null) {
+        this.state$.next({ status: 'vin_unavailable' });
+      } else {
+        void this.identify(vinInfo.vin);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.sub.unsubscribe();
+  }
+
+  private async identify(vin: string): Promise<void> {
+    this.state$.next({ status: 'loading' });
+    const vinPattern = vin.substring(0, 8);
+
+    // 1. Local cache hit — skip network if VIN already confirmed
+    const local = this.vehicleProfiles.getActiveProfile();
+    if (local?.vin === vin) {
+      this.state$.next({
+        status: 'found',
+        make: local.make,
+        model: local.model,
+        year: local.year || undefined,
+        fuelType: local.fuelType,
+        source: 'local',
+      });
+      return;
+    }
+
+    // 2. Exact VIN lookup in Firestore
+    const byVin = await this.vehicleIntelligence.getProfileByVin(vin);
+    if (byVin) {
+      this.cacheFirestoreProfile(byVin, vin, vinPattern, 'vin_lookup');
+      this.state$.next({
+        status: 'found',
+        make: byVin.make,
+        model: byVin.model,
+        year: byVin.year,
+        fuelType: byVin.fuelType,
+        source: 'vin_lookup',
+      });
+      return;
+    }
+
+    // 3. VIN pattern lookup in Firestore
+    const byPattern = await this.vehicleIntelligence.getProfileByVinPattern(vinPattern);
+    if (byPattern) {
+      this.cacheFirestoreProfile(byPattern, vin, vinPattern, 'vin_pattern');
+      this.state$.next({
+        status: 'found',
+        make: byPattern.make,
+        model: byPattern.model,
+        year: byPattern.year,
+        fuelType: byPattern.fuelType,
+        source: 'vin_pattern',
+      });
+      return;
+    }
+
+    // 4. No profile found anywhere
+    this.state$.next({ status: 'not_found', vin, vinPattern });
+  }
+
+  private cacheFirestoreProfile(
+    profile: VehicleIntelligenceProfile,
+    vin: string,
+    vinPattern: string,
+    source: 'vin_lookup' | 'vin_pattern',
+  ): void {
+    const now = Date.now();
+    this.vehicleProfiles.saveProfile({
+      id: 'veh_' + now,
+      make: profile.make,
+      model: profile.model,
+      year: profile.year ?? 0,
+      trimVariant: '',
+      engineSize: profile.engine ?? '',
+      fuelType: (profile.fuelType as VehicleProfile['fuelType']) ?? 'unknown',
+      transmission: 'unknown',
+      vin,
+      vinPattern,
+      detectedProtocol: profile.protocol,
+      source,
+      reviewStatus: 'unreviewed',
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+}

--- a/src/app/core/vehicle/vehicle-identification.service.ts
+++ b/src/app/core/vehicle/vehicle-identification.service.ts
@@ -22,11 +22,17 @@ export class VehicleIdentificationService implements OnDestroy {
 
   private readonly sub: Subscription;
 
+  // Tracks which VIN the current in-flight lookup is for. Set to null when the
+  // adapter emits null. Any await that completes and finds activeVin !== the VIN
+  // it started with discards its result without writing state or localStorage.
+  private activeVin: string | null = null;
+
   readonly state$ = new BehaviorSubject<VehicleIdentificationState>({ status: 'loading' });
 
   constructor() {
     this.sub = this.adapter.vinInfo$.subscribe(vinInfo => {
       if (vinInfo === null) {
+        this.activeVin = null;
         this.state$.next({ status: 'vin_unavailable' });
       } else {
         void this.identify(vinInfo.vin);
@@ -39,12 +45,14 @@ export class VehicleIdentificationService implements OnDestroy {
   }
 
   private async identify(vin: string): Promise<void> {
+    this.activeVin = vin;
     this.state$.next({ status: 'loading' });
     const vinPattern = vin.substring(0, 8);
 
     // 1. Local cache hit — skip network if VIN already confirmed
     const local = this.vehicleProfiles.getActiveProfile();
     if (local?.vin === vin) {
+      if (this.activeVin !== vin) return;
       this.state$.next({
         status: 'found',
         make: local.make,
@@ -58,6 +66,7 @@ export class VehicleIdentificationService implements OnDestroy {
 
     // 2. Exact VIN lookup in Firestore
     const byVin = await this.vehicleIntelligence.getProfileByVin(vin);
+    if (this.activeVin !== vin) return;
     if (byVin) {
       this.cacheFirestoreProfile(byVin, vin, vinPattern, 'vin_lookup');
       this.state$.next({
@@ -73,6 +82,7 @@ export class VehicleIdentificationService implements OnDestroy {
 
     // 3. VIN pattern lookup in Firestore
     const byPattern = await this.vehicleIntelligence.getProfileByVinPattern(vinPattern);
+    if (this.activeVin !== vin) return;
     if (byPattern) {
       this.cacheFirestoreProfile(byPattern, vin, vinPattern, 'vin_pattern');
       this.state$.next({

--- a/src/app/features/vehicle-profile/manual-vehicle-setup.component.html
+++ b/src/app/features/vehicle-profile/manual-vehicle-setup.component.html
@@ -4,7 +4,7 @@
   <div class="mvs-banner">
     <span class="banner-icon">⚠</span>
     <span class="banner-text">
-      Vehicle not found. Select details manually and we'll remember it for future diagnosis.
+      {{ bannerText ?? "Vehicle not found. Select details manually and we'll remember it for future diagnosis." }}
     </span>
   </div>
 

--- a/src/app/features/vehicle-profile/manual-vehicle-setup.component.ts
+++ b/src/app/features/vehicle-profile/manual-vehicle-setup.component.ts
@@ -19,6 +19,7 @@ type FuelOption = { value: FuelType; label: string };
 export class ManualVehicleSetupComponent {
   @Input() vin?: string;
   @Input() vinPattern?: string;
+  @Input() bannerText?: string;
 
   private vehicleService = inject(VehicleProfileService);
   private vehicleIntelligence = inject(VehicleIntelligenceService);

--- a/src/app/features/vehicle-profile/vehicle-profile-page.component.html
+++ b/src/app/features/vehicle-profile/vehicle-profile-page.component.html
@@ -14,6 +14,45 @@
     </div>
   </header>
 
+  <!-- ── VIN Identification ───────────────────────────────────────────── -->
+  <div class="vin-id-section">
+
+    <!-- Loading -->
+    <div class="vin-id-card vin-id-card--loading" *ngIf="idState.status === 'loading'">
+      <span class="vin-spinner"></span>
+      <span class="vin-id-label">Identifying vehicle via VIN…</span>
+    </div>
+
+    <!-- Found -->
+    <div class="vin-id-card vin-id-card--found" *ngIf="idState.status === 'found'">
+      <span class="led-dot led-green"></span>
+      <div class="vin-id-body">
+        <p class="vin-id-source">{{ foundSourceLabel }}</p>
+        <p class="vin-id-vehicle">
+          {{ idState.make }} {{ idState.model }}<ng-container *ngIf="idState.year"> · {{ idState.year }}</ng-container>
+        </p>
+        <p class="vin-id-fuel" *ngIf="idState.fuelType && idState.fuelType !== 'unknown'">
+          {{ idState.fuelType | titlecase }}
+        </p>
+      </div>
+    </div>
+
+    <!-- Not found — VIN detected but no profile match -->
+    <app-manual-vehicle-setup
+      *ngIf="idState.status === 'not_found'"
+      [vin]="notFoundVin"
+      [vinPattern]="notFoundVinPattern"
+      bannerText="VIN detected but not found in the database. Enter details manually and we'll remember this vehicle.">
+    </app-manual-vehicle-setup>
+
+    <!-- VIN unavailable — no VIN from adapter -->
+    <app-manual-vehicle-setup
+      *ngIf="idState.status === 'vin_unavailable'"
+      bannerText="VIN unavailable. Enter vehicle details manually and we'll remember them for future diagnosis.">
+    </app-manual-vehicle-setup>
+
+  </div>
+
   <!-- ── Two-column layout ───────────────────────────────────────────── -->
   <div class="vp-grid">
 
@@ -155,12 +194,5 @@
 
     </div>
   </div>
-
-  <!-- ── Manual vehicle setup (shown when VIN is not resolved) ─────────── -->
-  <app-manual-vehicle-setup
-    *ngIf="showManualSetup"
-    [vin]="pendingVin"
-    [vinPattern]="pendingVinPattern">
-  </app-manual-vehicle-setup>
 
 </div>

--- a/src/app/features/vehicle-profile/vehicle-profile-page.component.scss
+++ b/src/app/features/vehicle-profile/vehicle-profile-page.component.scss
@@ -329,6 +329,79 @@
   }
 }
 
+// ── VIN Identification ────────────────────────────────────────────────────────
+.vin-id-section {
+  // No wrapper padding needed; child cards/ManualVehicleSetup carry their own
+}
+
+.vin-id-card {
+  display: flex;
+  align-items: center;
+  gap: $spacing-md;
+  padding: $spacing-md $spacing-lg;
+  border-radius: $radius-md;
+  border: 1px solid $border-color;
+
+  &--loading {
+    background: $bg-secondary;
+    color: $text-muted;
+    font-size: $font-size-body-md;
+  }
+
+  &--found {
+    background: rgba($color-success, 0.06);
+    border-color: rgba($color-success, 0.25);
+  }
+}
+
+.vin-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba($text-muted, 0.3);
+  border-top-color: $text-muted;
+  border-radius: $radius-full;
+  animation: vin-spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes vin-spin {
+  to { transform: rotate(360deg); }
+}
+
+.vin-id-label {
+  font-size: $font-size-body-md;
+  color: $text-muted;
+}
+
+.vin-id-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.vin-id-source {
+  margin: 0;
+  font-size: $font-size-label-sm;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: $color-success;
+}
+
+.vin-id-vehicle {
+  margin: 0;
+  font-size: $font-size-body-lg;
+  font-weight: 600;
+  color: $text-primary;
+}
+
+.vin-id-fuel {
+  margin: 0;
+  font-size: $font-size-body-md;
+  color: $text-secondary;
+}
+
 // ── Empty state ───────────────────────────────────────────────────────────────
 .preview-empty {
   flex: 1;

--- a/src/app/features/vehicle-profile/vehicle-profile-page.component.ts
+++ b/src/app/features/vehicle-profile/vehicle-profile-page.component.ts
@@ -1,8 +1,10 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
+import { Subscription } from 'rxjs';
 import { VehicleProfileService } from '../../core/vehicle/vehicle-profile.service';
+import { VehicleIdentificationService, VehicleIdentificationState } from '../../core/vehicle/vehicle-identification.service';
 import { VehicleProfile } from '../../core/models/vehicle-profile.model';
 import {
   MAKE_NAMES,
@@ -22,9 +24,12 @@ import { ManualVehicleSetupComponent } from './manual-vehicle-setup.component';
   templateUrl: './vehicle-profile-page.component.html',
   styleUrls: ['./vehicle-profile-page.component.scss'],
 })
-export class VehicleProfilePageComponent implements OnInit {
+export class VehicleProfilePageComponent implements OnInit, OnDestroy {
   private vehicleService = inject(VehicleProfileService);
+  private vehicleIdentification = inject(VehicleIdentificationService);
   private router = inject(Router);
+
+  private idSub?: Subscription;
 
   readonly makes = MAKE_NAMES;
   readonly years = getYearRange();
@@ -34,18 +39,7 @@ export class VehicleProfilePageComponent implements OnInit {
   selectedYear: number | null = null;
 
   activeProfile: VehicleProfile | null = null;
-
-  get showManualSetup(): boolean {
-    return !this.activeProfile?.vin;
-  }
-
-  get pendingVin(): string | undefined {
-    return this.activeProfile?.vin;
-  }
-
-  get pendingVinPattern(): string | undefined {
-    return this.activeProfile?.vinPattern;
-  }
+  idState: VehicleIdentificationState = { status: 'loading' };
 
   get models(): string[] {
     return this.selectedMake ? getModelsForMake(this.selectedMake) : [];
@@ -60,6 +54,23 @@ export class VehicleProfilePageComponent implements OnInit {
 
   get canConnect(): boolean {
     return !!(this.selectedMake && this.selectedModel && this.selectedYear);
+  }
+
+  get foundSourceLabel(): string {
+    if (this.idState.status !== 'found') return '';
+    switch (this.idState.source) {
+      case 'local':       return 'Saved locally';
+      case 'vin_lookup':  return 'Matched via VIN';
+      case 'vin_pattern': return 'Matched via VIN pattern';
+    }
+  }
+
+  get notFoundVin(): string {
+    return this.idState.status === 'not_found' ? this.idState.vin : '';
+  }
+
+  get notFoundVinPattern(): string {
+    return this.idState.status === 'not_found' ? this.idState.vinPattern : '';
   }
 
   onMakeChange(): void {
@@ -100,5 +111,13 @@ export class VehicleProfilePageComponent implements OnInit {
       this.selectedModel = profile.model;
       this.selectedYear = profile.year;
     }
+
+    this.idSub = this.vehicleIdentification.state$.subscribe(state => {
+      this.idState = state;
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.idSub?.unsubscribe();
   }
 }


### PR DESCRIPTION
## Summary

- Adds `VehicleIdentificationService` — a 4-step lookup chain that fires on every VIN emission from the OBD adapter: **local cache → Firestore exact VIN → Firestore VIN pattern → manual fallback**
- Firestore hits are persisted to localStorage via `VehicleProfileService.saveProfile()` with `source: 'vin_lookup'` or `'vin_pattern'` so the next app load is a cache hit
- `VehicleProfilePageComponent` subscribes to the new service's `state$` observable and renders: a green *Matched* card when found, a spinner while loading, or the `ManualVehicleSetupComponent` with context-appropriate copy when not found or VIN unavailable
- `ManualVehicleSetupComponent` gains a `bannerText` `@Input()` so callers can override the default banner without touching the component logic

## State machine

| `status`          | UI shown                                                    |
|-------------------|-------------------------------------------------------------|
| `loading`         | Spinner + "Identifying vehicle via VIN…"                    |
| `found`           | Green card with make/model/year + source badge              |
| `not_found`       | `ManualVehicleSetupComponent` — VIN passed as input         |
| `vin_unavailable` | `ManualVehicleSetupComponent` — no VIN, generic copy        |

## Test plan

- [ ] Simulator mode: `vinInfo$` emits `{ vin: 'SIM00000000000000' }` → triggers lookup chain; no Firestore record → `not_found` state shows manual setup with VIN pre-wired
- [ ] After saving a profile via manual setup, reload page → local cache hit → `found` card shows immediately without network call
- [ ] Real ELM327 with a VIN that has a Firestore record → `found` card shows with "Matched via VIN" source badge
- [ ] Adapter emits `null` VIN → `vin_unavailable` banner renders
- [ ] Build: `npm run build` passes with zero errors