### PR TITLE
feat: show selected vehicle summary in sidebar

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,13 +9,36 @@
     </div>
 
     <ul class="nav-links">
-      <li>
+      <li class="vehicle-setup-group">
         <a routerLink="/vehicle-profile" routerLinkActive="active">
           <span class="nav-icon">⚙</span>
           <span class="nav-label">Vehicle Setup</span>
         </a>
+        <div
+          class="vehicle-summary"
+          *ngIf="activeProfile$ | async as activeProfile; else noVehicleSummary">
+          <span class="vehicle-summary__label">Selected Vehicle</span>
+          <span class="vehicle-summary__title" [title]="vehicleTitle(activeProfile)">
+            {{ vehicleTitle(activeProfile) }}
+          </span>
+          <span class="vehicle-summary__meta" [title]="vehicleDetails(activeProfile)">
+            {{ vehicleDetails(activeProfile) }}
+          </span>
+          <span
+            class="vehicle-summary__protocol"
+            *ngIf="vehicleProtocol(activeProfile) as protocol"
+            [title]="protocol">
+            {{ protocol }}
+          </span>
+        </div>
+        <ng-template #noVehicleSummary>
+          <div class="vehicle-summary vehicle-summary--empty">
+            <span class="vehicle-summary__label">Selected Vehicle</span>
+            <span class="vehicle-summary__empty-text">No vehicle selected</span>
+          </div>
+        </ng-template>
       </li>
-      <li>
+      <li class="workflow-group-start">
         <a routerLink="/diagnosis-assistant" [class.active]="diagnosisActive()">
           <span class="nav-icon">🔬</span>
           <span class="nav-label">AI Diagnosis Assistant</span>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -115,7 +115,69 @@
   }
 }
 
-// ── Sidebar footer ────────────────────────────────────────────────────────────
+// Vehicle setup summary
+.vehicle-setup-group {
+  margin-bottom: $spacing-sm;
+}
+
+.workflow-group-start {
+  margin-top: $spacing-md;
+}
+
+.vehicle-summary {
+  min-width: 0;
+  margin: $spacing-xs $spacing-xs $spacing-md 34px;
+  padding-left: $spacing-sm;
+  border-left: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: $text-muted;
+}
+
+.vehicle-summary__label {
+  font-size: $font-size-label-sm;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  color: $text-muted;
+}
+
+.vehicle-summary__title,
+.vehicle-summary__meta,
+.vehicle-summary__protocol,
+.vehicle-summary__empty-text {
+  min-width: 0;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.vehicle-summary__title {
+  color: $text-primary;
+  font-size: $font-size-body-sm;
+  font-weight: 700;
+}
+
+.vehicle-summary__meta,
+.vehicle-summary__protocol,
+.vehicle-summary__empty-text {
+  color: $text-muted;
+  font-size: $font-size-label-lg;
+  line-height: 1.35;
+}
+
+.vehicle-summary__protocol {
+  color: $text-secondary;
+}
+
+.vehicle-summary--empty {
+  margin-bottom: $spacing-lg;
+}
+
+// Sidebar footer
 .sidebar-footer {
   padding: $spacing-md;
   border-top: 1px solid $border-color;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { combineLatest, Subject } from 'rxjs';
 import { filter, map, startWith, takeUntil } from 'rxjs/operators';
 import { VehicleProfileService } from './core/vehicle/vehicle-profile.service';
+import { type VehicleProfile } from './core/models/vehicle-profile.model';
 import { AdapterSwitcherService } from './core/adapters/adapter-switcher.service';
 import { AdminAccessService } from './core/security/admin-access.service';
 import { GlobalTelemetryDockComponent } from './shared/components/global-telemetry-dock/global-telemetry-dock.component';
@@ -29,9 +30,11 @@ export class AppComponent implements OnInit, OnDestroy {
   private lastDiagnosisRoute = '/diagnosis-report';
   private diagnosisWasActive = false;
   private currentDiagnosisState: { status: string } | null = null;
+  private readonly unknownVehicleValues = new Set(['', 'unknown', 'n/a', 'na', 'none', 'null', 'undefined']);
   private readonly destroy$ = new Subject<void>();
 
   readonly isAdmin = this.adminAccess.isAdmin;
+  readonly activeProfile$ = this.vehicleService.activeProfile$;
   readonly diagnosisState$ = this.diagnosisService.state$;
   readonly currentUrl$ = this.router.events.pipe(
     filter(e => e instanceof NavigationEnd),
@@ -104,6 +107,34 @@ export class AppComponent implements OnInit, OnDestroy {
     this.widgetState.setMinimized(true);
   }
 
+  vehicleTitle(profile: VehicleProfile): string {
+    const title = [
+      this.cleanVehicleValue(profile.make),
+      this.cleanVehicleValue(profile.model),
+    ].filter((part): part is string => Boolean(part));
+
+    return title.length ? title.join(' ') : 'Unknown vehicle';
+  }
+
+  vehicleDetails(profile: VehicleProfile): string {
+    const variantEngine = [
+      this.cleanVehicleValue(profile.trimVariant),
+      this.cleanVehicleValue(profile.engineSize),
+    ].filter((part): part is string => Boolean(part));
+
+    const details = [
+      this.cleanYear(profile.year),
+      variantEngine.join(' / ') || null,
+      this.formatFuelType(profile.fuelType),
+    ].filter((part): part is string => Boolean(part));
+
+    return details.length ? details.join(' • ') : 'Details unavailable';
+  }
+
+  vehicleProtocol(profile: VehicleProfile): string | null {
+    return this.cleanVehicleValue(profile.detectedProtocol);
+  }
+
   ngOnInit(): void {
     this.currentUrl$
       .pipe(takeUntil(this.destroy$))
@@ -130,5 +161,40 @@ export class AppComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  private cleanYear(year: number | null | undefined): string | null {
+    return typeof year === 'number' && Number.isFinite(year) && year > 0
+      ? String(year)
+      : null;
+  }
+
+  private cleanVehicleValue(value: string | number | null | undefined): string | null {
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? String(value) : null;
+    }
+
+    const trimmed = value?.trim();
+    if (!trimmed || this.unknownVehicleValues.has(trimmed.toLowerCase())) {
+      return null;
+    }
+
+    return trimmed;
+  }
+
+  private formatFuelType(fuelType: VehicleProfile['fuelType']): string | null {
+    switch (fuelType) {
+      case 'petrol':
+        return 'Petrol';
+      case 'diesel':
+        return 'Diesel';
+      case 'hybrid':
+        return 'Hybrid';
+      case 'electric':
+      case 'ev':
+        return 'EV';
+      default:
+        return null;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Closes #234 by showing the active vehicle directly under `Vehicle Setup` in the left sidebar and separating setup context from the rest of the workflow navigation.

## Details

- Adds a compact selected vehicle summary under the existing `Vehicle Setup` nav item.
- Uses the existing `VehicleProfileService.activeProfile$` stream as the source of truth, so the sidebar updates after manual save, VIN-driven profile updates, and restored local profile state.
- Shows `No vehicle selected` when no active profile is available.
- Displays make/model, year, engine/variant where present, fuel type, and detected protocol where available.
- Adds extra vertical spacing before `AI Diagnosis Assistant` to visually group setup separately from diagnosis/live workflow items.
- Uses clamped, overflow-safe sidebar text with title attributes for long vehicle values.

## Open matching item note

The newest open matching item, #235, is already handled by open PR #236. This PR handles the next newest unhandled `@codex implement` issue, #234. Older open matches (#232, #230, #228, #224) are separate prior requests and were left untouched.

## Validation

- `npm run build` passed. Angular reported the existing initial bundle budget warning: total 618.30 kB exceeds the 550.00 kB budget by 68.30 kB.
- Browser check on `http://127.0.0.1:4200/` verified the empty sidebar state.
- Browser check after saving a Toyota Fortuner profile verified make/model/year/engine/fuel/protocol display and persistence across navigation.

Functions were not changed, so `cd functions && npm run build` was not run.