### PR TITLE
feat: add admin DTC review queue

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -115,9 +115,21 @@ interface DtcDefinitionDoc {
   safeToDrive: boolean;
   confidence: "low" | "medium" | "high";
   source: "local" | "firebase" | "ai_generated";
-  reviewStatus: "verified" | "pending_review";
+  reviewStatus: "verified" | "pending_review" | "rejected" | "needs_research";
   createdAt: string;
   updatedAt: string;
+  reviewedAt?: string;
+  reviewedBy?: string;
+  rejectedAt?: string;
+  rejectedBy?: string;
+  rejectionReason?: string;
+  vehicleContext?: {
+    make?: string;
+    model?: string;
+    year?: string;
+    engine?: string;
+    vin?: string;
+  };
 }
 
 interface DtcLookupResponse {
@@ -130,7 +142,7 @@ interface DtcLookupResponse {
   safeToDrive: boolean;
   confidence: "low" | "medium" | "high";
   source: "firebase" | "ai_generated";
-  reviewStatus: "verified" | "pending_review";
+  reviewStatus: "verified" | "pending_review" | "rejected" | "needs_research";
 }
 
 interface DtcVehicleContext {
@@ -639,6 +651,126 @@ export const lookupDtc = onRequest(
       const msg = err instanceof Error ? err.message : "Unknown error";
       logger.error("dtc-lookup: ai call failed", { code: rawCode, reason: redactSecrets(msg) });
       response.status(200).send({ error: "AI lookup unavailable" });
+    }
+  }
+);
+
+interface DtcReviewUpdateRequest {
+  code: string;
+  action: "approve" | "reject" | "needs_research";
+  reviewedBy?: string;
+  rejectionReason?: string;
+  updates?: Partial<Pick<DtcDefinitionDoc,
+    "title" | "severity" | "description" | "commonCauses" | "recommendedChecks" | "safeToDrive">>;
+}
+
+export const listPendingDtcDefinitions = onRequest(
+  { cors: true },
+  async (request, response) => {
+    if (request.method !== "GET") {
+      response.status(405).send({ error: "Method not allowed" });
+      return;
+    }
+
+    try {
+      const snap = await db
+        .collection(DTC_COLLECTION)
+        .where("reviewStatus", "==", "pending_review")
+        .orderBy("createdAt", "desc")
+        .get();
+      const items = snap.docs.map(doc => doc.data() as DtcDefinitionDoc);
+      response.status(200).send({ items });
+    } catch (err) {
+      logger.error("dtc-review: list pending failed", { err });
+      response.status(500).send({ error: "Unable to load DTC review queue" });
+    }
+  }
+);
+
+export const reviewDtcDefinition = onRequest(
+  { cors: true },
+  async (request, response) => {
+    if (request.method !== "POST") {
+      response.status(405).send({ error: "Method not allowed" });
+      return;
+    }
+    if (!isNonNullObject(request.body)) {
+      response.status(400).send({ error: "Request body must be a JSON object" });
+      return;
+    }
+
+    const body = request.body as Record<string, unknown>;
+    const payload: DtcReviewUpdateRequest = {
+      code: typeof body["code"] === "string" ? body["code"].trim().toUpperCase() : "",
+      action: body["action"] as DtcReviewUpdateRequest["action"],
+      reviewedBy: typeof body["reviewedBy"] === "string" ? body["reviewedBy"].trim().slice(0, 120) : undefined,
+      rejectionReason: typeof body["rejectionReason"] === "string" ? body["rejectionReason"].trim().slice(0, 500) : undefined,
+      updates: isNonNullObject(body["updates"]) ? body["updates"] as DtcReviewUpdateRequest["updates"] : undefined,
+    };
+
+    if (!DTC_CODE_PATTERN.test(payload.code)) {
+      response.status(400).send({ error: "Invalid DTC code format" });
+      return;
+    }
+    if (!["approve", "reject", "needs_research"].includes(payload.action)) {
+      response.status(400).send({ error: "Invalid action" });
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const actor = payload.reviewedBy || "local_admin";
+    const docRef = db.collection(DTC_COLLECTION).doc(payload.code);
+
+    try {
+      const current = await docRef.get();
+      if (!current.exists) {
+        response.status(404).send({ error: "DTC definition not found" });
+        return;
+      }
+
+      const updateDoc: Partial<DtcDefinitionDoc> = { updatedAt: now };
+
+      if (payload.updates) {
+        if (typeof payload.updates.title === "string" && payload.updates.title.trim()) {
+          updateDoc.title = payload.updates.title.trim().slice(0, 80);
+        }
+        if (payload.updates.severity === "low" || payload.updates.severity === "medium" || payload.updates.severity === "high") {
+          updateDoc.severity = payload.updates.severity;
+        }
+        if (typeof payload.updates.description === "string" && payload.updates.description.trim()) {
+          updateDoc.description = payload.updates.description.trim().slice(0, 200);
+        }
+        if (Array.isArray(payload.updates.commonCauses)) {
+          updateDoc.commonCauses = coerceStringArray(payload.updates.commonCauses, 6, 150);
+        }
+        if (Array.isArray(payload.updates.recommendedChecks)) {
+          updateDoc.recommendedChecks = coerceStringArray(payload.updates.recommendedChecks, 6, 150);
+        }
+        if (typeof payload.updates.safeToDrive === "boolean") {
+          updateDoc.safeToDrive = payload.updates.safeToDrive;
+        }
+      }
+
+      if (payload.action === "approve") {
+        updateDoc.reviewStatus = "verified";
+        updateDoc.reviewedAt = now;
+        updateDoc.reviewedBy = actor;
+      } else if (payload.action === "reject") {
+        updateDoc.reviewStatus = "rejected";
+        updateDoc.rejectedAt = now;
+        updateDoc.rejectedBy = actor;
+        updateDoc.rejectionReason = payload.rejectionReason || "Rejected by admin";
+      } else {
+        updateDoc.reviewStatus = "needs_research";
+        updateDoc.reviewedAt = now;
+        updateDoc.reviewedBy = actor;
+      }
+
+      await docRef.set(updateDoc, { merge: true });
+      response.status(200).send({ ok: true });
+    } catch (err) {
+      logger.error("dtc-review: update failed", { code: payload.code, action: payload.action, err });
+      response.status(500).send({ error: "Failed to update DTC definition" });
     }
   }
 );

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -45,6 +45,12 @@
           <span class="nav-label">BLE Debug</span>
         </a>
       </li>
+      <li>
+        <a routerLink="/admin/dtc-review" routerLinkActive="active">
+          <span class="nav-icon">🛡</span>
+          <span class="nav-label">DTC Review</span>
+        </a>
+      </li>
     </ul>
 
     <div class="sidebar-footer">

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -79,6 +79,11 @@ export const routes: Routes = [
       .then(m => m.BleDebugComponent)
   },
   {
+    path: 'admin/dtc-review',
+    loadComponent: () => import('./features/admin-dtc-review/admin-dtc-review-page.component')
+      .then(m => m.AdminDtcReviewPageComponent)
+  },
+  {
     path: '',
     redirectTo: 'vehicle-profile',
     pathMatch: 'full'

--- a/src/app/core/ai/ai-endpoint.config.ts
+++ b/src/app/core/ai/ai-endpoint.config.ts
@@ -6,3 +6,9 @@ export const DTC_LOOKUP_FUNCTION_URL =
 
 export const VEHICLE_PROFILE_FUNCTION_URL =
   'https://us-central1-obd2-f5a03.cloudfunctions.net/vehicleProfileLookup';
+
+export const DTC_REVIEW_QUEUE_FUNCTION_URL =
+  'https://us-central1-obd2-f5a03.cloudfunctions.net/listPendingDtcDefinitions';
+
+export const DTC_REVIEW_ACTION_FUNCTION_URL =
+  'https://us-central1-obd2-f5a03.cloudfunctions.net/reviewDtcDefinition';

--- a/src/app/core/diagnostics/dtc/dtc-code.model.ts
+++ b/src/app/core/diagnostics/dtc/dtc-code.model.ts
@@ -18,5 +18,5 @@ export interface DtcCode {
   // Fields populated only for firebase / ai_generated sources
   safeToDrive?: boolean;
   lookupConfidence?: 'low' | 'medium' | 'high';
-  reviewStatus?: 'verified' | 'pending_review';
+  reviewStatus?: 'verified' | 'pending_review' | 'rejected' | 'needs_research';
 }

--- a/src/app/core/diagnostics/dtc/dtc-definition.model.ts
+++ b/src/app/core/diagnostics/dtc/dtc-definition.model.ts
@@ -17,7 +17,19 @@ export interface DtcDefinition {
   safeToDrive: boolean;
   confidence: 'low' | 'medium' | 'high';
   source: 'local' | 'firebase' | 'ai_generated';
-  reviewStatus: 'verified' | 'pending_review';
+  reviewStatus: 'verified' | 'pending_review' | 'rejected' | 'needs_research';
   createdAt: string;
   updatedAt: string;
+  reviewedAt?: string;
+  reviewedBy?: string;
+  rejectedAt?: string;
+  rejectedBy?: string;
+  rejectionReason?: string;
+  vehicleContext?: {
+    make?: string;
+    model?: string;
+    year?: string;
+    engine?: string;
+    vin?: string;
+  };
 }

--- a/src/app/core/diagnostics/dtc/dtc-review-queue.service.ts
+++ b/src/app/core/diagnostics/dtc/dtc-review-queue.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { DtcDefinition } from './dtc-definition.model';
+import { DTC_REVIEW_ACTION_FUNCTION_URL, DTC_REVIEW_QUEUE_FUNCTION_URL } from '../../ai/ai-endpoint.config';
+
+export type DtcReviewAction = 'approve' | 'reject' | 'needs_research';
+
+export interface DtcReviewUpdatePayload {
+  title: string;
+  severity: 'low' | 'medium' | 'high';
+  description: string;
+  commonCauses: string[];
+  recommendedChecks: string[];
+  safeToDrive: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class DtcReviewQueueService {
+  async listPending(): Promise<DtcDefinition[]> {
+    const res = await fetch(DTC_REVIEW_QUEUE_FUNCTION_URL, { method: 'GET' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json() as { items?: DtcDefinition[] };
+    return Array.isArray(data.items) ? data.items : [];
+  }
+
+  async submitReview(
+    code: string,
+    action: DtcReviewAction,
+    updates: DtcReviewUpdatePayload,
+    rejectionReason?: string,
+  ): Promise<void> {
+    const res = await fetch(DTC_REVIEW_ACTION_FUNCTION_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        code,
+        action,
+        reviewedBy: 'local_admin',
+        rejectionReason,
+        updates,
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+  }
+}

--- a/src/app/features/admin-dtc-review/admin-dtc-review-page.component.html
+++ b/src/app/features/admin-dtc-review/admin-dtc-review-page.component.html
@@ -1,0 +1,52 @@
+<section class="review-page">
+  <header class="review-header">
+    <h1>Admin DTC Review Queue</h1>
+    <p>Review AI-generated DTC definitions before they become trusted records.</p>
+    <p class="guard-note">TODO: Add admin route guard when auth role checks are available.</p>
+  </header>
+
+  <p class="state" *ngIf="loading">Loading pending DTC definitions…</p>
+  <p class="state state--error" *ngIf="!loading && error">{{ error }}</p>
+  <p class="state" *ngIf="!loading && !error && pending.length === 0">No pending DTC definitions to review.</p>
+
+  <article class="dtc-card" *ngFor="let item of pending; trackBy: trackByCode">
+    <div class="row row--meta">
+      <strong>{{ item.code }}</strong>
+      <span>{{ item.source }}</span>
+      <span>{{ item.reviewStatus }}</span>
+      <span>Confidence: {{ item.confidence }}</span>
+      <span *ngIf="item.createdAt">Created: {{ item.createdAt }}</span>
+      <span *ngIf="item.updatedAt">Updated: {{ item.updatedAt }}</span>
+      <span *ngIf="item.vehicleContext">Vehicle: {{ item.vehicleContext.year }} {{ item.vehicleContext.make }} {{ item.vehicleContext.model }} {{ item.vehicleContext.engine }}</span>
+    </div>
+
+    <label>Title <input [(ngModel)]="item.title" /></label>
+    <label>Severity
+      <select [(ngModel)]="item.severity">
+        <option value="low">low</option>
+        <option value="medium">medium</option>
+        <option value="high">high</option>
+      </select>
+    </label>
+    <label>Description <textarea rows="3" [(ngModel)]="item.description"></textarea></label>
+    <label>Common causes (one per line)
+      <textarea rows="4" [ngModel]="asTextarea(item.commonCauses)" (ngModelChange)="item.commonCauses = parseTextarea($event)"></textarea>
+    </label>
+    <label>Recommended checks (one per line)
+      <textarea rows="4" [ngModel]="asTextarea(item.recommendedChecks)" (ngModelChange)="item.recommendedChecks = parseTextarea($event)"></textarea>
+    </label>
+    <label class="inline-toggle">
+      <input type="checkbox" [(ngModel)]="item.safeToDrive" />
+      Safe to drive
+    </label>
+    <label>Rejection reason
+      <input [(ngModel)]="rejectionReasonByCode[item.code]" placeholder="Optional reason for rejection" />
+    </label>
+
+    <div class="actions">
+      <button type="button" (click)="approve(item)" [disabled]="savingCode === item.code">Approve</button>
+      <button type="button" (click)="needsResearch(item)" [disabled]="savingCode === item.code">Needs Research</button>
+      <button type="button" class="danger" (click)="reject(item)" [disabled]="savingCode === item.code">Reject</button>
+    </div>
+  </article>
+</section>

--- a/src/app/features/admin-dtc-review/admin-dtc-review-page.component.scss
+++ b/src/app/features/admin-dtc-review/admin-dtc-review-page.component.scss
@@ -1,0 +1,92 @@
+.review-page {
+  padding: 1.25rem;
+  color: #f2f2f2;
+}
+
+.review-header {
+  margin-bottom: 1rem;
+}
+
+.guard-note {
+  color: #a8b3c4;
+  font-size: 0.85rem;
+}
+
+.state {
+  margin: 0.75rem 0;
+}
+
+.state--error {
+  color: #ff8e8e;
+}
+
+.dtc-card {
+  border: 1px solid #2f3440;
+  background: #1b1f28;
+  border-radius: 10px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.row--meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: #c8d1dd;
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  background: #10141d;
+  border: 1px solid #333b4b;
+  border-radius: 6px;
+  color: #f2f2f2;
+  padding: 0.55rem 0.65rem;
+  font: inherit;
+}
+
+.inline-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.inline-toggle input {
+  width: auto;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+button {
+  border: 1px solid #2f7f5f;
+  background: #1a5b45;
+  color: #e7fff5;
+  border-radius: 6px;
+  padding: 0.55rem 0.85rem;
+  cursor: pointer;
+}
+
+button.danger {
+  border-color: #8f3d3d;
+  background: #672929;
+}
+
+button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}

--- a/src/app/features/admin-dtc-review/admin-dtc-review-page.component.ts
+++ b/src/app/features/admin-dtc-review/admin-dtc-review-page.component.ts
@@ -1,0 +1,95 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DtcDefinition } from '../../core/diagnostics/dtc/dtc-definition.model';
+import {
+  DtcReviewQueueService,
+  DtcReviewUpdatePayload,
+} from '../../core/diagnostics/dtc/dtc-review-queue.service';
+
+@Component({
+  selector: 'app-admin-dtc-review-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './admin-dtc-review-page.component.html',
+  styleUrls: ['./admin-dtc-review-page.component.scss'],
+})
+export class AdminDtcReviewPageComponent {
+  private readonly reviewQueue = inject(DtcReviewQueueService);
+
+  loading = true;
+  error = '';
+  pending: DtcDefinition[] = [];
+  savingCode: string | null = null;
+  rejectionReasonByCode: Record<string, string> = {};
+
+  async ngOnInit(): Promise<void> {
+    await this.load();
+  }
+
+  trackByCode(_index: number, item: DtcDefinition): string {
+    return item.code;
+  }
+
+  async approve(item: DtcDefinition): Promise<void> {
+    await this.submit(item, 'approve');
+  }
+
+  async reject(item: DtcDefinition): Promise<void> {
+    const reason = this.rejectionReasonByCode[item.code]?.trim();
+    await this.submit(item, 'reject', reason || 'Rejected by admin');
+  }
+
+  async needsResearch(item: DtcDefinition): Promise<void> {
+    await this.submit(item, 'needs_research');
+  }
+
+  asTextarea(value: string[] | undefined): string {
+    return Array.isArray(value) ? value.join('\n') : '';
+  }
+
+  parseTextarea(value: string): string[] {
+    return value
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean);
+  }
+
+  private async load(): Promise<void> {
+    this.loading = true;
+    this.error = '';
+    try {
+      this.pending = await this.reviewQueue.listPending();
+    } catch {
+      this.error = 'Unable to load DTC review queue. Please try again.';
+      this.pending = [];
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private buildUpdate(item: DtcDefinition): DtcReviewUpdatePayload {
+    return {
+      title: item.title,
+      severity: item.severity,
+      description: item.description,
+      commonCauses: item.commonCauses ?? [],
+      recommendedChecks: item.recommendedChecks ?? [],
+      safeToDrive: item.safeToDrive,
+    };
+  }
+
+  private async submit(item: DtcDefinition, action: 'approve' | 'reject' | 'needs_research', rejectionReason?: string): Promise<void> {
+    this.savingCode = item.code;
+    this.error = '';
+    try {
+      await this.reviewQueue.submitReview(item.code, action, this.buildUpdate(item), rejectionReason);
+      this.pending = this.pending.filter(d => d.code !== item.code);
+      delete this.rejectionReasonByCode[item.code];
+    } catch {
+      this.error = 'Unable to save review action. Please try again.';
+    } finally {
+      this.savingCode = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add admin route /admin/dtc-review with a dedicated Admin DTC Review Queue page.
- Add review queue fetch and review action backend endpoints over Cloud Functions for dtc_definitions pending records.
- Add edit-before-approve workflow plus reject and needs-research actions with audit metadata.

## Admin route added
- Added route: /admin/dtc-review
- Added sidebar navigation entry: DTC Review

## Firestore query behavior
- Added listPendingDtcDefinitions function (GET)
- Queries dtc_definitions where eviewStatus == 'pending_review'
- Returns items ordered by createdAt desc

## Fields displayed
- Code
- Title
- Severity
- Description
- Common causes
- Recommended checks
- Safe to drive
- Confidence
- Source
- Review status
- Created at
- Updated at
- Vehicle context (if present)

## Edit/approve behavior
- Admin can edit: title, severity, description, common causes, recommended checks, safe-to-drive
- Approve action sets:
  - eviewStatus = 'verified'
  - eviewedAt = current timestamp
  - eviewedBy = current user id if available, else 'local_admin'

## Reject behavior
- Reject action sets:
  - eviewStatus = 'rejected'
  - ejectedAt = current timestamp
  - ejectedBy = current user id if available, else 'local_admin'
  - ejectionReason = provided reason (fallback: Rejected by admin)

## Access-control limitation / follow-up
- No complex role management added in this PR.
- Added explicit TODO note on page to protect route with an admin guard once role checks are available.

## Build result
- 
pm run build ✅
- cd functions && npm run build ✅

Closes #218