### PR TITLE
feat: add global telemetry dock and ongoing diagnosis widget

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -68,7 +68,15 @@
   </nav>
 
   <main class="main-content">
+    <app-global-telemetry-dock></app-global-telemetry-dock>
     <router-outlet></router-outlet>
+    <app-ongoing-diagnosis-widget
+      *ngIf="(widgetVisible$ | async)"
+      [state]="(diagnosisState$ | async) ?? null"
+      [visible]="true"
+      (open)="openDiagnosisWidget()"
+      (minimize)="minimizeDiagnosisWidget()">
+    </app-ongoing-diagnosis-widget>
   </main>
 
 </div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -165,6 +165,8 @@
   flex: 1;
   overflow-y: auto;
   background: $bg-primary;
+  display: flex;
+  flex-direction: column;
 
   &::-webkit-scrollbar { width: 6px; }
   &::-webkit-scrollbar-track { background: $bg-primary; }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,16 +1,21 @@
 import { Component, inject } from '@angular/core';
-import { NgIf } from '@angular/common';
+import { AsyncPipe, NgIf } from '@angular/common';
 import { RouterOutlet, Router, RouterLink, RouterLinkActive, NavigationEnd } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { combineLatest } from 'rxjs';
 import { filter, map, startWith } from 'rxjs/operators';
 import { VehicleProfileService } from './core/vehicle/vehicle-profile.service';
 import { AdapterSwitcherService } from './core/adapters/adapter-switcher.service';
 import { AdminAccessService } from './core/security/admin-access.service';
+import { GlobalTelemetryDockComponent } from './shared/components/global-telemetry-dock/global-telemetry-dock.component';
+import { OngoingDiagnosisWidgetComponent } from './shared/components/ongoing-diagnosis-widget/ongoing-diagnosis-widget.component';
+import { DeepDiagnosisService } from './core/diagnostics/deep-diagnosis.service';
+import { DiagnosisWidgetStateService } from './core/diagnostics/diagnosis-widget-state.service';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [NgIf, RouterOutlet, RouterLink, RouterLinkActive],
+  imports: [NgIf, AsyncPipe, RouterOutlet, RouterLink, RouterLinkActive, GlobalTelemetryDockComponent, OngoingDiagnosisWidgetComponent],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
@@ -19,8 +24,24 @@ export class AppComponent {
   private vehicleService = inject(VehicleProfileService);
   private adapterSwitcher = inject(AdapterSwitcherService);
   private adminAccess = inject(AdminAccessService);
+  private diagnosisService = inject(DeepDiagnosisService);
+  private widgetState = inject(DiagnosisWidgetStateService);
 
   readonly isAdmin = this.adminAccess.isAdmin;
+  readonly diagnosisState$ = this.diagnosisService.state$;
+  readonly currentUrl$ = this.router.events.pipe(
+    filter(e => e instanceof NavigationEnd),
+    map(() => this.router.url),
+    startWith(this.router.url),
+  );
+  readonly widgetVisible$ = combineLatest([this.diagnosisState$, this.widgetState.minimized$, this.currentUrl$]).pipe(
+    map(([state, minimized, url]) => {
+      const isDiagnosisRunning = state.status === 'running' || state.status === 'transitioning';
+      const showCompleted = state.status === 'completed' || state.status === 'error';
+      const onDiagnosisPage = this.isDiagnosisUrl(url);
+      return (isDiagnosisRunning || showCompleted) && (!onDiagnosisPage || minimized);
+    }),
+  );
 
   // True whenever the user is anywhere inside the diagnosis flows —
   // /diagnosis-assistant, /diagnosis-report, or /guided-tests.
@@ -41,11 +62,19 @@ export class AppComponent {
     this.adapterSwitcher.autoConnect();
   }
 
-  private isDiagnosisUrl(): boolean {
-    const url = this.router.url;
+  private isDiagnosisUrl(url = this.router.url): boolean {
     return url.startsWith('/diagnosis-assistant') ||
            url.startsWith('/ai-diagnosis-assistant') ||
            url.startsWith('/diagnosis-report') ||
            url.startsWith('/guided-tests');
+  }
+
+  openDiagnosisWidget(): void {
+    this.widgetState.setMinimized(false);
+    this.router.navigate(['/diagnosis-report']);
+  }
+
+  minimizeDiagnosisWidget(): void {
+    this.widgetState.setMinimized(true);
   }
 }

--- a/src/app/core/diagnostics/diagnosis-widget-state.service.ts
+++ b/src/app/core/diagnostics/diagnosis-widget-state.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class DiagnosisWidgetStateService {
+  private readonly minimizedSubject = new BehaviorSubject<boolean>(false);
+
+  readonly minimized$ = this.minimizedSubject.asObservable();
+
+  setMinimized(minimized: boolean): void {
+    this.minimizedSubject.next(minimized);
+  }
+}

--- a/src/app/core/telemetry/live-telemetry.service.ts
+++ b/src/app/core/telemetry/live-telemetry.service.ts
@@ -1,0 +1,42 @@
+import { Inject, Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs/operators';
+import { ObdAdapter, OBD_ADAPTER } from '../adapters/obd-adapter.interface';
+import { ObdLiveFrame } from '../models/obd-live-frame.model';
+
+export type TelemetryMetricId = 'rpm' | 'coolantTemp' | 'maf' | 'stftB1' | 'ltftB1' | 'throttlePosition';
+
+@Injectable({ providedIn: 'root' })
+export class LiveTelemetryService {
+  private readonly frameHistorySubject = new BehaviorSubject<readonly ObdLiveFrame[]>([]);
+
+  readonly frameHistory$ = this.frameHistorySubject.asObservable();
+  readonly latestFrame$ = this.frameHistory$.pipe(map(history => history.length > 0 ? history[history.length - 1] : null));
+  readonly connectionStatus$;
+
+  constructor(@Inject(OBD_ADAPTER) private readonly obdAdapter: ObdAdapter) {
+    this.connectionStatus$ = this.obdAdapter.connectionStatus$.pipe(distinctUntilChanged());
+
+    this.obdAdapter.data$.subscribe(frame => {
+      this.frameHistorySubject.next([...this.frameHistorySubject.value, frame].slice(-120));
+    });
+
+    this.connectionStatus$.subscribe(status => {
+      if (status === 'disconnected' || status === 'error') {
+        this.frameHistorySubject.next([]);
+      }
+    });
+  }
+
+  metricValue(frame: ObdLiveFrame | null, id: TelemetryMetricId): number | null {
+    if (!frame) return null;
+    switch (id) {
+      case 'rpm': return frame.rpm;
+      case 'coolantTemp': return frame.coolantTemp;
+      case 'maf': return frame.maf ?? null;
+      case 'stftB1': return frame.stftB1;
+      case 'ltftB1': return frame.ltftB1;
+      case 'throttlePosition': return frame.throttlePosition;
+    }
+  }
+}

--- a/src/app/features/catalytic-converter/catalytic-converter-page.component.html
+++ b/src/app/features/catalytic-converter/catalytic-converter-page.component.html
@@ -1,4 +1,5 @@
 <div class="analysis-page" *ngIf="result$ | async as result">
+  <button class="back-btn" (click)="goBack()">? Back to Diagnosis Assistant</button>
   <header class="analysis-header">
     <h1>Catalytic Converter Test</h1>
     <span class="status" [ngClass]="statusClass(result.status)">{{ statusLabel(result.status) }}</span>

--- a/src/app/features/catalytic-converter/catalytic-converter-page.component.scss
+++ b/src/app/features/catalytic-converter/catalytic-converter-page.component.scss
@@ -22,3 +22,5 @@
 .status--critical { background: #ffebee; color: #c62828; }
 
 .section { margin-top: 1rem; }
+
+.back-btn { margin-bottom: 12px; }

--- a/src/app/features/catalytic-converter/catalytic-converter-page.component.ts
+++ b/src/app/features/catalytic-converter/catalytic-converter-page.component.ts
@@ -1,5 +1,6 @@
 import { Component, inject } from '@angular/core';
 import { AsyncPipe, NgClass, NgFor, NgIf, TitleCasePipe } from '@angular/common';
+import { Router } from '@angular/router';
 import { Observable, combineLatest } from 'rxjs';
 import { map, throttleTime } from 'rxjs/operators';
 import { DeepDiagnosisService } from '../../core/diagnostics/deep-diagnosis.service';
@@ -19,6 +20,7 @@ export class CatalyticConverterPageComponent {
   private readonly deepDiagnosis = inject(DeepDiagnosisService);
   private readonly catalyticAnalysis = inject(CatalyticConverterAnalysisService);
   private readonly o2Buffer = inject(O2SensorBufferService);
+  private readonly router = inject(Router);
 
   readonly result$: Observable<CatalyticConverterResult> = combineLatest([
     this.deepDiagnosis.state$,
@@ -30,6 +32,10 @@ export class CatalyticConverterPageComponent {
       o2Sensors: this.o2Buffer.buildCatalyticO2Input(1),
     })),
   );
+
+  goBack(): void {
+    this.router.navigate(['/diagnosis-assistant']);
+  }
 
   statusClass(status: string): string {
     if (status === 'normal') return 'status--normal';

--- a/src/app/features/cylinder-analysis/cylinder-analysis-page.component.html
+++ b/src/app/features/cylinder-analysis/cylinder-analysis-page.component.html
@@ -1,4 +1,5 @@
 <div class="analysis-page" *ngIf="result$ | async as result">
+  <button class="back-btn" (click)="goBack()">Back to Diagnosis Assistant</button>
   <header class="analysis-header">
     <h1>Cylinder Analysis</h1>
     <span class="status" [ngClass]="'status--' + result.status">{{ result.status | titlecase }}</span>

--- a/src/app/features/cylinder-analysis/cylinder-analysis-page.component.scss
+++ b/src/app/features/cylinder-analysis/cylinder-analysis-page.component.scss
@@ -23,3 +23,5 @@
 
 .section { margin-top: 1rem; }
 .empty { color: #666; }
+
+.back-btn { margin-bottom: 12px; }

--- a/src/app/features/cylinder-analysis/cylinder-analysis-page.component.ts
+++ b/src/app/features/cylinder-analysis/cylinder-analysis-page.component.ts
@@ -1,5 +1,6 @@
 import { Component, inject } from '@angular/core';
 import { AsyncPipe, NgClass, NgFor, NgIf, TitleCasePipe } from '@angular/common';
+import { Router } from '@angular/router';
 import { map } from 'rxjs/operators';
 import { DeepDiagnosisService } from '../../core/diagnostics/deep-diagnosis.service';
 import { CylinderAnalysisService } from '../../core/diagnostics/cylinder-analysis.service';
@@ -15,6 +16,7 @@ import type { CylinderAnalysisResult } from '../../core/diagnostics/cylinder-ana
 export class CylinderAnalysisPageComponent {
   private readonly deepDiagnosis = inject(DeepDiagnosisService);
   private readonly cylinderAnalysis = inject(CylinderAnalysisService);
+  private readonly router = inject(Router);
 
   readonly result$ = this.deepDiagnosis.state$.pipe(
     map((state): CylinderAnalysisResult => this.cylinderAnalysis.analyse(state.dtcCodes ?? [])),
@@ -33,4 +35,8 @@ export class CylinderAnalysisPageComponent {
     ignition_coil_swap: 'Ignition Coil Swap Test',
     fuel_pressure_test: 'Fuel Pressure Test',
   };
+
+  goBack(): void {
+    this.router.navigate(['/diagnosis-assistant']);
+  }
 }

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.html
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.html
@@ -37,6 +37,9 @@
       <button class="btn btn-ghost" (click)="goToVehicleProfile()">
         ← Change Vehicle
       </button>
+      <button class="btn btn-ghost" (click)="goBackToAssistant()">
+        Back to Diagnosis Assistant
+      </button>
     </div>
   </header>
 

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.ts
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.ts
@@ -201,6 +201,7 @@ export class DiagnosisReportPageComponent implements OnInit, OnDestroy {
   exportCsv(s: DeepDiagnosisState):  void { this.exportService.exportCsv(s); }
   goToVehicleProfile():     void { this.router.navigate(['/vehicle-profile']); }
   goToHistory():            void { this.router.navigate(['/sessions']); }
+  goBackToAssistant():      void { this.router.navigate(['/diagnosis-assistant']); }
 
   async copyShareText(state: DeepDiagnosisState, profile: VehicleProfile | null): Promise<void> {
     const text = this.exportService.buildShareText(state, this.vehicleName(profile, state));

--- a/src/app/shared/components/global-telemetry-dock/global-telemetry-dock.component.html
+++ b/src/app/shared/components/global-telemetry-dock/global-telemetry-dock.component.html
@@ -1,0 +1,18 @@
+<section class="telemetry-dock" *ngIf="vm$ | async as vm">
+  <article class="dock-card" *ngFor="let card of vm.cards">
+    <header>
+      <span class="label">{{ card.label }}</span>
+      <span class="status" [ngClass]="card.isLive ? 'live' : 'idle'">{{ card.isLive ? 'Live' : 'Waiting' }}</span>
+    </header>
+    <div class="value-row">
+      <strong>{{ card.valueText }}</strong>
+      <span class="unit">{{ card.unit }}</span>
+    </div>
+    <svg class="spark" viewBox="0 0 100 24" preserveAspectRatio="none" *ngIf="card.sparkline; else emptySpark">
+      <polyline [attr.points]="card.sparkline"></polyline>
+    </svg>
+    <ng-template #emptySpark>
+      <div class="spark spark--empty"></div>
+    </ng-template>
+  </article>
+</section>

--- a/src/app/shared/components/global-telemetry-dock/global-telemetry-dock.component.scss
+++ b/src/app/shared/components/global-telemetry-dock/global-telemetry-dock.component.scss
@@ -1,0 +1,38 @@
+.telemetry-dock {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(150px, 1fr));
+  gap: 10px;
+  margin: 8px 16px 0;
+  overflow-x: auto;
+}
+
+.dock-card {
+  min-width: 150px;
+  border: 1px solid #303742;
+  border-radius: 10px;
+  padding: 8px;
+  background: #171d26;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.label { font-size: 11px; color: #9fb0c4; }
+.status { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; }
+.status.live { color: #4ddf74; }
+.status.idle { color: #7f8b99; }
+
+.value-row { display: flex; align-items: baseline; gap: 4px; margin-top: 6px; }
+.value-row strong { font-size: 18px; color: #edf3fb; }
+.unit { font-size: 11px; color: #9fb0c4; }
+
+.spark { width: 100%; height: 24px; margin-top: 6px; }
+.spark polyline { fill: none; stroke: #66c2ff; stroke-width: 2; }
+.spark--empty { border-top: 1px dashed #3a4553; }
+
+@media (max-width: 1200px) {
+  .telemetry-dock { grid-template-columns: repeat(6, 150px); }
+}

--- a/src/app/shared/components/global-telemetry-dock/global-telemetry-dock.component.ts
+++ b/src/app/shared/components/global-telemetry-dock/global-telemetry-dock.component.ts
@@ -1,0 +1,68 @@
+import { AsyncPipe, NgClass, NgFor, NgIf } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { combineLatest, map } from 'rxjs';
+import { LiveTelemetryService, TelemetryMetricId } from '../../../core/telemetry/live-telemetry.service';
+
+interface DockMetric {
+  id: TelemetryMetricId;
+  label: string;
+  unit: string;
+  digits: number;
+}
+
+@Component({
+  selector: 'app-global-telemetry-dock',
+  standalone: true,
+  imports: [NgIf, NgFor, NgClass, AsyncPipe],
+  templateUrl: './global-telemetry-dock.component.html',
+  styleUrls: ['./global-telemetry-dock.component.scss']
+})
+export class GlobalTelemetryDockComponent {
+  private readonly telemetry = inject(LiveTelemetryService);
+
+  readonly metrics: readonly DockMetric[] = [
+    { id: 'rpm', label: 'RPM', unit: '', digits: 0 },
+    { id: 'coolantTemp', label: 'Coolant', unit: '°C', digits: 0 },
+    { id: 'maf', label: 'MAF', unit: 'g/s', digits: 2 },
+    { id: 'stftB1', label: 'STFT B1', unit: '%', digits: 1 },
+    { id: 'ltftB1', label: 'LTFT B1', unit: '%', digits: 1 },
+    { id: 'throttlePosition', label: 'Throttle', unit: '%', digits: 0 },
+  ];
+
+  readonly vm$ = combineLatest([
+    this.telemetry.frameHistory$,
+    this.telemetry.latestFrame$,
+    this.telemetry.connectionStatus$,
+  ]).pipe(
+    map(([history, latest, status]) => ({
+      status,
+      cards: this.metrics.map(metric => {
+        const value = this.telemetry.metricValue(latest, metric.id);
+        const samples = history
+          .map(frame => this.telemetry.metricValue(frame, metric.id))
+          .filter((v): v is number => v !== null)
+          .slice(-30);
+        return {
+          ...metric,
+          valueText: value === null ? (status === 'connected' ? 'Waiting…' : 'No data') : value.toFixed(metric.digits),
+          sparkline: this.sparklinePoints(samples),
+          isLive: status === 'connected' && value !== null,
+        };
+      }),
+    }))
+  );
+
+  private sparklinePoints(values: readonly number[]): string {
+    if (values.length < 2) return '';
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const span = max - min || 1;
+    return values
+      .map((v, i) => {
+        const x = (i / (values.length - 1)) * 100;
+        const y = 22 - ((v - min) / span) * 20;
+        return `${x},${y}`;
+      })
+      .join(' ');
+  }
+}

--- a/src/app/shared/components/ongoing-diagnosis-widget/ongoing-diagnosis-widget.component.html
+++ b/src/app/shared/components/ongoing-diagnosis-widget/ongoing-diagnosis-widget.component.html
@@ -1,0 +1,8 @@
+<aside class="diag-widget" *ngIf="visible && state">
+  <button class="min-btn" (click)="minimize.emit()">_</button>
+  <p class="kicker">Diagnosis Running</p>
+  <h4>{{ titleFor(state) }}</h4>
+  <p class="status">{{ state.instruction }}</p>
+  <div class="bar"><div class="fill" [style.width.%]="state.status === 'running' || state.status === 'transitioning' ? state.progress : 100"></div></div>
+  <button class="open-btn" (click)="open.emit()">Open</button>
+</aside>

--- a/src/app/shared/components/ongoing-diagnosis-widget/ongoing-diagnosis-widget.component.scss
+++ b/src/app/shared/components/ongoing-diagnosis-widget/ongoing-diagnosis-widget.component.scss
@@ -1,0 +1,20 @@
+.diag-widget {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  width: 280px;
+  z-index: 1000;
+  border: 1px solid #384556;
+  border-radius: 12px;
+  background: #121821;
+  color: #eaf0f7;
+  padding: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+.kicker { margin: 0; font-size: 11px; color: #89a2bd; text-transform: uppercase; }
+h4 { margin: 6px 0; font-size: 16px; }
+.status { margin: 0 0 8px; font-size: 12px; color: #b6c6d8; }
+.bar { height: 8px; border-radius: 99px; background: #2a3646; overflow: hidden; }
+.fill { height: 100%; background: linear-gradient(90deg, #29c76f, #59d8ff); }
+.open-btn { margin-top: 10px; width: 100%; border: 0; border-radius: 8px; padding: 8px; background: #2a75ff; color: white; }
+.min-btn { position: absolute; right: 8px; top: 8px; border: 0; background: transparent; color: #7e93a9; }

--- a/src/app/shared/components/ongoing-diagnosis-widget/ongoing-diagnosis-widget.component.ts
+++ b/src/app/shared/components/ongoing-diagnosis-widget/ongoing-diagnosis-widget.component.ts
@@ -1,0 +1,24 @@
+import { NgIf } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { DeepDiagnosisState } from '../../../core/diagnostics/deep-diagnosis.service';
+
+@Component({
+  selector: 'app-ongoing-diagnosis-widget',
+  standalone: true,
+  imports: [NgIf],
+  templateUrl: './ongoing-diagnosis-widget.component.html',
+  styleUrls: ['./ongoing-diagnosis-widget.component.scss']
+})
+export class OngoingDiagnosisWidgetComponent {
+  @Input({ required: true }) state: DeepDiagnosisState | null = null;
+  @Input() visible = false;
+  @Output() open = new EventEmitter<void>();
+  @Output() minimize = new EventEmitter<void>();
+
+  titleFor(state: DeepDiagnosisState | null): string {
+    if (!state) return 'Diagnosis';
+    if (state.currentStep === 'driving_prompt') return 'Driving Analysis Prompt';
+    if (state.currentStep === 'completed') return 'Diagnosis Complete';
+    return 'Full Diagnosis';
+  }
+}


### PR DESCRIPTION
## Summary
Implements #230 with shell-level UX changes for persistent telemetry visibility and recoverable in-progress diagnosis context.

### 1. Global telemetry dock behavior
- Added a shared top-level telemetry dock in the app shell so it appears across major pages (Vehicle Setup, Diagnosis Assistant flows, Live Data, Sessions, Session Replay, BLE Debug, and admin pages when visible).
- Dock is compact, responsive, and horizontally scrollable at narrower widths.
- Uses shared live telemetry state and does not create per-page polling loops.

### 2. Metrics shown
- RPM
- Coolant temperature
- MAF
- STFT B1
- LTFT B1
- Throttle position
- For unavailable data, cards show explicit `Waiting…` / `No data` placeholders.

### 3. Sparkline implementation approach
- Implemented lightweight inline SVG sparklines per metric.
- Uses rolling shared frame history (up to 120 frames) and renders the latest 30 points per metric.
- Avoids adding heavier chart overhead for the dock.

### 4. AI Diagnosis back button behavior
- Added clear in-app back actions to return to Diagnosis Assistant from:
  - Full Diagnosis report page
  - Catalytic Converter test page
  - Cylinder Analysis page

### 5. Ongoing diagnosis widget behavior
- Added a bottom-right floating widget that appears when diagnosis is running (or complete/error) and user is away from diagnosis flow or explicitly minimizes.
- Widget shows diagnosis title, live status text, and progress bar.
- `Open` restores the diagnosis view without starting a new diagnosis.

### 6. State management approach
- Added `LiveTelemetryService` (shared rolling telemetry state sourced from the existing adapter stream).
- Added `DiagnosisWidgetStateService` (UI-level minimized/open state only).
- Core diagnosis lifecycle remains in existing `DeepDiagnosisService`; no diagnostic algorithm changes.

### 7. Build result
- `npm run build` (root): ✅ pass
- `npm run build` (functions): ✅ pass

## Duplicate matching command note
- Older open command issues `#228` and `#224` were also matched by `@codex implement`; this PR treats newest issue `#230` as canonical.