### PR TITLE
fix: route diagnostic modes to dedicated pages and hide poor guided UX

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -25,6 +25,21 @@ export const routes: Routes = [
     redirectTo: 'diagnosis-assistant',
     pathMatch: 'full'
   },
+  {
+    path: 'ai-diagnosis-assistant/full',
+    redirectTo: 'diagnosis-report',
+    pathMatch: 'full'
+  },
+  {
+    path: 'ai-diagnosis-assistant/catalytic-converter',
+    loadComponent: () => import('./features/catalytic-converter/catalytic-converter-page.component')
+      .then(m => m.CatalyticConverterPageComponent)
+  },
+  {
+    path: 'ai-diagnosis-assistant/cylinder-analysis',
+    loadComponent: () => import('./features/cylinder-analysis/cylinder-analysis-page.component')
+      .then(m => m.CylinderAnalysisPageComponent)
+  },
   // ── Guided Diagnosis — pack list and per-pack runner ───────────────────────
   {
     path: 'ai-diagnosis-assistant/guided',

--- a/src/app/features/catalytic-converter/catalytic-converter-page.component.html
+++ b/src/app/features/catalytic-converter/catalytic-converter-page.component.html
@@ -1,0 +1,28 @@
+<div class="analysis-page" *ngIf="result$ | async as result">
+  <header class="analysis-header">
+    <h1>Catalytic Converter Test</h1>
+    <span class="status" [ngClass]="statusClass(result.status)">{{ statusLabel(result.status) }}</span>
+    <span class="confidence">Confidence: <strong>{{ result.confidence | titlecase }}</strong></span>
+  </header>
+
+  <p class="explanation">{{ result.explanation }}</p>
+
+  <section class="section">
+    <h2>Sensor Matching</h2>
+    <app-o2-sensor-graph></app-o2-sensor-graph>
+  </section>
+
+  <section class="section" *ngIf="result.evidence.length > 0">
+    <h2>Evidence</h2>
+    <ul>
+      <li *ngFor="let e of result.evidence">{{ e }}</li>
+    </ul>
+  </section>
+
+  <section class="section">
+    <h2>Recommendations</h2>
+    <ul>
+      <li *ngFor="let r of result.recommendations">{{ r }}</li>
+    </ul>
+  </section>
+</div>

--- a/src/app/features/catalytic-converter/catalytic-converter-page.component.scss
+++ b/src/app/features/catalytic-converter/catalytic-converter-page.component.scss
@@ -1,0 +1,24 @@
+.analysis-page {
+  padding: 1.5rem;
+}
+
+.analysis-header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.status {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.status--normal { background: #e8f5e9; color: #2e7d32; }
+.status--warning { background: #fff3e0; color: #ef6c00; }
+.status--critical { background: #ffebee; color: #c62828; }
+
+.section { margin-top: 1rem; }

--- a/src/app/features/catalytic-converter/catalytic-converter-page.component.ts
+++ b/src/app/features/catalytic-converter/catalytic-converter-page.component.ts
@@ -1,0 +1,49 @@
+import { Component, inject } from '@angular/core';
+import { AsyncPipe, NgClass, NgFor, NgIf, TitleCasePipe } from '@angular/common';
+import { Observable, combineLatest } from 'rxjs';
+import { map, throttleTime } from 'rxjs/operators';
+import { DeepDiagnosisService } from '../../core/diagnostics/deep-diagnosis.service';
+import { CatalyticConverterAnalysisService } from '../../core/diagnostics/catalytic-converter-analysis.service';
+import type { CatalyticConverterResult } from '../../core/diagnostics/catalytic-converter-analysis.service';
+import { O2SensorBufferService } from '../../core/diagnostics/o2-sensor-buffer.service';
+import { O2SensorGraphComponent } from '../../shared/components/o2-sensor-graph/o2-sensor-graph.component';
+
+@Component({
+  selector: 'app-catalytic-converter-page',
+  standalone: true,
+  imports: [AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe, O2SensorGraphComponent],
+  templateUrl: './catalytic-converter-page.component.html',
+  styleUrls: ['./catalytic-converter-page.component.scss'],
+})
+export class CatalyticConverterPageComponent {
+  private readonly deepDiagnosis = inject(DeepDiagnosisService);
+  private readonly catalyticAnalysis = inject(CatalyticConverterAnalysisService);
+  private readonly o2Buffer = inject(O2SensorBufferService);
+
+  readonly result$: Observable<CatalyticConverterResult> = combineLatest([
+    this.deepDiagnosis.state$,
+    this.o2Buffer.state$,
+  ]).pipe(
+    throttleTime(500, undefined, { leading: true, trailing: true }),
+    map(([diagState]) => this.catalyticAnalysis.analyse({
+      dtcCodes: diagState.dtcCodes ?? [],
+      o2Sensors: this.o2Buffer.buildCatalyticO2Input(1),
+    })),
+  );
+
+  statusClass(status: string): string {
+    if (status === 'normal') return 'status--normal';
+    if (status === 'mildly_degraded' || status === 'possibly_restricted') return 'status--warning';
+    if (status === 'severely_degraded' || status === 'likely_missing') return 'status--critical';
+    return '';
+  }
+
+  statusLabel(status: string): string {
+    if (status === 'normal') return 'Normal';
+    if (status === 'mildly_degraded') return 'Mild Degradation';
+    if (status === 'severely_degraded') return 'Severely Degraded';
+    if (status === 'likely_missing') return 'Likely Missing';
+    if (status === 'possibly_restricted') return 'Possibly Restricted';
+    return status;
+  }
+}

--- a/src/app/features/cylinder-analysis/cylinder-analysis-page.component.html
+++ b/src/app/features/cylinder-analysis/cylinder-analysis-page.component.html
@@ -1,0 +1,39 @@
+<div class="analysis-page" *ngIf="result$ | async as result">
+  <header class="analysis-header">
+    <h1>Cylinder Analysis</h1>
+    <span class="status" [ngClass]="'status--' + result.status">{{ result.status | titlecase }}</span>
+    <span class="confidence">Confidence: <strong>{{ result.confidence | titlecase }}</strong></span>
+  </header>
+
+  <div *ngIf="!result.hasData" class="empty">
+    No misfire data available. Run Full Diagnosis first.
+  </div>
+
+  <ng-container *ngIf="result.hasData">
+    <section class="section">
+      <h2>Affected Cylinder</h2>
+      <p>
+        {{ result.primaryCylinder !== null ? ('Cylinder ' + result.primaryCylinder) : 'Random / Multiple-Cylinder Misfire' }}
+      </p>
+    </section>
+
+    <section class="section">
+      <h2>Evidence</h2>
+      <ul>
+        <li *ngFor="let e of result.evidence">{{ e }}</li>
+      </ul>
+    </section>
+
+    <section class="section">
+      <h2>Likely Causes</h2>
+      <ul>
+        <li *ngFor="let c of result.likelyCauses">{{ CAUSE_LABELS[c] || c }}</li>
+      </ul>
+    </section>
+
+    <section class="section" *ngIf="result.recommendedNextTest">
+      <h2>Recommended Next Test</h2>
+      <p>{{ NEXT_TEST_LABELS[result.recommendedNextTest] || result.recommendedNextTest }}</p>
+    </section>
+  </ng-container>
+</div>

--- a/src/app/features/cylinder-analysis/cylinder-analysis-page.component.scss
+++ b/src/app/features/cylinder-analysis/cylinder-analysis-page.component.scss
@@ -1,0 +1,25 @@
+.analysis-page {
+  padding: 1.5rem;
+}
+
+.analysis-header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.status {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.status--low { background: #fff3e0; color: #ef6c00; }
+.status--medium { background: #e3f2fd; color: #1565c0; }
+.status--high { background: #e8f5e9; color: #2e7d32; }
+
+.section { margin-top: 1rem; }
+.empty { color: #666; }

--- a/src/app/features/cylinder-analysis/cylinder-analysis-page.component.ts
+++ b/src/app/features/cylinder-analysis/cylinder-analysis-page.component.ts
@@ -1,0 +1,36 @@
+import { Component, inject } from '@angular/core';
+import { AsyncPipe, NgClass, NgFor, NgIf, TitleCasePipe } from '@angular/common';
+import { map } from 'rxjs/operators';
+import { DeepDiagnosisService } from '../../core/diagnostics/deep-diagnosis.service';
+import { CylinderAnalysisService } from '../../core/diagnostics/cylinder-analysis.service';
+import type { CylinderAnalysisResult } from '../../core/diagnostics/cylinder-analysis.service';
+
+@Component({
+  selector: 'app-cylinder-analysis-page',
+  standalone: true,
+  imports: [AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe],
+  templateUrl: './cylinder-analysis-page.component.html',
+  styleUrls: ['./cylinder-analysis-page.component.scss'],
+})
+export class CylinderAnalysisPageComponent {
+  private readonly deepDiagnosis = inject(DeepDiagnosisService);
+  private readonly cylinderAnalysis = inject(CylinderAnalysisService);
+
+  readonly result$ = this.deepDiagnosis.state$.pipe(
+    map((state): CylinderAnalysisResult => this.cylinderAnalysis.analyse(state.dtcCodes ?? [])),
+  );
+
+  readonly CAUSE_LABELS: Record<string, string> = {
+    ignition_coil_issue: 'Ignition coil failure',
+    spark_plug_issue: 'Spark plug fault',
+    injector_issue: 'Injector malfunction',
+    wiring_or_ecu_issue: 'Wiring / ECU driver fault',
+    compression_issue: 'Low compression (mechanical)',
+    intake_leak_issue: 'Intake / vacuum leak',
+  };
+
+  readonly NEXT_TEST_LABELS: Record<string, string> = {
+    ignition_coil_swap: 'Ignition Coil Swap Test',
+    fuel_pressure_test: 'Fuel Pressure Test',
+  };
+}

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.html
@@ -1,280 +1,59 @@
 <div class="assistant-page">
-
   <header class="page-header">
     <div class="header-eyebrow">
-      <span class="eyebrow-icon">🔍</span>
+      <span class="eyebrow-icon">??</span>
       <span class="eyebrow-text">Diagnostic System</span>
     </div>
     <h1 class="page-title">AI Diagnosis Assistant</h1>
-    <p class="page-subtitle">Select a diagnostic mode to get started.</p>
+    <p class="page-subtitle">Select a diagnostic mode to continue.</p>
   </header>
 
   <div class="mode-grid">
-
-    <!-- Full Diagnosis -->
     <button class="mode-card mode-card--primary" (click)="openFullDiagnosis()">
-      <div class="card-icon-wrap card-icon-wrap--green">
-        <span class="card-icon">🔬</span>
-      </div>
+      <div class="card-icon-wrap card-icon-wrap--green"><span class="card-icon">??</span></div>
       <div class="card-body">
         <div class="card-title-row">
           <h2 class="card-title">Full Diagnosis</h2>
           <span class="card-badge card-badge--auto">AUTO</span>
         </div>
-        <p class="card-description">
-          Analyze all available DTCs, live data, freeze-frame data, and evidence automatically.
-          Best when the vehicle is connected and a fault code is present.
-        </p>
-        <ul class="card-features">
-          <li><span class="feat-dot feat-dot--green"></span>DTC code analysis</li>
-          <li><span class="feat-dot feat-dot--green"></span>Live sensor evidence</li>
-          <li><span class="feat-dot feat-dot--green"></span>AI-assisted summary</li>
-        </ul>
+        <p class="card-description">Run full DTC and sensor-based diagnosis flow.</p>
       </div>
-      <span class="card-arrow">→</span>
+      <span class="card-arrow">?</span>
     </button>
 
-    <!-- Guided Diagnosis -->
-    <button class="mode-card mode-card--secondary" (click)="openGuidedDiagnosis()">
-      <div class="card-icon-wrap card-icon-wrap--blue">
-        <span class="card-icon">▶</span>
-      </div>
-      <div class="card-body">
-        <div class="card-title-row">
-          <h2 class="card-title">Guided Diagnosis</h2>
-          <span class="card-badge card-badge--step">STEP-BY-STEP</span>
-        </div>
-        <p class="card-description">
-          Follow a step-by-step troubleshooting workflow and answer questions as you perform
-          physical checks. 9 diagnostic packs covering the most common fault categories.
-        </p>
-        <ul class="card-features">
-          <li><span class="feat-dot feat-dot--blue"></span>No-start · Misfire · Rough idle</li>
-          <li><span class="feat-dot feat-dot--blue"></span>Overheating · Battery · DPF/EGR · EV</li>
-          <li><span class="feat-dot feat-dot--blue"></span>Hypothesis scoring — mechanic questions</li>
-        </ul>
-      </div>
-      <span class="card-arrow">→</span>
-    </button>
-
-    <!-- Analyze Cylinders -->
-    <button class="mode-card mode-card--amber"
-            [class.mode-card--active]="showCylinderPanel"
-            (click)="toggleCylinderAnalysis()">
-      <div class="card-icon-wrap card-icon-wrap--amber">
-        <span class="card-icon">🔧</span>
-      </div>
-      <div class="card-body">
-        <div class="card-title-row">
-          <h2 class="card-title">Analyze Cylinders</h2>
-          <span class="card-badge card-badge--new">NEW</span>
-        </div>
-        <p class="card-description">
-          Identify which cylinder is misfiring and isolate the root cause. Uses stored DTCs
-          and misfire counters to rank affected cylinders and recommend the next test.
-        </p>
-        <ul class="card-features">
-          <li><span class="feat-dot feat-dot--amber"></span>Per-cylinder misfire detection</li>
-          <li><span class="feat-dot feat-dot--amber"></span>Component isolation</li>
-          <li><span class="feat-dot feat-dot--amber"></span>Next-test recommendation</li>
-        </ul>
-      </div>
-      <span class="card-arrow" [class.card-arrow--open]="showCylinderPanel">
-        {{ showCylinderPanel ? '↓' : '→' }}
-      </span>
-    </button>
-
-    <!-- Catalytic Converter Test -->
-    <button class="mode-card mode-card--purple"
-            [class.mode-card--active]="showCatalyticPanel"
-            (click)="toggleCatalyticAnalysis()">
-      <div class="card-icon-wrap card-icon-wrap--purple">
-        <span class="card-icon">♻</span>
-      </div>
+    <button class="mode-card mode-card--purple" (click)="openCatalyticConverter()">
+      <div class="card-icon-wrap card-icon-wrap--purple"><span class="card-icon">?</span></div>
       <div class="card-body">
         <div class="card-title-row">
           <h2 class="card-title">Catalytic Converter Test</h2>
           <span class="card-badge card-badge--new">NEW</span>
         </div>
-        <p class="card-description">
-          Assess catalytic converter health using DTC codes and O2 sensor patterns.
-          Detects degradation, restriction, and missing substrates — even without active fault codes.
-        </p>
-        <ul class="card-features">
-          <li><span class="feat-dot feat-dot--purple"></span>P0420 / P0430 code analysis</li>
-          <li><span class="feat-dot feat-dot--purple"></span>O2 sensor correlation check</li>
-          <li><span class="feat-dot feat-dot--purple"></span>Restriction &amp; missing substrate detection</li>
-        </ul>
+        <p class="card-description">Open dedicated catalytic converter analysis page.</p>
       </div>
-      <span class="card-arrow" [class.card-arrow--open]="showCatalyticPanel">
-        {{ showCatalyticPanel ? '↓' : '→' }}
-      </span>
+      <span class="card-arrow">?</span>
     </button>
 
+    <button class="mode-card mode-card--amber" (click)="openCylinderAnalysis()">
+      <div class="card-icon-wrap card-icon-wrap--amber"><span class="card-icon">??</span></div>
+      <div class="card-body">
+        <div class="card-title-row">
+          <h2 class="card-title">Cylinder Analysis</h2>
+          <span class="card-badge card-badge--new">NEW</span>
+        </div>
+        <p class="card-description">Open dedicated cylinder/misfire analysis page.</p>
+      </div>
+      <span class="card-arrow">?</span>
+    </button>
+
+    <div class="mode-card mode-card--secondary mode-card--disabled" aria-disabled="true">
+      <div class="card-icon-wrap card-icon-wrap--blue"><span class="card-icon">?</span></div>
+      <div class="card-body">
+        <div class="card-title-row">
+          <h2 class="card-title">Guided Diagnosis</h2>
+          <span class="card-badge card-badge--soon">Redesign</span>
+        </div>
+        <p class="card-description">Guided Diagnosis is being redesigned for a more practical workshop workflow.</p>
+      </div>
+    </div>
   </div>
-
-  <!-- ── Catalytic Converter Panel ───────────────────────────────────────── -->
-  <div class="catalytic-panel" *ngIf="showCatalyticPanel">
-    <ng-container *ngIf="catalyticResult$ | async as result">
-
-      <div class="cat-header">
-        <div class="cat-title-row">
-          <h3 class="cat-title">Catalytic Converter Analysis</h3>
-          <span class="cat-status-badge" [ngClass]="catalyticStatusClass(result.status)">
-            {{ catalyticStatusLabel(result.status) }}
-          </span>
-          <span class="cat-confidence">
-            Confidence: <strong>{{ result.confidence | titlecase }}</strong>
-          </span>
-        </div>
-      </div>
-
-      <p class="cat-explanation">{{ result.explanation }}</p>
-
-      <!-- Indicators -->
-      <div class="cat-indicators">
-        <div class="cat-indicator" [class.cat-indicator--active]="result.indicators.p0420Detected">
-          <span class="cat-ind-dot" [class.cat-ind-dot--red]="result.indicators.p0420Detected"></span>
-          P0420 {{ result.indicators.p0420Detected ? 'Detected' : 'Not Present' }}
-        </div>
-        <div class="cat-indicator" [class.cat-indicator--active]="result.indicators.p0430Detected">
-          <span class="cat-ind-dot" [class.cat-ind-dot--red]="result.indicators.p0430Detected"></span>
-          P0430 {{ result.indicators.p0430Detected ? 'Detected' : 'Not Present' }}
-        </div>
-        <div class="cat-indicator" [class.cat-indicator--active]="result.indicators.downstreamMirrorsUpstream">
-          <span class="cat-ind-dot" [class.cat-ind-dot--red]="result.indicators.downstreamMirrorsUpstream"></span>
-          Downstream Mirrors Upstream
-        </div>
-        <div class="cat-indicator" [class.cat-indicator--ok]="result.indicators.downstreamStable">
-          <span class="cat-ind-dot" [class.cat-ind-dot--green]="result.indicators.downstreamStable"></span>
-          Downstream Stable
-        </div>
-        <div class="cat-indicator" [class.cat-indicator--active]="result.indicators.restrictionSuspected">
-          <span class="cat-ind-dot" [class.cat-ind-dot--amber]="result.indicators.restrictionSuspected"></span>
-          Restriction Suspected
-        </div>
-      </div>
-
-      <!-- Live O2 Sensor Graph -->
-      <div class="cat-section">
-        <h4 class="cat-section-label">Live O2 Sensor Voltage</h4>
-        <app-o2-sensor-graph></app-o2-sensor-graph>
-      </div>
-
-      <!-- Evidence -->
-      <div class="cat-section" *ngIf="result.evidence.length > 0">
-        <h4 class="cat-section-label">Evidence</h4>
-        <ul class="cat-list">
-          <li *ngFor="let e of result.evidence">
-            <span class="cat-list-dot"></span>{{ e }}
-          </li>
-        </ul>
-      </div>
-
-      <!-- No evidence state -->
-      <div class="cat-no-data" *ngIf="result.evidence.length === 0">
-        <span class="cat-no-data__icon">ℹ️</span>
-        <div>
-          <p class="cat-no-data__title">No catalyst-specific data available</p>
-          <p class="cat-no-data__body">
-            Run a Full Diagnosis or connect the vehicle with active fault codes to get sensor-based evidence.
-            The analysis above is based on code absence only.
-          </p>
-        </div>
-      </div>
-
-      <!-- Recommendations -->
-      <div class="cat-section">
-        <h4 class="cat-section-label">Recommendations</h4>
-        <ul class="cat-list cat-list--recs">
-          <li *ngFor="let r of result.recommendations; let i = index">
-            <span class="cat-rank">{{ i + 1 }}</span>{{ r }}
-          </li>
-        </ul>
-      </div>
-
-    </ng-container>
-  </div>
-
-  <!-- ── Cylinder Analysis Panel ──────────────────────────────────────────── -->
-  <div class="cylinder-panel" *ngIf="showCylinderPanel">
-    <ng-container *ngIf="cylinderResult$ | async as result">
-
-      <!-- No data state -->
-      <div class="ca-no-data" *ngIf="!result.hasData">
-        <span class="ca-no-data__icon">ℹ️</span>
-        <div>
-          <p class="ca-no-data__title">No misfire data available</p>
-          <p class="ca-no-data__body">
-            Cylinder analysis requires at least one misfire DTC (P0300–P0304).
-            Run a Full Diagnosis first or connect the vehicle with active fault codes.
-          </p>
-        </div>
-      </div>
-
-      <!-- Result state -->
-      <ng-container *ngIf="result.hasData">
-
-        <div class="ca-header">
-          <div class="ca-title-row">
-            <h3 class="ca-title">
-              {{ result.primaryCylinder !== null
-                 ? 'Cylinder ' + result.primaryCylinder + ' — Primary Suspect'
-                 : 'Random / Multiple-Cylinder Misfire' }}
-            </h3>
-            <span class="ca-status-badge"
-                  [ngClass]="'ca-status-badge--' + result.status">
-              {{ result.status | titlecase }}
-            </span>
-            <span class="ca-confidence">
-              Confidence: <strong>{{ result.confidence | titlecase }}</strong>
-            </span>
-          </div>
-        </div>
-
-        <!-- Evidence -->
-        <div class="ca-section">
-          <h4 class="ca-section-label">Evidence</h4>
-          <ul class="ca-list">
-            <li *ngFor="let e of result.evidence">
-              <span class="ca-list-dot ca-list-dot--red"></span>{{ e }}
-            </li>
-          </ul>
-        </div>
-
-        <!-- Likely causes -->
-        <div class="ca-section">
-          <h4 class="ca-section-label">Likely Causes</h4>
-          <ul class="ca-list">
-            <li *ngFor="let c of result.likelyCauses; let i = index">
-              <span class="ca-rank">{{ i + 1 }}</span>
-              {{ CAUSE_LABELS[c] || c }}
-            </li>
-          </ul>
-        </div>
-
-        <!-- Recommended next test -->
-        <div class="ca-next-test" *ngIf="result.recommendedNextTest">
-          <span class="ca-next-test__label">Recommended next test</span>
-          <span class="ca-next-test__value">
-            {{ NEXT_TEST_LABELS[result.recommendedNextTest] || result.recommendedNextTest }}
-          </span>
-        </div>
-
-        <!-- Affected cylinders (when multiple) -->
-        <div class="ca-section" *ngIf="result.affectedCylinders.length > 1">
-          <h4 class="ca-section-label">All Affected Cylinders</h4>
-          <div class="ca-cylinders">
-            <span class="ca-cyl-chip"
-                  *ngFor="let c of result.affectedCylinders"
-                  [class.ca-cyl-chip--primary]="c === result.primaryCylinder">
-              Cyl {{ c }}
-            </span>
-          </div>
-        </div>
-
-      </ng-container>
-    </ng-container>
-  </div>
-
 </div>

--- a/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
+++ b/src/app/features/diagnosis-assistant/diagnosis-assistant-page.component.ts
@@ -1,103 +1,24 @@
 import { Component, inject } from '@angular/core';
-import { AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe } from '@angular/common';
 import { Router } from '@angular/router';
-import { Observable, combineLatest } from 'rxjs';
-import { map, throttleTime } from 'rxjs/operators';
-import { DeepDiagnosisService } from '../../core/diagnostics/deep-diagnosis.service';
-import { CylinderAnalysisService } from '../../core/diagnostics/cylinder-analysis.service';
-import type { CylinderAnalysisResult } from '../../core/diagnostics/cylinder-analysis.service';
-import { CatalyticConverterAnalysisService } from '../../core/diagnostics/catalytic-converter-analysis.service';
-import type { CatalyticConverterResult } from '../../core/diagnostics/catalytic-converter-analysis.service';
-import { O2SensorBufferService } from '../../core/diagnostics/o2-sensor-buffer.service';
-import { O2SensorGraphComponent } from '../../shared/components/o2-sensor-graph/o2-sensor-graph.component';
 
 @Component({
   selector: 'app-diagnosis-assistant-page',
   standalone: true,
-  imports: [AsyncPipe, NgIf, NgFor, NgClass, TitleCasePipe, O2SensorGraphComponent],
   templateUrl: './diagnosis-assistant-page.component.html',
   styleUrls: ['./diagnosis-assistant-page.component.scss'],
 })
 export class DiagnosisAssistantPageComponent {
-  private router           = inject(Router);
-  private deepDiagnosis    = inject(DeepDiagnosisService);
-  private cylinderAnalysis = inject(CylinderAnalysisService);
-  private catalyticAnalysis = inject(CatalyticConverterAnalysisService);
-  private o2Buffer         = inject(O2SensorBufferService);
-
-  // ── Panel visibility ─────────────────────────────────────────────────────────
-  showCylinderPanel  = false;
-  showCatalyticPanel = false;
-
-  // ── Observables ──────────────────────────────────────────────────────────────
-
-  readonly cylinderResult$: Observable<CylinderAnalysisResult> =
-    this.deepDiagnosis.state$.pipe(
-      map(state => this.cylinderAnalysis.analyse(state.dtcCodes ?? []))
-    );
-
-  readonly catalyticResult$: Observable<CatalyticConverterResult> = combineLatest([
-    this.deepDiagnosis.state$,
-    this.o2Buffer.state$,
-  ]).pipe(
-    throttleTime(500, undefined, { leading: true, trailing: true }),
-    map(([diagState]) => this.catalyticAnalysis.analyse({
-      dtcCodes:  diagState.dtcCodes ?? [],
-      o2Sensors: this.o2Buffer.buildCatalyticO2Input(1),
-    })),
-  );
-
-  // ── Navigation ───────────────────────────────────────────────────────────────
+  private readonly router = inject(Router);
 
   openFullDiagnosis(): void {
-    this.router.navigate(['/diagnosis-report']);
+    this.router.navigate(['/ai-diagnosis-assistant/full']);
   }
 
-  openGuidedDiagnosis(): void {
-    this.router.navigate(['/ai-diagnosis-assistant/guided']);
+  openCylinderAnalysis(): void {
+    this.router.navigate(['/ai-diagnosis-assistant/cylinder-analysis']);
   }
 
-  // ── Panel toggles ────────────────────────────────────────────────────────────
-
-  toggleCylinderAnalysis(): void {
-    this.showCylinderPanel = !this.showCylinderPanel;
+  openCatalyticConverter(): void {
+    this.router.navigate(['/ai-diagnosis-assistant/catalytic-converter']);
   }
-
-  toggleCatalyticAnalysis(): void {
-    this.showCatalyticPanel = !this.showCatalyticPanel;
-  }
-
-  // ── Catalytic helpers ────────────────────────────────────────────────────────
-
-  catalyticStatusClass(status: string): string {
-    if (status === 'normal')              return 'cat-status-badge--normal';
-    if (status === 'mildly_degraded')     return 'cat-status-badge--warning';
-    if (status === 'severely_degraded')   return 'cat-status-badge--critical';
-    if (status === 'likely_missing')      return 'cat-status-badge--critical';
-    if (status === 'possibly_restricted') return 'cat-status-badge--warning';
-    return '';
-  }
-
-  catalyticStatusLabel(status: string): string {
-    if (status === 'normal')              return 'Normal';
-    if (status === 'mildly_degraded')     return 'Mild Degradation';
-    if (status === 'severely_degraded')   return 'Severely Degraded';
-    if (status === 'likely_missing')      return 'Likely Missing';
-    if (status === 'possibly_restricted') return 'Possibly Restricted';
-    return status;
-  }
-
-  readonly CAUSE_LABELS: Record<string, string> = {
-    ignition_coil_issue: 'Ignition coil failure',
-    spark_plug_issue:    'Spark plug fault',
-    injector_issue:      'Injector malfunction',
-    wiring_or_ecu_issue: 'Wiring / ECU driver fault',
-    compression_issue:   'Low compression (mechanical)',
-    intake_leak_issue:   'Intake / vacuum leak',
-  };
-
-  readonly NEXT_TEST_LABELS: Record<string, string> = {
-    ignition_coil_swap: 'Ignition Coil Swap Test',
-    fuel_pressure_test: 'Fuel Pressure Test',
-  };
 }


### PR DESCRIPTION
## Summary
- Removed inline catalytic/cylinder rendering from AI Diagnosis Assistant hub.
- Added dedicated route navigation cards for Full Diagnosis, Catalytic Converter Test, and Cylinder Analysis.
- Kept Guided Diagnosis visible as disabled redesign notice: "Guided Diagnosis is being redesigned for a more practical workshop workflow."

## Routing changes
- Added `/ai-diagnosis-assistant/full` (redirects to diagnosis report)
- Added `/ai-diagnosis-assistant/catalytic-converter`
- Added `/ai-diagnosis-assistant/cylinder-analysis`

## Catalytic Converter route behavior
- Clicking the hub card navigates to a dedicated page with status, confidence, evidence, recommendations, and O2 graph.
- No inline panel under the hub grid.

## Cylinder Analysis route behavior
- Clicking the hub card navigates to a dedicated page with affected cylinder/misfire output, evidence, likely causes, and recommended next test.
- No inline panel under the hub grid.

## Guided diagnosis follow-up
- Existing guided packs remain in codebase/routes, but hub access is intentionally disabled until redesign.

## Build result
- `npm run build` passed.

Closes #214.
