### PR TITLE
fix: preserve diagnostic and live data state across navigation

### DIFF
--- a/src/app/core/diagnostics/deep-diagnosis.service.ts
+++ b/src/app/core/diagnostics/deep-diagnosis.service.ts
@@ -59,6 +59,8 @@ export interface DeepDiagnosisState {
   incompleteSteps?: string[];
   /** Set to true when state is restored from history — prevents duplicate autosave */
   restoredFromHistory?: boolean;
+  /** Set after completed-state side effects run so route restores do not replay them */
+  completionSideEffectsHandled?: boolean;
   /** Vehicle name snapshot captured at diagnosis time — preserved across profile changes */
   vehicleNameSnapshot?: string;
 }
@@ -185,6 +187,11 @@ export class DeepDiagnosisService implements OnDestroy {
   public completeWithoutDriving(): void {
     if (!this.sessionActive || this.stateSubject.value.currentStep !== 'driving_prompt') return;
     this.aggregateResults();
+  }
+
+  public markCompletionSideEffectsHandled(): void {
+    if (this.stateSubject.value.status !== 'completed') return;
+    this.updateState({ completionSideEffectsHandled: true });
   }
 
   // ── Steps ────────────────────────────────────────────────────────────────

--- a/src/app/core/diagnostics/diagnostic-engine.service.ts
+++ b/src/app/core/diagnostics/diagnostic-engine.service.ts
@@ -28,6 +28,7 @@ export class DiagnosticEngineService {
   private readonly MAX_BUFFER_SIZE = 50;
   private readonly PERSISTENCE_THRESHOLD = 3;
   private persistenceCount = new Map<string, number>();
+  private liveSessionStarted = false;
 
   constructor() {
     this.initializeRules();
@@ -45,9 +46,24 @@ export class DiagnosticEngineService {
   }
 
   public startSession(): void {
+    if (this.liveSessionStarted) {
+      return;
+    }
+
+    this.liveSessionStarted = true;
+    this.resetSession();
+  }
+
+  public resetSession(): void {
     this.frameBuffer = [];
     this.persistenceCount.clear();
     this.activeResultsSubject.next([]);
+  }
+
+  public restoreSession(frames: readonly ObdLiveFrame[]): void {
+    this.liveSessionStarted = true;
+    this.resetSession();
+    frames.slice(-this.MAX_BUFFER_SIZE).forEach(frame => this.processFrame(frame));
   }
 
   public processFrame(frame: ObdLiveFrame): void {
@@ -61,7 +77,8 @@ export class DiagnosticEngineService {
   }
 
   public stopSession(): void {
-    this.activeResultsSubject.next([]);
+    this.liveSessionStarted = false;
+    this.resetSession();
   }
 
   private runRules(): void {

--- a/src/app/core/telemetry/live-telemetry.service.ts
+++ b/src/app/core/telemetry/live-telemetry.service.ts
@@ -39,4 +39,8 @@ export class LiveTelemetryService {
       case 'throttlePosition': return frame.throttlePosition;
     }
   }
+
+  clearHistory(): void {
+    this.frameHistorySubject.next([]);
+  }
 }

--- a/src/app/features/dashboard/dashboard-page.component.ts
+++ b/src/app/features/dashboard/dashboard-page.component.ts
@@ -1,13 +1,14 @@
 import { Component, Inject, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { CommonModule, TitleCasePipe } from '@angular/common';
 import { Observable, Subscription } from 'rxjs';
-import { filter, distinctUntilChanged } from 'rxjs/operators';
+import { filter, distinctUntilChanged, take } from 'rxjs/operators';
 import { ChartData, ChartOptions } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
 import { ObdAdapter, OBD_ADAPTER, ObdDebugInfo } from '../../core/adapters/obd-adapter.interface';
 import { AdapterSwitcherService, AdapterMode } from '../../core/adapters/adapter-switcher.service';
 import { DiagnosticEngineService } from '../../core/diagnostics/diagnostic-engine.service';
 import { SessionReplayService } from '../../core/replay/session-replay.service';
+import { LiveTelemetryService } from '../../core/telemetry/live-telemetry.service';
 import { ObdLiveFrame } from '../../core/models/obd-live-frame.model';
 import { DiagnosticResult } from '../../core/models/diagnostic-result.model';
 import { MetricCardComponent } from '../../shared/components/metric-card/metric-card.component';
@@ -99,6 +100,7 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
   };
 
   private frameCount = 0;
+  private lastFrameTimestamp: number | null = null;
   private subscriptions = new Subscription();
 
   constructor(
@@ -106,6 +108,7 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
     private diagnosticEngine: DiagnosticEngineService,
     private adapterSwitcher: AdapterSwitcherService,
     private replayService: SessionReplayService,
+    private telemetryService: LiveTelemetryService,
   ) {
     this.connectionStatus$ = this.obdAdapter.connectionStatus$;
     this.debugInfo$ = this.obdAdapter.debug$;
@@ -114,6 +117,10 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
   public ngOnInit(): void {
     this.diagnosticEngine.startSession();
     this.adapterMode = this.adapterSwitcher.getMode();
+
+    const restoreSubscription = this.telemetryService.frameHistory$.pipe(take(1)).subscribe({
+      next: history => this.restoreFromTelemetryHistory(history)
+    });
 
     const dataSubscription = this.obdAdapter.data$.subscribe({
       next: (frame: ObdLiveFrame) => this.handleNewFrame(frame)
@@ -142,14 +149,14 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
     this.subscriptions.add(diagSubscription);
     this.subscriptions.add(modeSubscription);
     this.subscriptions.add(disconnectSubscription);
+    this.subscriptions.add(restoreSubscription);
   }
 
   public ngOnDestroy(): void {
     this.ltftChart?.chart?.destroy();
-    // Persist BEFORE stopSession — stopSession emits empty results which would
-    // overwrite diagnosticResults and save a replay with no diagnostic events.
+    // Keep the live diagnostic session in the service so route changes do not
+    // reset active Live Data state.
     this.persistSession();
-    this.diagnosticEngine.stopSession();
     this.subscriptions.unsubscribe();
   }
 
@@ -184,8 +191,11 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
     this.persistSession();
     this.frames = [];
     this.frameCount = 0;
+    this.lastFrameTimestamp = null;
     this.dataState = 'no_data';
     this.diagnosticResults = [];
+    this.telemetryService.clearHistory();
+    this.diagnosticEngine.resetSession();
 
     this.ltftChartData.labels = [];
     this.ltftChartData.datasets[0].data = [];
@@ -196,6 +206,11 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
 
   private handleNewFrame(rawFrame: ObdLiveFrame): void {
     const frame = SignalValidator.sanitizeFrame(rawFrame);
+    if (this.lastFrameTimestamp === frame.timestamp) {
+      return;
+    }
+
+    this.lastFrameTimestamp = frame.timestamp;
     this.latestFrame = frame;
     this.dataState = 'receiving';
     this.connectionMessage = '';
@@ -218,6 +233,21 @@ export class DashboardPageComponent implements OnInit, OnDestroy {
     if (this.frameCount % 30 === 0) {
       this.persistSession();
     }
+  }
+
+  private restoreFromTelemetryHistory(history: readonly ObdLiveFrame[]): void {
+    const restoredFrames = history.slice(-60).map(frame => SignalValidator.sanitizeFrame(frame));
+    if (restoredFrames.length === 0) {
+      return;
+    }
+
+    this.frames = restoredFrames;
+    this.frameCount = restoredFrames.length;
+    this.latestFrame = restoredFrames[restoredFrames.length - 1];
+    this.lastFrameTimestamp = this.latestFrame.timestamp;
+    this.dataState = 'receiving';
+    this.diagnosticEngine.restoreSession(restoredFrames);
+    this.updateDetailChart();
   }
 
   private updateDetailChart(): void {

--- a/src/app/features/diagnosis-report/diagnosis-report-page.component.ts
+++ b/src/app/features/diagnosis-report/diagnosis-report-page.component.ts
@@ -81,13 +81,14 @@ export class DiagnosisReportPageComponent implements OnInit, OnDestroy {
     this.sub.add(
       this.diagnosisService.state$.pipe(
         distinctUntilChanged((a, b) => a.status === b.status),
-        filter(s => s.status === 'completed' && !s.restoredFromHistory),
+        filter(s => s.status === 'completed' && !s.restoredFromHistory && !s.completionSideEffectsHandled),
       ).subscribe(state => {
         const profile = this.vehicleService.getActiveProfile();
         const name = profile ? `${profile.year} ${profile.make} ${profile.model}`.trim() : 'Unknown Vehicle';
         this.historyService.save({ ...state, vehicleNameSnapshot: name }, name);
         // Fire AI analysis non-blocking after save
         this.aiService.analyse(state);
+        this.diagnosisService.markCompletionSideEffectsHandled();
       })
     );
 


### PR DESCRIPTION
## Summary

Fixes #224 by preserving active diagnosis and Live Data UI state across route changes instead of letting component teardown make the app look reset.

## Root cause of state reset

- The full diagnosis lifecycle was already service-backed, but completed-report side effects were tied to `DiagnosisReportPageComponent` creation, so returning to a completed report could re-run history save and AI analysis.
- The Live Data page kept its displayed frames, latest PID values, chart state, and live diagnostic session in component-local state. Navigating away destroyed that component, then remounting started from empty arrays even though the adapter stream was still active.

## State management changes made

- Added a completed-state side-effect marker to `DeepDiagnosisState` and `DeepDiagnosisService` so route restores do not replay completed-report save/AI work.
- Updated `DiagnosticEngineService` so the live diagnostic session is not reset by ordinary route remounts, while explicit reset/stop paths still clear the buffer.
- Added shared telemetry history clearing to `LiveTelemetryService` for explicit Live Data resets.
- Rehydrated `DashboardPageComponent` from shared telemetry history on init, including charts, latest frame, frame count, and live diagnostic rule state.

## Diagnostic state preservation behavior

- Active and completed full diagnosis state continues to come from `DeepDiagnosisService`, not component-local state.
- Returning to the diagnosis report restores the current service state without starting a new diagnosis or replaying completed-report side effects.

## Live Data state preservation behavior

- Navigating away from Live Data no longer stops the live diagnostic session.
- Returning to Live Data immediately restores recent telemetry samples from the shared rolling history and avoids reconnecting the adapter.
- Duplicate replayed frames are ignored by timestamp when the adapter uses replayed latest data.

## Reset / new diagnosis behavior

- Live Data `Clear` remains an explicit reset and now clears the shared telemetry history plus live diagnostic rule state.
- Full diagnosis reset/new-run behavior remains explicit through the existing diagnosis actions.

## Matching issue note

Current open `@codex implement` matches included #235, #234, #232, #230, #228, and #224. #235/#234/#232/#230/#228 already have implementation PRs (#236/#237/#233/#231/#229), so this PR handles #224 as the newest remaining unhandled item.

## Validation

- `npm run build` passed. Angular still reports the existing initial bundle budget warning: total 615.28 kB exceeds the 550.00 kB budget by 65.28 kB.
- Browser smoke test on `http://127.0.0.1:4201/` passed: Live Data rendered, simulator metrics populated, and after navigating away and back the Engine Speed card still restored with a live value immediately.

Functions were not changed, so `cd functions && npm run build` was not run.