### PR TITLE
Add ChatGPT → Claude Code automation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ Thumbs.db
 functions/node_modules
 functions/lib
 functions/.env*
+
+# ChatGPT automation
+scripts/.chatgpt-session.json
+scripts/node_modules/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,54 @@
+# ChatGPT → Claude Code Automation
+
+Fetches the next task prompt from your ChatGPT Project and hands it off to the `claude` CLI automatically.
+
+## First-time setup (run once)
+
+```bash
+cd scripts
+npm install
+npm run setup        # downloads Chromium for Playwright
+```
+
+## Configure
+
+Edit `config.json`:
+
+```json
+{
+  "chatgptProjectUrl": "https://chatgpt.com/c/YOUR-CONVERSATION-ID"
+}
+```
+
+Paste the URL from your browser's address bar while the ChatGPT Project conversation is open.
+
+## Run
+
+```bash
+# From the scripts/ folder:
+
+node chatgpt-to-claude.js           # fetch next task → run Claude → tell ChatGPT "done"
+node chatgpt-to-claude.js --fetch   # fetch prompt only, print it, don't run Claude
+node chatgpt-to-claude.js --loop    # keep looping until ChatGPT says all tasks are done
+```
+
+## First run — login
+
+On the first run a browser window opens. Log into ChatGPT normally. The session is saved to `.chatgpt-session.json` so you won't need to log in again.
+
+## How the loop works
+
+1. Script navigates to your ChatGPT Project URL
+2. Sends the configured `nextTaskPrompt` ("What is the next task…")
+3. ChatGPT replies with the raw task prompt
+4. `claude` CLI is launched with that prompt (full interactive output in your terminal)
+5. After Claude finishes, script sends `"Done. What's next?"` to ChatGPT so it advances its internal state
+6. In `--loop` mode, repeats from step 2
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `config.json` | URL, prompts, and behaviour settings |
+| `.chatgpt-session.json` | Saved browser session (gitignored) |
+| `chatgpt-to-claude.js` | The automation script |

--- a/scripts/chatgpt-to-claude.js
+++ b/scripts/chatgpt-to-claude.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * ChatGPT → Claude Code automation
+ *
+ * Usage:
+ *   node chatgpt-to-claude.js          # fetch next task and run claude
+ *   node chatgpt-to-claude.js --fetch  # fetch only, print prompt, don't run claude
+ *   node chatgpt-to-claude.js --loop   # keep going: fetch → claude → done → repeat
+ */
+
+const { chromium } = require('playwright');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const COOKIES_FILE = path.join(__dirname, '.chatgpt-session.json');
+const config = JSON.parse(fs.readFileSync(path.join(__dirname, 'config.json'), 'utf8'));
+
+const FETCH_ONLY = process.argv.includes('--fetch');
+const LOOP_MODE = process.argv.includes('--loop');
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function ask(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => rl.question(question, ans => { rl.close(); resolve(ans); }));
+}
+
+function saveCookies(cookies) {
+  fs.writeFileSync(COOKIES_FILE, JSON.stringify(cookies, null, 2));
+}
+
+function loadCookies() {
+  if (fs.existsSync(COOKIES_FILE)) {
+    return JSON.parse(fs.readFileSync(COOKIES_FILE, 'utf8'));
+  }
+  return null;
+}
+
+// ─── ChatGPT interaction ─────────────────────────────────────────────────────
+
+async function ensureLoggedIn(page, context) {
+  await page.goto('https://chatgpt.com', { waitUntil: 'domcontentloaded' });
+
+  // If redirected to auth, wait for the user to log in manually
+  if (page.url().includes('/auth') || page.url().includes('login')) {
+    console.log('\n⚠️  Not logged in. Browser window is open — please log in to ChatGPT.');
+    console.log('   The script will continue automatically once you are logged in.\n');
+    await page.waitForURL(url => !url.includes('/auth') && !url.includes('login'), {
+      timeout: 120_000,
+    });
+    const cookies = await context.cookies();
+    saveCookies(cookies);
+    console.log('✅ Session saved to .chatgpt-session.json\n');
+  }
+}
+
+async function sendMessage(page, message) {
+  // Focus the input — ChatGPT uses a contenteditable div
+  const input = page.locator('#prompt-textarea, div[contenteditable="true"]').first();
+  await input.click();
+  await input.fill('');
+  await page.keyboard.type(message, { delay: 20 });
+
+  // Submit
+  await page.keyboard.press('Enter');
+}
+
+async function waitForResponse(page) {
+  console.log('⏳ Waiting for ChatGPT response...');
+
+  // Wait until the "Stop generating" button appears then disappears
+  try {
+    await page.locator('button[data-testid="stop-button"]').waitFor({ state: 'visible', timeout: 15_000 });
+  } catch {
+    // Already done generating very quickly
+  }
+  await page.locator('button[data-testid="stop-button"]').waitFor({ state: 'hidden', timeout: 120_000 });
+
+  // Small settle delay
+  await page.waitForTimeout(800);
+
+  // Grab the last assistant message
+  const messages = page.locator('[data-message-author-role="assistant"]');
+  const count = await messages.count();
+  if (count === 0) throw new Error('No assistant message found in the conversation.');
+
+  const lastMessage = messages.nth(count - 1);
+  const text = await lastMessage.innerText();
+  return text.trim();
+}
+
+async function navigateToProject(page) {
+  const url = config.chatgptProjectUrl;
+  if (!url || url.startsWith('PASTE_')) {
+    throw new Error(
+      'Set your ChatGPT project URL in scripts/config.json → "chatgptProjectUrl"'
+    );
+  }
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  // Wait for the composer to be ready
+  await page.locator('#prompt-textarea, div[contenteditable="true"]').first().waitFor({
+    state: 'visible',
+    timeout: 30_000,
+  });
+}
+
+// ─── Claude Code runner ──────────────────────────────────────────────────────
+
+function runClaude(prompt) {
+  console.log('\n─────────────────────────────────────────────');
+  console.log('🤖 Handing off to Claude Code…');
+  console.log('─────────────────────────────────────────────\n');
+
+  // Inherit stdio so the user sees full interactive Claude output
+  const result = spawnSync('claude', [prompt], {
+    stdio: 'inherit',
+    cwd: path.join(__dirname, '..'),
+    shell: false,
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to run claude: ${result.error.message}`);
+  }
+
+  return result.status === 0;
+}
+
+// ─── main loop ───────────────────────────────────────────────────────────────
+
+async function main() {
+  const browser = await chromium.launch({ headless: config.headless });
+  const context = await browser.newContext();
+
+  // Restore saved session if available
+  const savedCookies = loadCookies();
+  if (savedCookies) {
+    await context.addCookies(savedCookies);
+    console.log('🔑 Loaded saved session.\n');
+  }
+
+  const page = await context.newPage();
+
+  try {
+    await ensureLoggedIn(page, context);
+    await navigateToProject(page);
+
+    let iteration = 0;
+
+    do {
+      iteration++;
+      if (LOOP_MODE) console.log(`\n══════════ Task #${iteration} ══════════`);
+
+      // 1. Ask ChatGPT for the next task
+      console.log('💬 Asking ChatGPT for the next task…');
+      await sendMessage(page, config.nextTaskPrompt);
+      const prompt = await waitForResponse(page);
+
+      console.log('\n📋 Prompt received:\n');
+      console.log('  ' + prompt.split('\n').join('\n  '));
+      console.log('');
+
+      // Stop signal — ChatGPT says there's nothing left
+      if (/all (tasks|steps) (are )?complete|nothing (left|remaining)|no more tasks/i.test(prompt)) {
+        console.log('🎉 ChatGPT says all tasks are complete. Stopping.\n');
+        break;
+      }
+
+      if (FETCH_ONLY) {
+        console.log('(--fetch mode: not running Claude)\n');
+        break;
+      }
+
+      // 2. Run Claude Code with the prompt
+      const success = runClaude(prompt);
+
+      // 3. Tell ChatGPT we're done (so it advances its state)
+      if (config.autoConfirmDone) {
+        const doneMsg = success
+          ? config.doneMessage
+          : 'Claude encountered an issue with that task. Please note it and give me the next task.';
+
+        console.log(`\n💬 Sending to ChatGPT: "${doneMsg}"`);
+        await sendMessage(page, doneMsg);
+        await waitForResponse(page); // consume the acknowledgement
+      }
+
+    } while (LOOP_MODE);
+
+  } finally {
+    // Persist any refreshed cookies
+    const cookies = await context.cookies();
+    saveCookies(cookies);
+    await browser.close();
+  }
+}
+
+main().catch(err => {
+  console.error('\n❌ Error:', err.message);
+  process.exit(1);
+});

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -1,0 +1,7 @@
+{
+  "chatgptProjectUrl": "PASTE_YOUR_CHATGPT_PROJECT_URL_HERE",
+  "nextTaskPrompt": "What is the next task prompt for Claude Code? Reply with ONLY the prompt text itself — no explanation, no intro, no markdown wrapper. Just the raw prompt.",
+  "doneMessage": "Done. What's next?",
+  "headless": false,
+  "autoConfirmDone": true
+}

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -1,7 +1,7 @@
 {
   "chatgptProjectUrl": "PASTE_YOUR_CHATGPT_PROJECT_URL_HERE",
   "nextTaskPrompt": "What is the next task prompt for Claude Code? Reply with ONLY the prompt text itself — no explanation, no intro, no markdown wrapper. Just the raw prompt.",
-  "doneMessage": "Done. What's next?",
+  "doneMessage": "Done. Give me next prompt",
   "headless": false,
   "autoConfirmDone": true
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "obd-automation",
+  "version": "1.0.0",
+  "description": "ChatGPT → Claude Code automation scripts",
+  "type": "commonjs",
+  "scripts": {
+    "setup": "npx playwright install chromium",
+    "run": "node chatgpt-to-claude.js"
+  },
+  "dependencies": {
+    "playwright": "^1.44.0",
+    "dotenv": "^16.4.5"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new automation script that bridges ChatGPT Projects and the Claude Code CLI, enabling hands-off task fetching and execution in a loop. The script uses Playwright to interact with ChatGPT, extracts task prompts, and pipes them directly to the `claude` CLI for execution.

## Key Changes

- **`scripts/chatgpt-to-claude.js`** — Main automation script that:
  - Logs into ChatGPT via Playwright with session persistence (`.chatgpt-session.json`)
  - Navigates to a configured ChatGPT Project URL
  - Sends a configurable "next task" prompt and captures the response
  - Hands the prompt off to the `claude` CLI with full interactive output
  - Optionally sends a "done" confirmation back to ChatGPT to advance its state
  - Supports three modes: single run, fetch-only (print prompt, no Claude), and loop (repeat until ChatGPT says all tasks are complete)

- **`scripts/config.json`** — Configuration file with:
  - `chatgptProjectUrl` — URL of the ChatGPT Project conversation
  - `nextTaskPrompt` — Prompt to ask ChatGPT for the next task
  - `doneMessage` — Message to send after Claude finishes
  - `headless` and `autoConfirmDone` — Behaviour flags

- **`scripts/package.json`** — Dependencies and setup script:
  - Playwright for browser automation
  - `npm run setup` to download Chromium

- **`scripts/README.md`** — User guide covering setup, configuration, usage modes, and how the loop works

- **`.gitignore`** — Updated to exclude `.chatgpt-session.json` and `scripts/node_modules/`

## Implementation Details

- Uses Playwright's `chromium` browser to interact with ChatGPT's web UI
- Detects login state and prompts user to authenticate manually if needed; saves session cookies for subsequent runs
- Waits for ChatGPT's "stop generating" button to appear and disappear to ensure response is complete
- Spawns the `claude` CLI with `stdio: 'inherit'` so users see full interactive output in their terminal
- Detects completion via regex pattern matching on ChatGPT's response (e.g., "all tasks complete")
- Supports `--fetch` and `--loop` command-line flags for different workflows

https://claude.ai/code/session_01LsnbPT9iAkNC6wKLfMgwcA